### PR TITLE
Release 0.1.30

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.30 Aug 27 2019
+
+- Renamed package to `github.com/openshift-online/ocm-sdk-go`.
+
 == 0.1.29 Aug 26 2019
 
 - Generated servers can handle routes with and without trailing slashes.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.29"
+const Version = "0.1.30"


### PR DESCRIPTION
This more relevant changes in the new version are the following:

- Renamed package to `github.com/openshift-online/ocm-sdk-go`.