### PR TITLE
Release 0.1.33

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,16 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.33 Sep 10 2019
+
+- Update to model 0.0.2:
+** Add `DisplayName` attribute to `Subscription` type.
+
+- Update to metamodel 0.0.5:
+** Fix generation of field names for query parameters.
+** Remove `query` and `path` fields from request objects.
+** Remove unused imports.
+
 == 0.1.32 Sep 03 2019
 
 - Makefile generates code using the ocm-api-metamodel v0.0.4.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ model_version:=v0.0.2
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.4
+metamodel_version:=v0.0.5
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples

--- a/accountsmgmt/v1/errors.go
+++ b/accountsmgmt/v1/errors.go
@@ -18,5 +18,3 @@ limitations under the License.
 // your changes will be lost when the file is generated again.
 
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
-
-const ()

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.32"
+const Version = "0.1.33"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.2:
    - Add `DisplayName` attribute to `Subscription` type.

- Update to metamodel 0.0.5:
    - Fix generation of field names for query parameters.
    - Remove `query` and `path` fields from request objects.
    - Remove unused imports.