### PR TITLE
Use about to expire access token if needed

### DIFF
--- a/token_test.go
+++ b/token_test.go
@@ -201,6 +201,25 @@ var _ = Describe("Tokens", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("Succeeds if access token expires soon and there is no refresh token", func() {
+			// Generate the tokens:
+			accessToken := DefaultToken("Bearer", 1*time.Second)
+
+			// Create the connection:
+			connection, err := NewConnectionBuilder().
+				Logger(logger).
+				TokenURL(oidServer.URL()).
+				URL(apiServer.URL()).
+				Tokens(accessToken).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			defer connection.Close()
+
+			// Get the tokens:
+			_, _, err = connection.Tokens()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Fails if the refresh token is expired", func() {
 			// Generate the tokens:
 			refreshToken := DefaultToken("Refresh", -5*time.Second)


### PR DESCRIPTION
Currently the SDK always tries to refresh the access token when it
expires in less than one minute. But this fails when there is no refresh
token or credentials that can be used to obtain a new one. This patch
changes it so that in that case it uses that access token, even if it is
about to expire.

Related: https://jira.coreos.com/browse/SDA-1402