### PR TITLE
Fetch tags of model and metamodel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,13 @@ generate: model metamodel
 .PHONY: model
 model:
 	[ -d "$@" ] || git clone "$(model_url)" "$@"
-	cd "$@" && git fetch origin
+	cd "$@" && git fetch --tags origin
 	cd "$@" && git checkout -B build "$(model_version)"
 
 .PHONY: metamodel
 metamodel:
 	[ -d "$@" ] || git clone "$(metamodel_url)" "$@"
-	cd "$@" && git fetch origin
+	cd "$@" && git fetch --tags origin
 	cd "$@" && git checkout -B build "$(metamodel_version)"
 	make -C "$@"
 


### PR DESCRIPTION
Currently the `model` and `metamodel` targets of the _Makefile_ clone
the corresponding repositories only if needed, and then they always do a
`git fetch` to get the latest code. But they don't use the `--tags`
options and as a result some tags may be missing. This patch adds that
`--tags` option.