### PR TITLE
Move to `github.com/openshift-online/ocm-sdk-go`

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,6 @@
 = Changes
 
-This document describes the relevant changes between releases of the UHC API
+This document describes the relevant changes between releases of the OCM API
 SDK.
 
 == 0.1.29 Aug 26 2019

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@
 
 # Details of the model to use:
 model_version:=v0.0.1
-model_url:=https://gitlab.cee.redhat.com/service/ocm-api-model.git
+model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
 metamodel_version:=v0.0.1
-metamodel_url:=https://gitlab.cee.redhat.com/service/ocm-api-metamodel.git
+metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples
 examples:
@@ -73,7 +73,7 @@ generate: model metamodel
 	metamodel/ocm-metamodel-tool \
 		generate \
 		--model=model/model \
-		--base=github.com/openshift-online/uhc-sdk-go \
+		--base=github.com/openshift-online/ocm-sdk-go \
 		--output=.
 
 .PHONY: model

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
-= UHC SDK
+= OCM SDK
 
 ifdef::env-github[]
-image:https://godoc.org/github.com/openshift-online/uhc-sdk-go?status.svg[GoDoc,
-link=https://godoc.org/github.com/openshift-online/uhc-sdk-go/pkg/client]
+image:https://godoc.org/github.com/openshift-online/ocm-sdk-go?status.svg[GoDoc,
+link=https://godoc.org/github.com/openshift-online/ocm-sdk-go/pkg/client]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg[License,
 link=https://opensource.org/licenses/Apache-2.0]
 endif::[]
@@ -12,10 +12,10 @@ API, available in `api.openshift.com`.
 
 == Usage
 
-To use it import the `github.com/openshift-online/uhc-sdk-go` package, and then
+To use it import the `github.com/openshift-online/ocm-sdk-go` package, and then
 use it to send requests to the API.
 
-Note that the name of the directory is `uhc-sdk-go` but the name of the package
+Note that the name of the directory is `ocm-sdk-go` but the name of the package
 is just `sdk`, so to use it you will have to import it and then use `sdk` as
 the package selector.
 
@@ -29,8 +29,8 @@ import (
         "fmt"
         "os"
 
-        "github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+        "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := client.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).
@@ -143,7 +143,7 @@ the clients for the services that are part of the API:
 [source,go]
 ----
 import (
-	"github.com/openshift-online/uhc-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go"
 )
 
 // Create the connection:

--- a/accountsmgmt/client.go
+++ b/accountsmgmt/client.go
@@ -17,13 +17,13 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package accountsmgmt // github.com/openshift-online/uhc-sdk-go/accountsmgmt
+package accountsmgmt // github.com/openshift-online/ocm-sdk-go/accountsmgmt
 
 import (
 	"net/http"
 	"path"
 
-	v1 "github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
 // Client is the client for service 'accounts_mgmt'.

--- a/accountsmgmt/v1/access_token_builder.go
+++ b/accountsmgmt/v1/access_token_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // AccessTokenBuilder contains the data and logic needed to build 'access_token' objects.
 //

--- a/accountsmgmt/v1/access_token_client.go
+++ b/accountsmgmt/v1/access_token_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // AccessTokenClient is the client of the 'access_token' resource.

--- a/accountsmgmt/v1/access_token_list_builder.go
+++ b/accountsmgmt/v1/access_token_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // AccessTokenListBuilder contains the data and logic needed to build
 // 'access_token' objects.

--- a/accountsmgmt/v1/access_token_list_reader.go
+++ b/accountsmgmt/v1/access_token_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // accessTokenListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/access_token_reader.go
+++ b/accountsmgmt/v1/access_token_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // accessTokenData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/access_token_server.go
+++ b/accountsmgmt/v1/access_token_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // AccessTokenServer represents the interface the manages the 'access_token' resource.

--- a/accountsmgmt/v1/access_token_type.go
+++ b/accountsmgmt/v1/access_token_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // AccessToken represents the values of the 'access_token' type.
 //

--- a/accountsmgmt/v1/account_builder.go
+++ b/accountsmgmt/v1/account_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // AccountBuilder contains the data and logic needed to build 'account' objects.
 //

--- a/accountsmgmt/v1/account_client.go
+++ b/accountsmgmt/v1/account_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -28,8 +28,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // AccountClient is the client of the 'account' resource.

--- a/accountsmgmt/v1/account_list_builder.go
+++ b/accountsmgmt/v1/account_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // AccountListBuilder contains the data and logic needed to build
 // 'account' objects.

--- a/accountsmgmt/v1/account_list_reader.go
+++ b/accountsmgmt/v1/account_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // accountListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/account_reader.go
+++ b/accountsmgmt/v1/account_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // accountData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/account_server.go
+++ b/accountsmgmt/v1/account_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // AccountServer represents the interface the manages the 'account' resource.

--- a/accountsmgmt/v1/account_type.go
+++ b/accountsmgmt/v1/account_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // AccountKind is the name of the type used to represent objects
 // of type 'account'.

--- a/accountsmgmt/v1/accounts_client.go
+++ b/accountsmgmt/v1/accounts_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // AccountsClient is the client of the 'accounts' resource.

--- a/accountsmgmt/v1/accounts_server.go
+++ b/accountsmgmt/v1/accounts_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // AccountsServer represents the interface the manages the 'accounts' resource.

--- a/accountsmgmt/v1/action_type.go
+++ b/accountsmgmt/v1/action_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // Action represents the values of the 'action' enumerated type.
 type Action string

--- a/accountsmgmt/v1/cluster_authorization_request_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_request_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterAuthorizationRequestBuilder contains the data and logic needed to build 'cluster_authorization_request' objects.
 //

--- a/accountsmgmt/v1/cluster_authorization_request_list_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_request_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterAuthorizationRequestListBuilder contains the data and logic needed to build
 // 'cluster_authorization_request' objects.

--- a/accountsmgmt/v1/cluster_authorization_request_list_reader.go
+++ b/accountsmgmt/v1/cluster_authorization_request_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterAuthorizationRequestListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/cluster_authorization_request_reader.go
+++ b/accountsmgmt/v1/cluster_authorization_request_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterAuthorizationRequestData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/cluster_authorization_request_type.go
+++ b/accountsmgmt/v1/cluster_authorization_request_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterAuthorizationRequest represents the values of the 'cluster_authorization_request' type.
 //

--- a/accountsmgmt/v1/cluster_authorization_response_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_response_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterAuthorizationResponseBuilder contains the data and logic needed to build 'cluster_authorization_response' objects.
 //

--- a/accountsmgmt/v1/cluster_authorization_response_list_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_response_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterAuthorizationResponseListBuilder contains the data and logic needed to build
 // 'cluster_authorization_response' objects.

--- a/accountsmgmt/v1/cluster_authorization_response_list_reader.go
+++ b/accountsmgmt/v1/cluster_authorization_response_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterAuthorizationResponseListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/cluster_authorization_response_reader.go
+++ b/accountsmgmt/v1/cluster_authorization_response_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterAuthorizationResponseData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/cluster_authorization_response_type.go
+++ b/accountsmgmt/v1/cluster_authorization_response_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterAuthorizationResponse represents the values of the 'cluster_authorization_response' type.
 //

--- a/accountsmgmt/v1/cluster_authorizations_client.go
+++ b/accountsmgmt/v1/cluster_authorizations_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -28,8 +28,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ClusterAuthorizationsClient is the client of the 'cluster_authorizations' resource.

--- a/accountsmgmt/v1/cluster_authorizations_server.go
+++ b/accountsmgmt/v1/cluster_authorizations_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // ClusterAuthorizationsServer represents the interface the manages the 'cluster_authorizations' resource.

--- a/accountsmgmt/v1/cluster_registration_request_builder.go
+++ b/accountsmgmt/v1/cluster_registration_request_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterRegistrationRequestBuilder contains the data and logic needed to build 'cluster_registration_request' objects.
 //

--- a/accountsmgmt/v1/cluster_registration_request_list_builder.go
+++ b/accountsmgmt/v1/cluster_registration_request_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterRegistrationRequestListBuilder contains the data and logic needed to build
 // 'cluster_registration_request' objects.

--- a/accountsmgmt/v1/cluster_registration_request_list_reader.go
+++ b/accountsmgmt/v1/cluster_registration_request_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterRegistrationRequestListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/cluster_registration_request_reader.go
+++ b/accountsmgmt/v1/cluster_registration_request_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterRegistrationRequestData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/cluster_registration_request_type.go
+++ b/accountsmgmt/v1/cluster_registration_request_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterRegistrationRequest represents the values of the 'cluster_registration_request' type.
 //

--- a/accountsmgmt/v1/cluster_registration_response_builder.go
+++ b/accountsmgmt/v1/cluster_registration_response_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterRegistrationResponseBuilder contains the data and logic needed to build 'cluster_registration_response' objects.
 //

--- a/accountsmgmt/v1/cluster_registration_response_list_builder.go
+++ b/accountsmgmt/v1/cluster_registration_response_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterRegistrationResponseListBuilder contains the data and logic needed to build
 // 'cluster_registration_response' objects.

--- a/accountsmgmt/v1/cluster_registration_response_list_reader.go
+++ b/accountsmgmt/v1/cluster_registration_response_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterRegistrationResponseListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/cluster_registration_response_reader.go
+++ b/accountsmgmt/v1/cluster_registration_response_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterRegistrationResponseData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/cluster_registration_response_type.go
+++ b/accountsmgmt/v1/cluster_registration_response_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ClusterRegistrationResponse represents the values of the 'cluster_registration_response' type.
 //

--- a/accountsmgmt/v1/cluster_registrations_client.go
+++ b/accountsmgmt/v1/cluster_registrations_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -28,8 +28,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ClusterRegistrationsClient is the client of the 'cluster_registrations' resource.

--- a/accountsmgmt/v1/cluster_registrations_server.go
+++ b/accountsmgmt/v1/cluster_registrations_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // ClusterRegistrationsServer represents the interface the manages the 'cluster_registrations' resource.

--- a/accountsmgmt/v1/current_account_client.go
+++ b/accountsmgmt/v1/current_account_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // CurrentAccountClient is the client of the 'current_account' resource.

--- a/accountsmgmt/v1/current_account_server.go
+++ b/accountsmgmt/v1/current_account_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // CurrentAccountServer represents the interface the manages the 'current_account' resource.

--- a/accountsmgmt/v1/errors.go
+++ b/accountsmgmt/v1/errors.go
@@ -17,4 +17,4 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1

--- a/accountsmgmt/v1/organization_builder.go
+++ b/accountsmgmt/v1/organization_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // OrganizationBuilder contains the data and logic needed to build 'organization' objects.
 //

--- a/accountsmgmt/v1/organization_client.go
+++ b/accountsmgmt/v1/organization_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // OrganizationClient is the client of the 'organization' resource.

--- a/accountsmgmt/v1/organization_list_builder.go
+++ b/accountsmgmt/v1/organization_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // OrganizationListBuilder contains the data and logic needed to build
 // 'organization' objects.

--- a/accountsmgmt/v1/organization_list_reader.go
+++ b/accountsmgmt/v1/organization_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // organizationListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/organization_reader.go
+++ b/accountsmgmt/v1/organization_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // organizationData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/organization_server.go
+++ b/accountsmgmt/v1/organization_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // OrganizationServer represents the interface the manages the 'organization' resource.

--- a/accountsmgmt/v1/organization_type.go
+++ b/accountsmgmt/v1/organization_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // OrganizationKind is the name of the type used to represent objects
 // of type 'organization'.

--- a/accountsmgmt/v1/organizations_client.go
+++ b/accountsmgmt/v1/organizations_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // OrganizationsClient is the client of the 'organizations' resource.

--- a/accountsmgmt/v1/organizations_server.go
+++ b/accountsmgmt/v1/organizations_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // OrganizationsServer represents the interface the manages the 'organizations' resource.

--- a/accountsmgmt/v1/permission_builder.go
+++ b/accountsmgmt/v1/permission_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // PermissionBuilder contains the data and logic needed to build 'permission' objects.
 //

--- a/accountsmgmt/v1/permission_client.go
+++ b/accountsmgmt/v1/permission_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // PermissionClient is the client of the 'permission' resource.

--- a/accountsmgmt/v1/permission_list_builder.go
+++ b/accountsmgmt/v1/permission_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // PermissionListBuilder contains the data and logic needed to build
 // 'permission' objects.

--- a/accountsmgmt/v1/permission_list_reader.go
+++ b/accountsmgmt/v1/permission_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // permissionListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/permission_reader.go
+++ b/accountsmgmt/v1/permission_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // permissionData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/permission_server.go
+++ b/accountsmgmt/v1/permission_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // PermissionServer represents the interface the manages the 'permission' resource.

--- a/accountsmgmt/v1/permission_type.go
+++ b/accountsmgmt/v1/permission_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // PermissionKind is the name of the type used to represent objects
 // of type 'permission'.

--- a/accountsmgmt/v1/permissions_client.go
+++ b/accountsmgmt/v1/permissions_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // PermissionsClient is the client of the 'permissions' resource.

--- a/accountsmgmt/v1/permissions_server.go
+++ b/accountsmgmt/v1/permissions_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // PermissionsServer represents the interface the manages the 'permissions' resource.

--- a/accountsmgmt/v1/plan_builder.go
+++ b/accountsmgmt/v1/plan_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // PlanBuilder contains the data and logic needed to build 'plan' objects.
 //

--- a/accountsmgmt/v1/plan_list_builder.go
+++ b/accountsmgmt/v1/plan_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // PlanListBuilder contains the data and logic needed to build
 // 'plan' objects.

--- a/accountsmgmt/v1/plan_list_reader.go
+++ b/accountsmgmt/v1/plan_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // planListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/plan_reader.go
+++ b/accountsmgmt/v1/plan_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // planData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/plan_type.go
+++ b/accountsmgmt/v1/plan_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // PlanKind is the name of the type used to represent objects
 // of type 'plan'.

--- a/accountsmgmt/v1/quota_summary_builder.go
+++ b/accountsmgmt/v1/quota_summary_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // QuotaSummaryBuilder contains the data and logic needed to build 'quota_summary' objects.
 //

--- a/accountsmgmt/v1/quota_summary_client.go
+++ b/accountsmgmt/v1/quota_summary_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // QuotaSummaryClient is the client of the 'quota_summary' resource.

--- a/accountsmgmt/v1/quota_summary_list_builder.go
+++ b/accountsmgmt/v1/quota_summary_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // QuotaSummaryListBuilder contains the data and logic needed to build
 // 'quota_summary' objects.

--- a/accountsmgmt/v1/quota_summary_list_reader.go
+++ b/accountsmgmt/v1/quota_summary_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // quotaSummaryListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/quota_summary_reader.go
+++ b/accountsmgmt/v1/quota_summary_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // quotaSummaryData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/quota_summary_server.go
+++ b/accountsmgmt/v1/quota_summary_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // QuotaSummaryServer represents the interface the manages the 'quota_summary' resource.

--- a/accountsmgmt/v1/quota_summary_type.go
+++ b/accountsmgmt/v1/quota_summary_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // QuotaSummary represents the values of the 'quota_summary' type.
 //

--- a/accountsmgmt/v1/registries_client.go
+++ b/accountsmgmt/v1/registries_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RegistriesClient is the client of the 'registries' resource.

--- a/accountsmgmt/v1/registries_server.go
+++ b/accountsmgmt/v1/registries_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RegistriesServer represents the interface the manages the 'registries' resource.

--- a/accountsmgmt/v1/registry_builder.go
+++ b/accountsmgmt/v1/registry_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RegistryBuilder contains the data and logic needed to build 'registry' objects.
 //

--- a/accountsmgmt/v1/registry_client.go
+++ b/accountsmgmt/v1/registry_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RegistryClient is the client of the 'registry' resource.

--- a/accountsmgmt/v1/registry_credential_builder.go
+++ b/accountsmgmt/v1/registry_credential_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RegistryCredentialBuilder contains the data and logic needed to build 'registry_credential' objects.
 //

--- a/accountsmgmt/v1/registry_credential_client.go
+++ b/accountsmgmt/v1/registry_credential_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RegistryCredentialClient is the client of the 'registry_credential' resource.

--- a/accountsmgmt/v1/registry_credential_list_builder.go
+++ b/accountsmgmt/v1/registry_credential_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RegistryCredentialListBuilder contains the data and logic needed to build
 // 'registry_credential' objects.

--- a/accountsmgmt/v1/registry_credential_list_reader.go
+++ b/accountsmgmt/v1/registry_credential_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // registryCredentialListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/registry_credential_reader.go
+++ b/accountsmgmt/v1/registry_credential_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // registryCredentialData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/registry_credential_server.go
+++ b/accountsmgmt/v1/registry_credential_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RegistryCredentialServer represents the interface the manages the 'registry_credential' resource.

--- a/accountsmgmt/v1/registry_credential_type.go
+++ b/accountsmgmt/v1/registry_credential_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RegistryCredentialKind is the name of the type used to represent objects
 // of type 'registry_credential'.

--- a/accountsmgmt/v1/registry_credentials_client.go
+++ b/accountsmgmt/v1/registry_credentials_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RegistryCredentialsClient is the client of the 'registry_credentials' resource.

--- a/accountsmgmt/v1/registry_credentials_server.go
+++ b/accountsmgmt/v1/registry_credentials_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RegistryCredentialsServer represents the interface the manages the 'registry_credentials' resource.

--- a/accountsmgmt/v1/registry_list_builder.go
+++ b/accountsmgmt/v1/registry_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RegistryListBuilder contains the data and logic needed to build
 // 'registry' objects.

--- a/accountsmgmt/v1/registry_list_reader.go
+++ b/accountsmgmt/v1/registry_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // registryListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/registry_reader.go
+++ b/accountsmgmt/v1/registry_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // registryData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/registry_server.go
+++ b/accountsmgmt/v1/registry_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RegistryServer represents the interface the manages the 'registry' resource.

--- a/accountsmgmt/v1/registry_type.go
+++ b/accountsmgmt/v1/registry_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RegistryKind is the name of the type used to represent objects
 // of type 'registry'.

--- a/accountsmgmt/v1/reserved_resource_builder.go
+++ b/accountsmgmt/v1/reserved_resource_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ReservedResourceBuilder contains the data and logic needed to build 'reserved_resource' objects.
 //

--- a/accountsmgmt/v1/reserved_resource_list_builder.go
+++ b/accountsmgmt/v1/reserved_resource_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ReservedResourceListBuilder contains the data and logic needed to build
 // 'reserved_resource' objects.

--- a/accountsmgmt/v1/reserved_resource_list_reader.go
+++ b/accountsmgmt/v1/reserved_resource_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // reservedResourceListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/reserved_resource_reader.go
+++ b/accountsmgmt/v1/reserved_resource_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // reservedResourceData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/reserved_resource_type.go
+++ b/accountsmgmt/v1/reserved_resource_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ReservedResource represents the values of the 'reserved_resource' type.
 //

--- a/accountsmgmt/v1/resource_quota_builder.go
+++ b/accountsmgmt/v1/resource_quota_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ResourceQuotaBuilder contains the data and logic needed to build 'resource_quota' objects.
 //

--- a/accountsmgmt/v1/resource_quota_client.go
+++ b/accountsmgmt/v1/resource_quota_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -28,8 +28,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ResourceQuotaClient is the client of the 'resource_quota' resource.

--- a/accountsmgmt/v1/resource_quota_list_builder.go
+++ b/accountsmgmt/v1/resource_quota_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ResourceQuotaListBuilder contains the data and logic needed to build
 // 'resource_quota' objects.

--- a/accountsmgmt/v1/resource_quota_list_reader.go
+++ b/accountsmgmt/v1/resource_quota_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // resourceQuotaListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/resource_quota_reader.go
+++ b/accountsmgmt/v1/resource_quota_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // resourceQuotaData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/resource_quota_server.go
+++ b/accountsmgmt/v1/resource_quota_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // ResourceQuotaServer represents the interface the manages the 'resource_quota' resource.

--- a/accountsmgmt/v1/resource_quota_type.go
+++ b/accountsmgmt/v1/resource_quota_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // ResourceQuotaKind is the name of the type used to represent objects
 // of type 'resource_quota'.

--- a/accountsmgmt/v1/resource_quotas_client.go
+++ b/accountsmgmt/v1/resource_quotas_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ResourceQuotasClient is the client of the 'resource_quotas' resource.

--- a/accountsmgmt/v1/resource_quotas_server.go
+++ b/accountsmgmt/v1/resource_quotas_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // ResourceQuotasServer represents the interface the manages the 'resource_quotas' resource.

--- a/accountsmgmt/v1/role_binding_builder.go
+++ b/accountsmgmt/v1/role_binding_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RoleBindingBuilder contains the data and logic needed to build 'role_binding' objects.
 //

--- a/accountsmgmt/v1/role_binding_client.go
+++ b/accountsmgmt/v1/role_binding_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RoleBindingClient is the client of the 'role_binding' resource.

--- a/accountsmgmt/v1/role_binding_list_builder.go
+++ b/accountsmgmt/v1/role_binding_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RoleBindingListBuilder contains the data and logic needed to build
 // 'role_binding' objects.

--- a/accountsmgmt/v1/role_binding_list_reader.go
+++ b/accountsmgmt/v1/role_binding_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // roleBindingListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/role_binding_reader.go
+++ b/accountsmgmt/v1/role_binding_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // roleBindingData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/role_binding_server.go
+++ b/accountsmgmt/v1/role_binding_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RoleBindingServer represents the interface the manages the 'role_binding' resource.

--- a/accountsmgmt/v1/role_binding_type.go
+++ b/accountsmgmt/v1/role_binding_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RoleBindingKind is the name of the type used to represent objects
 // of type 'role_binding'.

--- a/accountsmgmt/v1/role_bindings_client.go
+++ b/accountsmgmt/v1/role_bindings_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RoleBindingsClient is the client of the 'role_bindings' resource.

--- a/accountsmgmt/v1/role_bindings_server.go
+++ b/accountsmgmt/v1/role_bindings_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RoleBindingsServer represents the interface the manages the 'role_bindings' resource.

--- a/accountsmgmt/v1/role_builder.go
+++ b/accountsmgmt/v1/role_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RoleBuilder contains the data and logic needed to build 'role' objects.
 //

--- a/accountsmgmt/v1/role_client.go
+++ b/accountsmgmt/v1/role_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -28,8 +28,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RoleClient is the client of the 'role' resource.

--- a/accountsmgmt/v1/role_list_builder.go
+++ b/accountsmgmt/v1/role_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RoleListBuilder contains the data and logic needed to build
 // 'role' objects.

--- a/accountsmgmt/v1/role_list_reader.go
+++ b/accountsmgmt/v1/role_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // roleListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/role_reader.go
+++ b/accountsmgmt/v1/role_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // roleData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/role_server.go
+++ b/accountsmgmt/v1/role_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RoleServer represents the interface the manages the 'role' resource.

--- a/accountsmgmt/v1/role_type.go
+++ b/accountsmgmt/v1/role_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // RoleKind is the name of the type used to represent objects
 // of type 'role'.

--- a/accountsmgmt/v1/roles_client.go
+++ b/accountsmgmt/v1/roles_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // RolesClient is the client of the 'roles' resource.

--- a/accountsmgmt/v1/roles_server.go
+++ b/accountsmgmt/v1/roles_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // RolesServer represents the interface the manages the 'roles' resource.

--- a/accountsmgmt/v1/root_client.go
+++ b/accountsmgmt/v1/root_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"net/http"

--- a/accountsmgmt/v1/root_server.go
+++ b/accountsmgmt/v1/root_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"net/http"

--- a/accountsmgmt/v1/subscription_builder.go
+++ b/accountsmgmt/v1/subscription_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	time "time"

--- a/accountsmgmt/v1/subscription_client.go
+++ b/accountsmgmt/v1/subscription_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // SubscriptionClient is the client of the 'subscription' resource.

--- a/accountsmgmt/v1/subscription_list_builder.go
+++ b/accountsmgmt/v1/subscription_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 // SubscriptionListBuilder contains the data and logic needed to build
 // 'subscription' objects.

--- a/accountsmgmt/v1/subscription_list_reader.go
+++ b/accountsmgmt/v1/subscription_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // subscriptionListData is type used internally to marshal and unmarshal lists of objects

--- a/accountsmgmt/v1/subscription_reader.go
+++ b/accountsmgmt/v1/subscription_reader.go
@@ -17,13 +17,13 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"fmt"
 	time "time"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // subscriptionData is the data structure used internally to marshal and unmarshal

--- a/accountsmgmt/v1/subscription_server.go
+++ b/accountsmgmt/v1/subscription_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // SubscriptionServer represents the interface the manages the 'subscription' resource.

--- a/accountsmgmt/v1/subscription_type.go
+++ b/accountsmgmt/v1/subscription_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	time "time"

--- a/accountsmgmt/v1/subscriptions_client.go
+++ b/accountsmgmt/v1/subscriptions_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // SubscriptionsClient is the client of the 'subscriptions' resource.

--- a/accountsmgmt/v1/subscriptions_server.go
+++ b/accountsmgmt/v1/subscriptions_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // SubscriptionsServer represents the interface the manages the 'subscriptions' resource.

--- a/clustersmgmt/client.go
+++ b/clustersmgmt/client.go
@@ -17,13 +17,13 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package clustersmgmt // github.com/openshift-online/uhc-sdk-go/clustersmgmt
+package clustersmgmt // github.com/openshift-online/ocm-sdk-go/clustersmgmt
 
 import (
 	"net/http"
 	"path"
 
-	v1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 // Client is the client for service 'clusters_mgmt'.

--- a/clustersmgmt/v1/admin_credentials_builder.go
+++ b/clustersmgmt/v1/admin_credentials_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // AdminCredentialsBuilder contains the data and logic needed to build 'admin_credentials' objects.
 //

--- a/clustersmgmt/v1/admin_credentials_list_builder.go
+++ b/clustersmgmt/v1/admin_credentials_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // AdminCredentialsListBuilder contains the data and logic needed to build
 // 'admin_credentials' objects.

--- a/clustersmgmt/v1/admin_credentials_list_reader.go
+++ b/clustersmgmt/v1/admin_credentials_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // adminCredentialsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/admin_credentials_reader.go
+++ b/clustersmgmt/v1/admin_credentials_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // adminCredentialsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/admin_credentials_type.go
+++ b/clustersmgmt/v1/admin_credentials_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // AdminCredentials represents the values of the 'admin_credentials' type.
 //

--- a/clustersmgmt/v1/aws_builder.go
+++ b/clustersmgmt/v1/aws_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // AWSBuilder contains the data and logic needed to build 'AWS' objects.
 //

--- a/clustersmgmt/v1/aws_list_builder.go
+++ b/clustersmgmt/v1/aws_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // AWSListBuilder contains the data and logic needed to build
 // 'AWS' objects.

--- a/clustersmgmt/v1/aws_list_reader.go
+++ b/clustersmgmt/v1/aws_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // awsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/aws_reader.go
+++ b/clustersmgmt/v1/aws_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // awsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/aws_type.go
+++ b/clustersmgmt/v1/aws_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // AWS represents the values of the 'AWS' type.
 //

--- a/clustersmgmt/v1/cloud_provider_builder.go
+++ b/clustersmgmt/v1/cloud_provider_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // CloudProviderBuilder contains the data and logic needed to build 'cloud_provider' objects.
 //

--- a/clustersmgmt/v1/cloud_provider_list_builder.go
+++ b/clustersmgmt/v1/cloud_provider_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // CloudProviderListBuilder contains the data and logic needed to build
 // 'cloud_provider' objects.

--- a/clustersmgmt/v1/cloud_provider_list_reader.go
+++ b/clustersmgmt/v1/cloud_provider_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // cloudProviderListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cloud_provider_reader.go
+++ b/clustersmgmt/v1/cloud_provider_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // cloudProviderData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cloud_provider_type.go
+++ b/clustersmgmt/v1/cloud_provider_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // CloudProvider represents the values of the 'cloud_provider' type.
 //

--- a/clustersmgmt/v1/cloud_region_builder.go
+++ b/clustersmgmt/v1/cloud_region_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // CloudRegionBuilder contains the data and logic needed to build 'cloud_region' objects.
 //

--- a/clustersmgmt/v1/cloud_region_list_builder.go
+++ b/clustersmgmt/v1/cloud_region_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // CloudRegionListBuilder contains the data and logic needed to build
 // 'cloud_region' objects.

--- a/clustersmgmt/v1/cloud_region_list_reader.go
+++ b/clustersmgmt/v1/cloud_region_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // cloudRegionListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cloud_region_reader.go
+++ b/clustersmgmt/v1/cloud_region_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // cloudRegionData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cloud_region_type.go
+++ b/clustersmgmt/v1/cloud_region_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // CloudRegionKind is the name of the type used to represent objects
 // of type 'cloud_region'.

--- a/clustersmgmt/v1/cluster_api_builder.go
+++ b/clustersmgmt/v1/cluster_api_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterAPIBuilder contains the data and logic needed to build 'cluster_API' objects.
 //

--- a/clustersmgmt/v1/cluster_api_list_builder.go
+++ b/clustersmgmt/v1/cluster_api_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterAPIListBuilder contains the data and logic needed to build
 // 'cluster_API' objects.

--- a/clustersmgmt/v1/cluster_api_list_reader.go
+++ b/clustersmgmt/v1/cluster_api_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterAPIListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_api_reader.go
+++ b/clustersmgmt/v1/cluster_api_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterAPIData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_api_type.go
+++ b/clustersmgmt/v1/cluster_api_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterAPI represents the values of the 'cluster_API' type.
 //

--- a/clustersmgmt/v1/cluster_builder.go
+++ b/clustersmgmt/v1/cluster_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"

--- a/clustersmgmt/v1/cluster_client.go
+++ b/clustersmgmt/v1/cluster_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ClusterClient is the client of the 'cluster' resource.

--- a/clustersmgmt/v1/cluster_console_builder.go
+++ b/clustersmgmt/v1/cluster_console_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterConsoleBuilder contains the data and logic needed to build 'cluster_console' objects.
 //

--- a/clustersmgmt/v1/cluster_console_list_builder.go
+++ b/clustersmgmt/v1/cluster_console_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterConsoleListBuilder contains the data and logic needed to build
 // 'cluster_console' objects.

--- a/clustersmgmt/v1/cluster_console_list_reader.go
+++ b/clustersmgmt/v1/cluster_console_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterConsoleListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_console_reader.go
+++ b/clustersmgmt/v1/cluster_console_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterConsoleData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_console_type.go
+++ b/clustersmgmt/v1/cluster_console_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterConsole represents the values of the 'cluster_console' type.
 //

--- a/clustersmgmt/v1/cluster_credentials_builder.go
+++ b/clustersmgmt/v1/cluster_credentials_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterCredentialsBuilder contains the data and logic needed to build 'cluster_credentials' objects.
 //

--- a/clustersmgmt/v1/cluster_credentials_list_builder.go
+++ b/clustersmgmt/v1/cluster_credentials_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterCredentialsListBuilder contains the data and logic needed to build
 // 'cluster_credentials' objects.

--- a/clustersmgmt/v1/cluster_credentials_list_reader.go
+++ b/clustersmgmt/v1/cluster_credentials_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterCredentialsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_credentials_reader.go
+++ b/clustersmgmt/v1/cluster_credentials_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterCredentialsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_credentials_type.go
+++ b/clustersmgmt/v1/cluster_credentials_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterCredentialsKind is the name of the type used to represent objects
 // of type 'cluster_credentials'.

--- a/clustersmgmt/v1/cluster_list_builder.go
+++ b/clustersmgmt/v1/cluster_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterListBuilder contains the data and logic needed to build
 // 'cluster' objects.

--- a/clustersmgmt/v1/cluster_list_reader.go
+++ b/clustersmgmt/v1/cluster_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_metric_builder.go
+++ b/clustersmgmt/v1/cluster_metric_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"

--- a/clustersmgmt/v1/cluster_metric_list_builder.go
+++ b/clustersmgmt/v1/cluster_metric_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterMetricListBuilder contains the data and logic needed to build
 // 'cluster_metric' objects.

--- a/clustersmgmt/v1/cluster_metric_list_reader.go
+++ b/clustersmgmt/v1/cluster_metric_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterMetricListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_metric_reader.go
+++ b/clustersmgmt/v1/cluster_metric_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterMetricData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_metric_type.go
+++ b/clustersmgmt/v1/cluster_metric_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"

--- a/clustersmgmt/v1/cluster_metrics_builder.go
+++ b/clustersmgmt/v1/cluster_metrics_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterMetricsBuilder contains the data and logic needed to build 'cluster_metrics' objects.
 //

--- a/clustersmgmt/v1/cluster_metrics_list_builder.go
+++ b/clustersmgmt/v1/cluster_metrics_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterMetricsListBuilder contains the data and logic needed to build
 // 'cluster_metrics' objects.

--- a/clustersmgmt/v1/cluster_metrics_list_reader.go
+++ b/clustersmgmt/v1/cluster_metrics_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterMetricsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_metrics_reader.go
+++ b/clustersmgmt/v1/cluster_metrics_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterMetricsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_metrics_type.go
+++ b/clustersmgmt/v1/cluster_metrics_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterMetrics represents the values of the 'cluster_metrics' type.
 //

--- a/clustersmgmt/v1/cluster_nodes_builder.go
+++ b/clustersmgmt/v1/cluster_nodes_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterNodesBuilder contains the data and logic needed to build 'cluster_nodes' objects.
 //

--- a/clustersmgmt/v1/cluster_nodes_list_builder.go
+++ b/clustersmgmt/v1/cluster_nodes_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterNodesListBuilder contains the data and logic needed to build
 // 'cluster_nodes' objects.

--- a/clustersmgmt/v1/cluster_nodes_list_reader.go
+++ b/clustersmgmt/v1/cluster_nodes_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterNodesListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_nodes_reader.go
+++ b/clustersmgmt/v1/cluster_nodes_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterNodesData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_nodes_type.go
+++ b/clustersmgmt/v1/cluster_nodes_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterNodes represents the values of the 'cluster_nodes' type.
 //

--- a/clustersmgmt/v1/cluster_reader.go
+++ b/clustersmgmt/v1/cluster_reader.go
@@ -17,13 +17,13 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 	time "time"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_registration_builder.go
+++ b/clustersmgmt/v1/cluster_registration_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterRegistrationBuilder contains the data and logic needed to build 'cluster_registration' objects.
 //

--- a/clustersmgmt/v1/cluster_registration_list_builder.go
+++ b/clustersmgmt/v1/cluster_registration_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterRegistrationListBuilder contains the data and logic needed to build
 // 'cluster_registration' objects.

--- a/clustersmgmt/v1/cluster_registration_list_reader.go
+++ b/clustersmgmt/v1/cluster_registration_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterRegistrationListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_registration_reader.go
+++ b/clustersmgmt/v1/cluster_registration_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterRegistrationData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_registration_type.go
+++ b/clustersmgmt/v1/cluster_registration_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterRegistration represents the values of the 'cluster_registration' type.
 //

--- a/clustersmgmt/v1/cluster_server.go
+++ b/clustersmgmt/v1/cluster_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // ClusterServer represents the interface the manages the 'cluster' resource.

--- a/clustersmgmt/v1/cluster_state_type.go
+++ b/clustersmgmt/v1/cluster_state_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterState represents the values of the 'cluster_state' enumerated type.
 type ClusterState string

--- a/clustersmgmt/v1/cluster_status_builder.go
+++ b/clustersmgmt/v1/cluster_status_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterStatusBuilder contains the data and logic needed to build 'cluster_status' objects.
 //

--- a/clustersmgmt/v1/cluster_status_client.go
+++ b/clustersmgmt/v1/cluster_status_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ClusterStatusClient is the client of the 'cluster_status' resource.

--- a/clustersmgmt/v1/cluster_status_list_builder.go
+++ b/clustersmgmt/v1/cluster_status_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterStatusListBuilder contains the data and logic needed to build
 // 'cluster_status' objects.

--- a/clustersmgmt/v1/cluster_status_list_reader.go
+++ b/clustersmgmt/v1/cluster_status_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterStatusListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/cluster_status_reader.go
+++ b/clustersmgmt/v1/cluster_status_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // clusterStatusData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/cluster_status_server.go
+++ b/clustersmgmt/v1/cluster_status_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // ClusterStatusServer represents the interface the manages the 'cluster_status' resource.

--- a/clustersmgmt/v1/cluster_status_type.go
+++ b/clustersmgmt/v1/cluster_status_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ClusterStatusKind is the name of the type used to represent objects
 // of type 'cluster_status'.

--- a/clustersmgmt/v1/cluster_type.go
+++ b/clustersmgmt/v1/cluster_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"

--- a/clustersmgmt/v1/clusters_client.go
+++ b/clustersmgmt/v1/clusters_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ClustersClient is the client of the 'clusters' resource.

--- a/clustersmgmt/v1/clusters_server.go
+++ b/clustersmgmt/v1/clusters_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // ClustersServer represents the interface the manages the 'clusters' resource.

--- a/clustersmgmt/v1/credentials_client.go
+++ b/clustersmgmt/v1/credentials_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // CredentialsClient is the client of the 'credentials' resource.

--- a/clustersmgmt/v1/credentials_server.go
+++ b/clustersmgmt/v1/credentials_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // CredentialsServer represents the interface the manages the 'credentials' resource.

--- a/clustersmgmt/v1/dashboard_builder.go
+++ b/clustersmgmt/v1/dashboard_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // DashboardBuilder contains the data and logic needed to build 'dashboard' objects.
 //

--- a/clustersmgmt/v1/dashboard_client.go
+++ b/clustersmgmt/v1/dashboard_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // DashboardClient is the client of the 'dashboard' resource.

--- a/clustersmgmt/v1/dashboard_list_builder.go
+++ b/clustersmgmt/v1/dashboard_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // DashboardListBuilder contains the data and logic needed to build
 // 'dashboard' objects.

--- a/clustersmgmt/v1/dashboard_list_reader.go
+++ b/clustersmgmt/v1/dashboard_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // dashboardListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/dashboard_reader.go
+++ b/clustersmgmt/v1/dashboard_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // dashboardData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/dashboard_server.go
+++ b/clustersmgmt/v1/dashboard_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // DashboardServer represents the interface the manages the 'dashboard' resource.

--- a/clustersmgmt/v1/dashboard_type.go
+++ b/clustersmgmt/v1/dashboard_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // DashboardKind is the name of the type used to represent objects
 // of type 'dashboard'.

--- a/clustersmgmt/v1/dashboards_client.go
+++ b/clustersmgmt/v1/dashboards_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // DashboardsClient is the client of the 'dashboards' resource.

--- a/clustersmgmt/v1/dashboards_server.go
+++ b/clustersmgmt/v1/dashboards_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // DashboardsServer represents the interface the manages the 'dashboards' resource.

--- a/clustersmgmt/v1/dns_builder.go
+++ b/clustersmgmt/v1/dns_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // DNSBuilder contains the data and logic needed to build 'DNS' objects.
 //

--- a/clustersmgmt/v1/dns_list_builder.go
+++ b/clustersmgmt/v1/dns_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // DNSListBuilder contains the data and logic needed to build
 // 'DNS' objects.

--- a/clustersmgmt/v1/dns_list_reader.go
+++ b/clustersmgmt/v1/dns_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // dnsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/dns_reader.go
+++ b/clustersmgmt/v1/dns_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // dnsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/dns_type.go
+++ b/clustersmgmt/v1/dns_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // DNS represents the values of the 'DNS' type.
 //

--- a/clustersmgmt/v1/errors.go
+++ b/clustersmgmt/v1/errors.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 const (
 	// Can't create cluster, the given external identifier is already in use.

--- a/clustersmgmt/v1/flavour_builder.go
+++ b/clustersmgmt/v1/flavour_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // FlavourBuilder contains the data and logic needed to build 'flavour' objects.
 //

--- a/clustersmgmt/v1/flavour_client.go
+++ b/clustersmgmt/v1/flavour_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // FlavourClient is the client of the 'flavour' resource.

--- a/clustersmgmt/v1/flavour_list_builder.go
+++ b/clustersmgmt/v1/flavour_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // FlavourListBuilder contains the data and logic needed to build
 // 'flavour' objects.

--- a/clustersmgmt/v1/flavour_list_reader.go
+++ b/clustersmgmt/v1/flavour_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // flavourListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/flavour_reader.go
+++ b/clustersmgmt/v1/flavour_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // flavourData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/flavour_server.go
+++ b/clustersmgmt/v1/flavour_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // FlavourServer represents the interface the manages the 'flavour' resource.

--- a/clustersmgmt/v1/flavour_type.go
+++ b/clustersmgmt/v1/flavour_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // FlavourKind is the name of the type used to represent objects
 // of type 'flavour'.

--- a/clustersmgmt/v1/flavours_client.go
+++ b/clustersmgmt/v1/flavours_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // FlavoursClient is the client of the 'flavours' resource.

--- a/clustersmgmt/v1/flavours_server.go
+++ b/clustersmgmt/v1/flavours_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // FlavoursServer represents the interface the manages the 'flavours' resource.

--- a/clustersmgmt/v1/github_identity_provider_builder.go
+++ b/clustersmgmt/v1/github_identity_provider_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GithubIdentityProviderBuilder contains the data and logic needed to build 'github_identity_provider' objects.
 //

--- a/clustersmgmt/v1/github_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/github_identity_provider_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GithubIdentityProviderListBuilder contains the data and logic needed to build
 // 'github_identity_provider' objects.

--- a/clustersmgmt/v1/github_identity_provider_list_reader.go
+++ b/clustersmgmt/v1/github_identity_provider_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // githubIdentityProviderListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/github_identity_provider_reader.go
+++ b/clustersmgmt/v1/github_identity_provider_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // githubIdentityProviderData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/github_identity_provider_type.go
+++ b/clustersmgmt/v1/github_identity_provider_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GithubIdentityProvider represents the values of the 'github_identity_provider' type.
 //

--- a/clustersmgmt/v1/gitlab_identity_provider_builder.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GitlabIdentityProviderBuilder contains the data and logic needed to build 'gitlab_identity_provider' objects.
 //

--- a/clustersmgmt/v1/gitlab_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GitlabIdentityProviderListBuilder contains the data and logic needed to build
 // 'gitlab_identity_provider' objects.

--- a/clustersmgmt/v1/gitlab_identity_provider_list_reader.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // gitlabIdentityProviderListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/gitlab_identity_provider_reader.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // gitlabIdentityProviderData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/gitlab_identity_provider_type.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GitlabIdentityProvider represents the values of the 'gitlab_identity_provider' type.
 //

--- a/clustersmgmt/v1/google_identity_provider_builder.go
+++ b/clustersmgmt/v1/google_identity_provider_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GoogleIdentityProviderBuilder contains the data and logic needed to build 'google_identity_provider' objects.
 //

--- a/clustersmgmt/v1/google_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/google_identity_provider_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GoogleIdentityProviderListBuilder contains the data and logic needed to build
 // 'google_identity_provider' objects.

--- a/clustersmgmt/v1/google_identity_provider_list_reader.go
+++ b/clustersmgmt/v1/google_identity_provider_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // googleIdentityProviderListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/google_identity_provider_reader.go
+++ b/clustersmgmt/v1/google_identity_provider_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // googleIdentityProviderData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/google_identity_provider_type.go
+++ b/clustersmgmt/v1/google_identity_provider_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GoogleIdentityProvider represents the values of the 'google_identity_provider' type.
 //

--- a/clustersmgmt/v1/group_builder.go
+++ b/clustersmgmt/v1/group_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GroupBuilder contains the data and logic needed to build 'group' objects.
 //

--- a/clustersmgmt/v1/group_client.go
+++ b/clustersmgmt/v1/group_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // GroupClient is the client of the 'group' resource.

--- a/clustersmgmt/v1/group_list_builder.go
+++ b/clustersmgmt/v1/group_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GroupListBuilder contains the data and logic needed to build
 // 'group' objects.

--- a/clustersmgmt/v1/group_list_reader.go
+++ b/clustersmgmt/v1/group_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // groupListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/group_reader.go
+++ b/clustersmgmt/v1/group_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // groupData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/group_server.go
+++ b/clustersmgmt/v1/group_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // GroupServer represents the interface the manages the 'group' resource.

--- a/clustersmgmt/v1/group_type.go
+++ b/clustersmgmt/v1/group_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // GroupKind is the name of the type used to represent objects
 // of type 'group'.

--- a/clustersmgmt/v1/groups_client.go
+++ b/clustersmgmt/v1/groups_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // GroupsClient is the client of the 'groups' resource.

--- a/clustersmgmt/v1/groups_server.go
+++ b/clustersmgmt/v1/groups_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // GroupsServer represents the interface the manages the 'groups' resource.

--- a/clustersmgmt/v1/identity_provider_builder.go
+++ b/clustersmgmt/v1/identity_provider_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // IdentityProviderBuilder contains the data and logic needed to build 'identity_provider' objects.
 //

--- a/clustersmgmt/v1/identity_provider_client.go
+++ b/clustersmgmt/v1/identity_provider_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // IdentityProviderClient is the client of the 'identity_provider' resource.

--- a/clustersmgmt/v1/identity_provider_list_builder.go
+++ b/clustersmgmt/v1/identity_provider_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // IdentityProviderListBuilder contains the data and logic needed to build
 // 'identity_provider' objects.

--- a/clustersmgmt/v1/identity_provider_list_reader.go
+++ b/clustersmgmt/v1/identity_provider_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // identityProviderListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/identity_provider_mapping_method_type.go
+++ b/clustersmgmt/v1/identity_provider_mapping_method_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // IdentityProviderMappingMethod represents the values of the 'identity_provider_mapping_method' enumerated type.
 type IdentityProviderMappingMethod string

--- a/clustersmgmt/v1/identity_provider_reader.go
+++ b/clustersmgmt/v1/identity_provider_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // identityProviderData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/identity_provider_server.go
+++ b/clustersmgmt/v1/identity_provider_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // IdentityProviderServer represents the interface the manages the 'identity_provider' resource.

--- a/clustersmgmt/v1/identity_provider_type.go
+++ b/clustersmgmt/v1/identity_provider_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // IdentityProviderKind is the name of the type used to represent objects
 // of type 'identity_provider'.

--- a/clustersmgmt/v1/identity_provider_type_type.go
+++ b/clustersmgmt/v1/identity_provider_type_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // IdentityProviderType represents the values of the 'identity_provider_type' enumerated type.
 type IdentityProviderType string

--- a/clustersmgmt/v1/identity_providers_client.go
+++ b/clustersmgmt/v1/identity_providers_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // IdentityProvidersClient is the client of the 'identity_providers' resource.

--- a/clustersmgmt/v1/identity_providers_server.go
+++ b/clustersmgmt/v1/identity_providers_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // IdentityProvidersServer represents the interface the manages the 'identity_providers' resource.

--- a/clustersmgmt/v1/ldapattributes_builder.go
+++ b/clustersmgmt/v1/ldapattributes_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LdapattributesBuilder contains the data and logic needed to build 'ldapattributes' objects.
 //

--- a/clustersmgmt/v1/ldapattributes_list_builder.go
+++ b/clustersmgmt/v1/ldapattributes_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LdapattributesListBuilder contains the data and logic needed to build
 // 'ldapattributes' objects.

--- a/clustersmgmt/v1/ldapattributes_list_reader.go
+++ b/clustersmgmt/v1/ldapattributes_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ldapattributesListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/ldapattributes_reader.go
+++ b/clustersmgmt/v1/ldapattributes_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ldapattributesData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/ldapattributes_type.go
+++ b/clustersmgmt/v1/ldapattributes_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // Ldapattributes represents the values of the 'ldapattributes' type.
 //

--- a/clustersmgmt/v1/ldapidentity_provider_builder.go
+++ b/clustersmgmt/v1/ldapidentity_provider_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LdapidentityProviderBuilder contains the data and logic needed to build 'ldapidentity_provider' objects.
 //

--- a/clustersmgmt/v1/ldapidentity_provider_list_builder.go
+++ b/clustersmgmt/v1/ldapidentity_provider_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LdapidentityProviderListBuilder contains the data and logic needed to build
 // 'ldapidentity_provider' objects.

--- a/clustersmgmt/v1/ldapidentity_provider_list_reader.go
+++ b/clustersmgmt/v1/ldapidentity_provider_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ldapidentityProviderListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/ldapidentity_provider_reader.go
+++ b/clustersmgmt/v1/ldapidentity_provider_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // ldapidentityProviderData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/ldapidentity_provider_type.go
+++ b/clustersmgmt/v1/ldapidentity_provider_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LdapidentityProvider represents the values of the 'ldapidentity_provider' type.
 //

--- a/clustersmgmt/v1/log_builder.go
+++ b/clustersmgmt/v1/log_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LogBuilder contains the data and logic needed to build 'log' objects.
 //

--- a/clustersmgmt/v1/log_client.go
+++ b/clustersmgmt/v1/log_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // LogClient is the client of the 'log' resource.

--- a/clustersmgmt/v1/log_list_builder.go
+++ b/clustersmgmt/v1/log_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LogListBuilder contains the data and logic needed to build
 // 'log' objects.

--- a/clustersmgmt/v1/log_list_reader.go
+++ b/clustersmgmt/v1/log_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // logListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/log_reader.go
+++ b/clustersmgmt/v1/log_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // logData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/log_server.go
+++ b/clustersmgmt/v1/log_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // LogServer represents the interface the manages the 'log' resource.

--- a/clustersmgmt/v1/log_type.go
+++ b/clustersmgmt/v1/log_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // LogKind is the name of the type used to represent objects
 // of type 'log'.

--- a/clustersmgmt/v1/logs_client.go
+++ b/clustersmgmt/v1/logs_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // LogsClient is the client of the 'logs' resource.

--- a/clustersmgmt/v1/logs_server.go
+++ b/clustersmgmt/v1/logs_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // LogsServer represents the interface the manages the 'logs' resource.

--- a/clustersmgmt/v1/metric_builder.go
+++ b/clustersmgmt/v1/metric_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // MetricBuilder contains the data and logic needed to build 'metric' objects.
 //

--- a/clustersmgmt/v1/metric_list_builder.go
+++ b/clustersmgmt/v1/metric_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // MetricListBuilder contains the data and logic needed to build
 // 'metric' objects.

--- a/clustersmgmt/v1/metric_list_reader.go
+++ b/clustersmgmt/v1/metric_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // metricListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/metric_reader.go
+++ b/clustersmgmt/v1/metric_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // metricData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/metric_type.go
+++ b/clustersmgmt/v1/metric_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // Metric represents the values of the 'metric' type.
 //

--- a/clustersmgmt/v1/network_builder.go
+++ b/clustersmgmt/v1/network_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // NetworkBuilder contains the data and logic needed to build 'network' objects.
 //

--- a/clustersmgmt/v1/network_list_builder.go
+++ b/clustersmgmt/v1/network_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // NetworkListBuilder contains the data and logic needed to build
 // 'network' objects.

--- a/clustersmgmt/v1/network_list_reader.go
+++ b/clustersmgmt/v1/network_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // networkListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/network_reader.go
+++ b/clustersmgmt/v1/network_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // networkData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/network_type.go
+++ b/clustersmgmt/v1/network_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // Network represents the values of the 'network' type.
 //

--- a/clustersmgmt/v1/open_idclaims_builder.go
+++ b/clustersmgmt/v1/open_idclaims_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdclaimsBuilder contains the data and logic needed to build 'open_idclaims' objects.
 //

--- a/clustersmgmt/v1/open_idclaims_list_builder.go
+++ b/clustersmgmt/v1/open_idclaims_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdclaimsListBuilder contains the data and logic needed to build
 // 'open_idclaims' objects.

--- a/clustersmgmt/v1/open_idclaims_list_reader.go
+++ b/clustersmgmt/v1/open_idclaims_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // openIdclaimsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/open_idclaims_reader.go
+++ b/clustersmgmt/v1/open_idclaims_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // openIdclaimsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/open_idclaims_type.go
+++ b/clustersmgmt/v1/open_idclaims_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdclaims represents the values of the 'open_idclaims' type.
 //

--- a/clustersmgmt/v1/open_ididentity_provider_builder.go
+++ b/clustersmgmt/v1/open_ididentity_provider_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdidentityProviderBuilder contains the data and logic needed to build 'open_ididentity_provider' objects.
 //

--- a/clustersmgmt/v1/open_ididentity_provider_list_builder.go
+++ b/clustersmgmt/v1/open_ididentity_provider_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdidentityProviderListBuilder contains the data and logic needed to build
 // 'open_ididentity_provider' objects.

--- a/clustersmgmt/v1/open_ididentity_provider_list_reader.go
+++ b/clustersmgmt/v1/open_ididentity_provider_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // openIdidentityProviderListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/open_ididentity_provider_reader.go
+++ b/clustersmgmt/v1/open_ididentity_provider_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // openIdidentityProviderData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/open_ididentity_provider_type.go
+++ b/clustersmgmt/v1/open_ididentity_provider_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdidentityProvider represents the values of the 'open_ididentity_provider' type.
 //

--- a/clustersmgmt/v1/open_idurls_builder.go
+++ b/clustersmgmt/v1/open_idurls_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdurlsBuilder contains the data and logic needed to build 'open_idurls' objects.
 //

--- a/clustersmgmt/v1/open_idurls_list_builder.go
+++ b/clustersmgmt/v1/open_idurls_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdurlsListBuilder contains the data and logic needed to build
 // 'open_idurls' objects.

--- a/clustersmgmt/v1/open_idurls_list_reader.go
+++ b/clustersmgmt/v1/open_idurls_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // openIdurlsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/open_idurls_reader.go
+++ b/clustersmgmt/v1/open_idurls_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // openIdurlsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/open_idurls_type.go
+++ b/clustersmgmt/v1/open_idurls_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // OpenIdurls represents the values of the 'open_idurls' type.
 //

--- a/clustersmgmt/v1/root_client.go
+++ b/clustersmgmt/v1/root_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"net/http"

--- a/clustersmgmt/v1/root_server.go
+++ b/clustersmgmt/v1/root_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"net/http"

--- a/clustersmgmt/v1/sample_builder.go
+++ b/clustersmgmt/v1/sample_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"

--- a/clustersmgmt/v1/sample_list_builder.go
+++ b/clustersmgmt/v1/sample_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // SampleListBuilder contains the data and logic needed to build
 // 'sample' objects.

--- a/clustersmgmt/v1/sample_list_reader.go
+++ b/clustersmgmt/v1/sample_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // sampleListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/sample_reader.go
+++ b/clustersmgmt/v1/sample_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // sampleData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/sample_type.go
+++ b/clustersmgmt/v1/sample_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	time "time"

--- a/clustersmgmt/v1/sshcredentials_builder.go
+++ b/clustersmgmt/v1/sshcredentials_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // SshcredentialsBuilder contains the data and logic needed to build 'sshcredentials' objects.
 //

--- a/clustersmgmt/v1/sshcredentials_list_builder.go
+++ b/clustersmgmt/v1/sshcredentials_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // SshcredentialsListBuilder contains the data and logic needed to build
 // 'sshcredentials' objects.

--- a/clustersmgmt/v1/sshcredentials_list_reader.go
+++ b/clustersmgmt/v1/sshcredentials_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // sshcredentialsListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/sshcredentials_reader.go
+++ b/clustersmgmt/v1/sshcredentials_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // sshcredentialsData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/sshcredentials_type.go
+++ b/clustersmgmt/v1/sshcredentials_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // Sshcredentials represents the values of the 'sshcredentials' type.
 //

--- a/clustersmgmt/v1/subscription_builder.go
+++ b/clustersmgmt/v1/subscription_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // SubscriptionBuilder contains the data and logic needed to build 'subscription' objects.
 //

--- a/clustersmgmt/v1/subscription_list_builder.go
+++ b/clustersmgmt/v1/subscription_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // SubscriptionListBuilder contains the data and logic needed to build
 // 'subscription' objects.

--- a/clustersmgmt/v1/subscription_list_reader.go
+++ b/clustersmgmt/v1/subscription_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // subscriptionListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/subscription_reader.go
+++ b/clustersmgmt/v1/subscription_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // subscriptionData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/subscription_type.go
+++ b/clustersmgmt/v1/subscription_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // SubscriptionKind is the name of the type used to represent objects
 // of type 'subscription'.

--- a/clustersmgmt/v1/user_builder.go
+++ b/clustersmgmt/v1/user_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // UserBuilder contains the data and logic needed to build 'user' objects.
 //

--- a/clustersmgmt/v1/user_client.go
+++ b/clustersmgmt/v1/user_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // UserClient is the client of the 'user' resource.

--- a/clustersmgmt/v1/user_list_builder.go
+++ b/clustersmgmt/v1/user_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // UserListBuilder contains the data and logic needed to build
 // 'user' objects.

--- a/clustersmgmt/v1/user_list_reader.go
+++ b/clustersmgmt/v1/user_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // userListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/user_reader.go
+++ b/clustersmgmt/v1/user_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // userData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/user_server.go
+++ b/clustersmgmt/v1/user_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // UserServer represents the interface the manages the 'user' resource.

--- a/clustersmgmt/v1/user_type.go
+++ b/clustersmgmt/v1/user_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // UserKind is the name of the type used to represent objects
 // of type 'user'.

--- a/clustersmgmt/v1/users_client.go
+++ b/clustersmgmt/v1/users_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // UsersClient is the client of the 'users' resource.

--- a/clustersmgmt/v1/users_server.go
+++ b/clustersmgmt/v1/users_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // UsersServer represents the interface the manages the 'users' resource.

--- a/clustersmgmt/v1/value_builder.go
+++ b/clustersmgmt/v1/value_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ValueBuilder contains the data and logic needed to build 'value' objects.
 //

--- a/clustersmgmt/v1/value_list_builder.go
+++ b/clustersmgmt/v1/value_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // ValueListBuilder contains the data and logic needed to build
 // 'value' objects.

--- a/clustersmgmt/v1/value_list_reader.go
+++ b/clustersmgmt/v1/value_list_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // valueListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/value_reader.go
+++ b/clustersmgmt/v1/value_reader.go
@@ -17,10 +17,10 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // valueData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/value_type.go
+++ b/clustersmgmt/v1/value_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // Value represents the values of the 'value' type.
 //

--- a/clustersmgmt/v1/version_builder.go
+++ b/clustersmgmt/v1/version_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // VersionBuilder contains the data and logic needed to build 'version' objects.
 //

--- a/clustersmgmt/v1/version_client.go
+++ b/clustersmgmt/v1/version_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // VersionClient is the client of the 'version' resource.

--- a/clustersmgmt/v1/version_list_builder.go
+++ b/clustersmgmt/v1/version_list_builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // VersionListBuilder contains the data and logic needed to build
 // 'version' objects.

--- a/clustersmgmt/v1/version_list_reader.go
+++ b/clustersmgmt/v1/version_list_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // versionListData is type used internally to marshal and unmarshal lists of objects

--- a/clustersmgmt/v1/version_reader.go
+++ b/clustersmgmt/v1/version_reader.go
@@ -17,12 +17,12 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"fmt"
 
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // versionData is the data structure used internally to marshal and unmarshal

--- a/clustersmgmt/v1/version_server.go
+++ b/clustersmgmt/v1/version_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // VersionServer represents the interface the manages the 'version' resource.

--- a/clustersmgmt/v1/version_type.go
+++ b/clustersmgmt/v1/version_type.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 // VersionKind is the name of the type used to represent objects
 // of type 'version'.

--- a/clustersmgmt/v1/versions_client.go
+++ b/clustersmgmt/v1/versions_client.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openshift-online/uhc-sdk-go/errors"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // VersionsClient is the client of the 'versions' resource.

--- a/clustersmgmt/v1/versions_server.go
+++ b/clustersmgmt/v1/versions_server.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package v1 // github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"github.com/openshift-online/uhc-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 // VersionsServer represents the interface the manages the 'versions' resource.

--- a/connection.go
+++ b/connection.go
@@ -31,8 +31,8 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/openshift-online/uhc-sdk-go/accountsmgmt"
-	"github.com/openshift-online/uhc-sdk-go/clustersmgmt"
+	"github.com/openshift-online/ocm-sdk-go/accountsmgmt"
+	"github.com/openshift-online/ocm-sdk-go/clustersmgmt"
 )
 
 // Default values:
@@ -42,7 +42,7 @@ const (
 	DefaultClientID     = "cloud-services"
 	DefaultClientSecret = ""
 	DefaultURL          = "https://api.openshift.com"
-	DefaultAgent        = "UHC/" + Version
+	DefaultAgent        = "OCM/" + Version
 )
 
 // Alternative default values used in combination with the now deprecated `developers.redhat.com`:
@@ -189,7 +189,7 @@ func (b *ConnectionBuilder) URL(url string) *ConnectionBuilder {
 }
 
 // Agent sets the `User-Agent` header that the client will use in all the HTTP requests. The default
-// is `UHC` followed by an slash and the version of the client, for example `UHC/0.0.0`.
+// is `OCM` followed by an slash and the version of the client, for example `OCM/0.0.0`.
 func (b *ConnectionBuilder) Agent(agent string) *ConnectionBuilder {
 	b.agent = agent
 	return b

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package errors // github.com/openshift-online/uhc-sdk-go/errors
+package errors // github.com/openshift-online/ocm-sdk-go/errors
 
 import (
 	"fmt"
@@ -25,7 +25,7 @@ import (
 	"strconv"
 
 	"github.com/golang/glog"
-	"github.com/openshift-online/uhc-sdk-go/helpers"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // Error kind is the name of the type used to represent errors.

--- a/examples/client_credentials_grant.go
+++ b/examples/client_credentials_grant.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {

--- a/examples/create_cluster.go
+++ b/examples/create_cluster.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/delete_cluster.go
+++ b/examples/delete_cluster.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/delete_subscription.go
+++ b/examples/delete_subscription.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/existing_token.go
+++ b/examples/existing_token.go
@@ -25,8 +25,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {

--- a/examples/get_cluster.go
+++ b/examples/get_cluster.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/get_cluster_credentials.go
+++ b/examples/get_cluster_credentials.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/get_cluster_logs.go
+++ b/examples/get_cluster_logs.go
@@ -24,8 +24,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/get_cluster_metrics.go
+++ b/examples/get_cluster_metrics.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/list_cluster_creators.go
+++ b/examples/list_cluster_creators.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/list_clusters.go
+++ b/examples/list_clusters.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/list_quota_summary.go
+++ b/examples/list_quota_summary.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	amv1 "github.com/openshift-online/uhc-sdk-go/accountsmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
 func main() {
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/list_versions.go
+++ b/examples/list_versions.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -50,7 +50,7 @@ func main() {
 
 	// Create the connection, specifying the `api_outbound` subsystem so that metrics are
 	// enabled and available with the `api_outbound_` prefix.
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/examples/update_cluster.go
+++ b/examples/update_cluster.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/uhc-sdk-go"
-	cmv1 "github.com/openshift-online/uhc-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	// Create the connection, and remember to close it:
-	token := os.Getenv("UHC_TOKEN")
+	token := os.Getenv("OCM_TOKEN")
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift-online/uhc-sdk-go
+module github.com/openshift-online/ocm-sdk-go
 
 go 1.12
 

--- a/helpers/clients.go
+++ b/helpers/clients.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package helpers // github.com/openshift-online/uhc-sdk-go/helpers
+package helpers // github.com/openshift-online/ocm-sdk-go/helpers
 
 import (
 	"fmt"

--- a/helpers/readers.go
+++ b/helpers/readers.go
@@ -17,7 +17,7 @@ limitations under the License.
 // IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
 // your changes will be lost when the file is generated again.
 
-package helpers // github.com/openshift-online/uhc-sdk-go/helpers
+package helpers // github.com/openshift-online/ocm-sdk-go/helpers
 
 import (
 	"bytes"

--- a/request.go
+++ b/request.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/openshift-online/uhc-sdk-go/internal"
+	"github.com/openshift-online/ocm-sdk-go/internal"
 )
 
 // Request contains the information and logic needed to perform an HTTP request.

--- a/token.go
+++ b/token.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 
-	"github.com/openshift-online/uhc-sdk-go/internal"
+	"github.com/openshift-online/ocm-sdk-go/internal"
 )
 
 // Tokens returns the access and refresh tokens that is currently in use by the connection. If it is


### PR DESCRIPTION
This patch renames the project from `uhc-sdk-go` to `ocm-sdk-go`.