### PR TITLE
Release 0.1.34

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,15 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.34 Sep 11 2019
+
+- Use access token that is about to expire if there is no other mechanism to
+  obtain a new one.
+
+- Update to model 0.0.3:
+** Add `order` parameter to the collections that suport it.
+** Add cloud providers collection.
+
 == 0.1.33 Sep 10 2019
 
 - Update to model 0.0.2:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 
 # Details of the model to use:
-model_version:=v0.0.2
+model_version:=v0.0.3
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:

--- a/clustersmgmt/v1/cloud_provider_builder.go
+++ b/clustersmgmt/v1/cloud_provider_builder.go
@@ -23,6 +23,9 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 //
 // Cloud provider.
 type CloudProviderBuilder struct {
+	id          *string
+	href        *string
+	link        bool
 	name        *string
 	displayName *string
 }
@@ -30,6 +33,24 @@ type CloudProviderBuilder struct {
 // NewCloudProvider creates a new builder of 'cloud_provider' objects.
 func NewCloudProvider() *CloudProviderBuilder {
 	return new(CloudProviderBuilder)
+}
+
+// ID sets the identifier of the object.
+func (b *CloudProviderBuilder) ID(value string) *CloudProviderBuilder {
+	b.id = &value
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *CloudProviderBuilder) HREF(value string) *CloudProviderBuilder {
+	b.href = &value
+	return b
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *CloudProviderBuilder) Link(value bool) *CloudProviderBuilder {
+	b.link = value
+	return b
 }
 
 // Name sets the value of the 'name' attribute
@@ -53,6 +74,9 @@ func (b *CloudProviderBuilder) DisplayName(value string) *CloudProviderBuilder {
 // Build creates a 'cloud_provider' object using the configuration stored in the builder.
 func (b *CloudProviderBuilder) Build() (object *CloudProvider, err error) {
 	object = new(CloudProvider)
+	object.id = b.id
+	object.href = b.href
+	object.link = b.link
 	if b.name != nil {
 		object.name = b.name
 	}

--- a/clustersmgmt/v1/cloud_provider_client.go
+++ b/clustersmgmt/v1/cloud_provider_client.go
@@ -1,0 +1,205 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// CloudProviderClient is the client of the 'cloud_provider' resource.
+//
+// Manages a specific cloud provider.
+type CloudProviderClient struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+}
+
+// NewCloudProviderClient creates a new client for the 'cloud_provider'
+// resource using the given transport to sned the requests and receive the
+// responses.
+func NewCloudProviderClient(transport http.RoundTripper, path string, metric string) *CloudProviderClient {
+	client := new(CloudProviderClient)
+	client.transport = transport
+	client.path = path
+	client.metric = metric
+	return client
+}
+
+// Get creates a request for the 'get' method.
+//
+// Retrieves the details of the cloud provider.
+func (c *CloudProviderClient) Get() *CloudProviderGetRequest {
+	request := new(CloudProviderGetRequest)
+	request.transport = c.transport
+	request.path = c.path
+	request.metric = c.metric
+	return request
+}
+
+// Regions returns the target 'cloud_regions' resource.
+//
+// Reference to the resource that manages the collection of regions for
+// this cloud provider.
+func (c *CloudProviderClient) Regions() *CloudRegionsClient {
+	return NewCloudRegionsClient(
+		c.transport,
+		path.Join(c.path, "regions"),
+		path.Join(c.metric, "regions"),
+	)
+}
+
+// CloudProviderGetRequest is the request for the 'get' method.
+type CloudProviderGetRequest struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+	query     url.Values
+	header    http.Header
+}
+
+// Parameter adds a query parameter.
+func (r *CloudProviderGetRequest) Parameter(name string, value interface{}) *CloudProviderGetRequest {
+	helpers.AddValue(&r.query, name, value)
+	return r
+}
+
+// Header adds a request header.
+func (r *CloudProviderGetRequest) Header(name string, value interface{}) *CloudProviderGetRequest {
+	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Send sends this request, waits for the response, and returns it.
+//
+// This is a potentially lengthy operation, as it requires network communication.
+// Consider using a context and the SendContext method.
+func (r *CloudProviderGetRequest) Send() (result *CloudProviderGetResponse, err error) {
+	return r.SendContext(context.Background())
+}
+
+// SendContext sends this request, waits for the response, and returns it.
+func (r *CloudProviderGetRequest) SendContext(ctx context.Context) (result *CloudProviderGetResponse, err error) {
+	query := helpers.CopyQuery(r.query)
+	header := helpers.SetHeader(r.header, r.metric)
+	uri := &url.URL{
+		Path:     r.path,
+		RawQuery: query.Encode(),
+	}
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL:    uri,
+		Header: header,
+	}
+	if ctx != nil {
+		request = request.WithContext(ctx)
+	}
+	response, err := r.transport.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result = new(CloudProviderGetResponse)
+	result.status = response.StatusCode
+	result.header = response.Header
+	if result.status >= 400 {
+		result.err, err = errors.UnmarshalError(response.Body)
+		if err != nil {
+			return
+		}
+		err = result.err
+		return
+	}
+	err = result.unmarshal(response.Body)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// CloudProviderGetResponse is the response for the 'get' method.
+type CloudProviderGetResponse struct {
+	status int
+	header http.Header
+	err    *errors.Error
+	body   *CloudProvider
+}
+
+// Status returns the response status code.
+func (r *CloudProviderGetResponse) Status() int {
+	return r.status
+}
+
+// Header returns header of the response.
+func (r *CloudProviderGetResponse) Header() http.Header {
+	return r.header
+}
+
+// Error returns the response error.
+func (r *CloudProviderGetResponse) Error() *errors.Error {
+	return r.err
+}
+
+// Body returns the value of the 'body' parameter.
+//
+//
+func (r *CloudProviderGetResponse) Body() *CloudProvider {
+	if r == nil {
+		return nil
+	}
+	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *CloudProviderGetResponse) GetBody() (value *CloudProvider, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
+}
+
+// unmarshal is the method used internally to unmarshal responses to the
+// 'get' method.
+func (r *CloudProviderGetResponse) unmarshal(reader io.Reader) error {
+	var err error
+	decoder := json.NewDecoder(reader)
+	data := new(cloudProviderData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	r.body, err = data.unwrap()
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/clustersmgmt/v1/cloud_provider_reader.go
+++ b/clustersmgmt/v1/cloud_provider_reader.go
@@ -20,12 +20,17 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
 // cloudProviderData is the data structure used internally to marshal and unmarshal
 // objects of type 'cloud_provider'.
 type cloudProviderData struct {
+	Kind        *string "json:\"kind,omitempty\""
+	ID          *string "json:\"id,omitempty\""
+	HREF        *string "json:\"href,omitempty\""
 	Name        *string "json:\"name,omitempty\""
 	DisplayName *string "json:\"display_name,omitempty\""
 }
@@ -51,6 +56,14 @@ func (o *CloudProvider) wrap() (data *cloudProviderData, err error) {
 		return
 	}
 	data = new(cloudProviderData)
+	data.ID = o.id
+	data.HREF = o.href
+	data.Kind = new(string)
+	if o.link {
+		*data.Kind = CloudProviderLinkKind
+	} else {
+		*data.Kind = CloudProviderKind
+	}
 	data.Name = o.name
 	data.DisplayName = o.displayName
 	return
@@ -79,6 +92,24 @@ func (d *cloudProviderData) unwrap() (object *CloudProvider, err error) {
 		return
 	}
 	object = new(CloudProvider)
+	object.id = d.ID
+	object.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case CloudProviderKind:
+			object.link = false
+		case CloudProviderLinkKind:
+			object.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				CloudProviderKind,
+				CloudProviderLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	object.name = d.Name
 	object.displayName = d.DisplayName
 	return

--- a/clustersmgmt/v1/cloud_provider_server.go
+++ b/clustersmgmt/v1/cloud_provider_server.go
@@ -1,0 +1,154 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+)
+
+// CloudProviderServer represents the interface the manages the 'cloud_provider' resource.
+type CloudProviderServer interface {
+
+	// Get handles a request for the 'get' method.
+	//
+	// Retrieves the details of the cloud provider.
+	Get(ctx context.Context, request *CloudProviderGetServerRequest, response *CloudProviderGetServerResponse) error
+
+	// Regions returns the target 'cloud_regions' resource.
+	//
+	// Reference to the resource that manages the collection of regions for
+	// this cloud provider.
+	Regions() CloudRegionsServer
+}
+
+// CloudProviderGetServerRequest is the request for the 'get' method.
+type CloudProviderGetServerRequest struct {
+}
+
+// CloudProviderGetServerResponse is the response for the 'get' method.
+type CloudProviderGetServerResponse struct {
+	status int
+	err    *errors.Error
+	body   *CloudProvider
+}
+
+// Body sets the value of the 'body' parameter.
+//
+//
+func (r *CloudProviderGetServerResponse) Body(value *CloudProvider) *CloudProviderGetServerResponse {
+	r.body = value
+	return r
+}
+
+// SetStatusCode sets the status code for a give response and returns the response object.
+func (r *CloudProviderGetServerResponse) SetStatusCode(status int) *CloudProviderGetServerResponse {
+	r.status = status
+	return r
+}
+
+// marshall is the method used internally to marshal responses for the
+// 'get' method.
+func (r *CloudProviderGetServerResponse) marshal(writer io.Writer) error {
+	var err error
+	encoder := json.NewEncoder(writer)
+	data, err := r.body.wrap()
+	if err != nil {
+		return err
+	}
+	err = encoder.Encode(data)
+	return err
+}
+
+// CloudProviderServerAdapter represents the structs that adapts Requests and Response to internal
+// structs.
+type CloudProviderServerAdapter struct {
+	server CloudProviderServer
+	router *mux.Router
+}
+
+func NewCloudProviderServerAdapter(server CloudProviderServer, router *mux.Router) *CloudProviderServerAdapter {
+	adapter := new(CloudProviderServerAdapter)
+	adapter.server = server
+	adapter.router = router
+	adapter.router.PathPrefix("/regions").HandlerFunc(adapter.regionsHandler)
+	adapter.router.Methods("GET").Path("").HandlerFunc(adapter.getHandler)
+	return adapter
+}
+func (a *CloudProviderServerAdapter) regionsHandler(w http.ResponseWriter, r *http.Request) {
+	target := a.server.Regions()
+	targetAdapter := NewCloudRegionsServerAdapter(target, a.router.PathPrefix("/regions").Subrouter())
+	targetAdapter.ServeHTTP(w, r)
+	return
+}
+func (a *CloudProviderServerAdapter) readCloudProviderGetServerRequest(r *http.Request) (*CloudProviderGetServerRequest, error) {
+	var err error
+	result := new(CloudProviderGetServerRequest)
+	return result, err
+}
+func (a *CloudProviderServerAdapter) writeCloudProviderGetServerResponse(w http.ResponseWriter, r *CloudProviderGetServerResponse) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(r.status)
+	err := r.marshal(w)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (a *CloudProviderServerAdapter) getHandler(w http.ResponseWriter, r *http.Request) {
+	req, err := a.readCloudProviderGetServerRequest(r)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to read request from client: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+		return
+	}
+	resp := new(CloudProviderGetServerResponse)
+	err = a.server.Get(r.Context(), req, resp)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to run method Get: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+	}
+	err = a.writeCloudProviderGetServerResponse(w, resp)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to write response for client: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+	}
+}
+func (a *CloudProviderServerAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.router.ServeHTTP(w, r)
+}

--- a/clustersmgmt/v1/cloud_provider_type.go
+++ b/clustersmgmt/v1/cloud_provider_type.go
@@ -19,17 +19,85 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
+// CloudProviderKind is the name of the type used to represent objects
+// of type 'cloud_provider'.
+const CloudProviderKind = "CloudProvider"
+
+// CloudProviderLinkKind is the name of the type used to represent links
+// to objects of type 'cloud_provider'.
+const CloudProviderLinkKind = "CloudProviderLink"
+
+// CloudProviderNilKind is the name of the type used to nil references
+// to objects of type 'cloud_provider'.
+const CloudProviderNilKind = "CloudProviderNil"
+
 // CloudProvider represents the values of the 'cloud_provider' type.
 //
 // Cloud provider.
 type CloudProvider struct {
+	id          *string
+	href        *string
+	link        bool
 	name        *string
 	displayName *string
 }
 
+// Kind returns the name of the type of the object.
+func (o *CloudProvider) Kind() string {
+	if o == nil {
+		return CloudProviderNilKind
+	}
+	if o.link {
+		return CloudProviderLinkKind
+	}
+	return CloudProviderKind
+}
+
+// ID returns the identifier of the object.
+func (o *CloudProvider) ID() string {
+	if o != nil && o.id != nil {
+		return *o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *CloudProvider) GetID() (value string, ok bool) {
+	ok = o != nil && o.id != nil
+	if ok {
+		value = *o.id
+	}
+	return
+}
+
+// Link returns true iif this is a link.
+func (o *CloudProvider) Link() bool {
+	return o != nil && o.link
+}
+
+// HREF returns the link to the object.
+func (o *CloudProvider) HREF() string {
+	if o != nil && o.href != nil {
+		return *o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *CloudProvider) GetHREF() (value string, ok bool) {
+	ok = o != nil && o.href != nil
+	if ok {
+		value = *o.href
+	}
+	return
+}
+
 // Empty returns true if the object is empty, i.e. no attribute has a value.
 func (o *CloudProvider) Empty() bool {
-	return o == nil || (o.name == nil &&
+	return o == nil || (o.id == nil &&
+		o.name == nil &&
 		o.displayName == nil &&
 		true)
 }
@@ -82,9 +150,57 @@ func (o *CloudProvider) GetDisplayName() (value string, ok bool) {
 	return
 }
 
+// CloudProviderListKind is the name of the type used to represent list of
+// objects of type 'cloud_provider'.
+const CloudProviderListKind = "CloudProviderList"
+
+// CloudProviderListLinkKind is the name of the type used to represent links
+// to list of objects of type 'cloud_provider'.
+const CloudProviderListLinkKind = "CloudProviderListLink"
+
+// CloudProviderNilKind is the name of the type used to nil lists of
+// objects of type 'cloud_provider'.
+const CloudProviderListNilKind = "CloudProviderListNil"
+
 // CloudProviderList is a list of values of the 'cloud_provider' type.
 type CloudProviderList struct {
+	href  *string
+	link  bool
 	items []*CloudProvider
+}
+
+// Kind returns the name of the type of the object.
+func (l *CloudProviderList) Kind() string {
+	if l == nil {
+		return CloudProviderListNilKind
+	}
+	if l.link {
+		return CloudProviderListLinkKind
+	}
+	return CloudProviderListKind
+}
+
+// Link returns true iif this is a link.
+func (l *CloudProviderList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *CloudProviderList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *CloudProviderList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/clustersmgmt/v1/cloud_providers_client.go
+++ b/clustersmgmt/v1/cloud_providers_client.go
@@ -31,20 +31,20 @@ import (
 	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
-// DashboardsClient is the client of the 'dashboards' resource.
+// CloudProvidersClient is the client of the 'cloud_providers' resource.
 //
-// Manages the collection of dashboards.
-type DashboardsClient struct {
+// Manages the collection of cloud providers.
+type CloudProvidersClient struct {
 	transport http.RoundTripper
 	path      string
 	metric    string
 }
 
-// NewDashboardsClient creates a new client for the 'dashboards'
+// NewCloudProvidersClient creates a new client for the 'cloud_providers'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewDashboardsClient(transport http.RoundTripper, path string, metric string) *DashboardsClient {
-	client := new(DashboardsClient)
+func NewCloudProvidersClient(transport http.RoundTripper, path string, metric string) *CloudProvidersClient {
+	client := new(CloudProvidersClient)
 	client.transport = transport
 	client.path = path
 	client.metric = metric
@@ -53,28 +53,28 @@ func NewDashboardsClient(transport http.RoundTripper, path string, metric string
 
 // List creates a request for the 'list' method.
 //
-// Retrieves a list of dashboards.
-func (c *DashboardsClient) List() *DashboardsListRequest {
-	request := new(DashboardsListRequest)
+// Retrieves the list of cloud providers.
+func (c *CloudProvidersClient) List() *CloudProvidersListRequest {
+	request := new(CloudProvidersListRequest)
 	request.transport = c.transport
 	request.path = c.path
 	request.metric = c.metric
 	return request
 }
 
-// Dashboard returns the target 'dashboard' resource for the given identifier.
+// CloudProvider returns the target 'cloud_provider' resource for the given identifier.
 //
-// Reference to the resource that manages a specific dashboard.
-func (c *DashboardsClient) Dashboard(id string) *DashboardClient {
-	return NewDashboardClient(
+// Returns a reference to the service that manages an specific cloud provider.
+func (c *CloudProvidersClient) CloudProvider(id string) *CloudProviderClient {
+	return NewCloudProviderClient(
 		c.transport,
 		path.Join(c.path, id),
 		path.Join(c.metric, "-"),
 	)
 }
 
-// DashboardsListRequest is the request for the 'list' method.
-type DashboardsListRequest struct {
+// CloudProvidersListRequest is the request for the 'list' method.
+type CloudProvidersListRequest struct {
 	transport http.RoundTripper
 	path      string
 	metric    string
@@ -88,13 +88,13 @@ type DashboardsListRequest struct {
 }
 
 // Parameter adds a query parameter.
-func (r *DashboardsListRequest) Parameter(name string, value interface{}) *DashboardsListRequest {
+func (r *CloudProvidersListRequest) Parameter(name string, value interface{}) *CloudProvidersListRequest {
 	helpers.AddValue(&r.query, name, value)
 	return r
 }
 
 // Header adds a request header.
-func (r *DashboardsListRequest) Header(name string, value interface{}) *DashboardsListRequest {
+func (r *CloudProvidersListRequest) Header(name string, value interface{}) *CloudProvidersListRequest {
 	helpers.AddHeader(&r.header, name, value)
 	return r
 }
@@ -104,7 +104,7 @@ func (r *DashboardsListRequest) Header(name string, value interface{}) *Dashboar
 // Index of the requested page, where one corresponds to the first page.
 //
 // Default value is `1`.
-func (r *DashboardsListRequest) Page(value int) *DashboardsListRequest {
+func (r *CloudProvidersListRequest) Page(value int) *CloudProvidersListRequest {
 	r.page = &value
 	return r
 }
@@ -114,7 +114,7 @@ func (r *DashboardsListRequest) Page(value int) *DashboardsListRequest {
 // Maximum number of items that will be contained in the returned page.
 //
 // Default value is `100`.
-func (r *DashboardsListRequest) Size(value int) *DashboardsListRequest {
+func (r *CloudProvidersListRequest) Size(value int) *CloudProvidersListRequest {
 	r.size = &value
 	return r
 }
@@ -124,18 +124,18 @@ func (r *DashboardsListRequest) Size(value int) *DashboardsListRequest {
 // Search criteria.
 //
 // The syntax of this parameter is similar to the syntax of the _where_ clause of a
-// SQL statement, but using the names of the attributes of the dashboard instead of
-// the names of the columns of a table. For example, in order to retrieve all the
-// dashboards with a name starting with `my` the value should be:
+// SQL statement, but using the names of the attributes of the cloud provider
+// instead of the names of the columns of a table. For example, in order to retrieve
+// all the cloud providers with a name starting with `A` the value should be:
 //
 // [source,sql]
 // ----
-// name like 'my%'
+// name like 'A%'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// dashboards that the user has permission to see will be returned.
-func (r *DashboardsListRequest) Search(value string) *DashboardsListRequest {
+// If the parameter isn't provided, or if the value is empty, then all the clusters
+// that the user has permission to see will be returned.
+func (r *CloudProvidersListRequest) Search(value string) *CloudProvidersListRequest {
 	r.search = &value
 	return r
 }
@@ -145,9 +145,9 @@ func (r *DashboardsListRequest) Search(value string) *DashboardsListRequest {
 // Order criteria.
 //
 // The syntax of this parameter is similar to the syntax of the _order by_ clause of
-// a SQL statement, but using the names of the attributes of the dashboard instead of
-// the names of the columns of a table. For example, in order to sort the dashboards
-// descending by name the value should be:
+// a SQL statement, but using the names of the attributes of the cloud provider
+// instead of the names of the columns of a table. For example, in order to sort the
+// clusters descending by name identifier the value should be:
 //
 // [source,sql]
 // ----
@@ -156,7 +156,7 @@ func (r *DashboardsListRequest) Search(value string) *DashboardsListRequest {
 //
 // If the parameter isn't provided, or if the value is empty, then the order of the
 // results is undefined.
-func (r *DashboardsListRequest) Order(value string) *DashboardsListRequest {
+func (r *CloudProvidersListRequest) Order(value string) *CloudProvidersListRequest {
 	r.order = &value
 	return r
 }
@@ -165,7 +165,7 @@ func (r *DashboardsListRequest) Order(value string) *DashboardsListRequest {
 //
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
-func (r *DashboardsListRequest) Total(value int) *DashboardsListRequest {
+func (r *CloudProvidersListRequest) Total(value int) *CloudProvidersListRequest {
 	r.total = &value
 	return r
 }
@@ -174,12 +174,12 @@ func (r *DashboardsListRequest) Total(value int) *DashboardsListRequest {
 //
 // This is a potentially lengthy operation, as it requires network communication.
 // Consider using a context and the SendContext method.
-func (r *DashboardsListRequest) Send() (result *DashboardsListResponse, err error) {
+func (r *CloudProvidersListRequest) Send() (result *CloudProvidersListResponse, err error) {
 	return r.SendContext(context.Background())
 }
 
 // SendContext sends this request, waits for the response, and returns it.
-func (r *DashboardsListRequest) SendContext(ctx context.Context) (result *DashboardsListResponse, err error) {
+func (r *CloudProvidersListRequest) SendContext(ctx context.Context) (result *CloudProvidersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)
@@ -214,7 +214,7 @@ func (r *DashboardsListRequest) SendContext(ctx context.Context) (result *Dashbo
 		return
 	}
 	defer response.Body.Close()
-	result = new(DashboardsListResponse)
+	result = new(CloudProvidersListResponse)
 	result.status = response.StatusCode
 	result.header = response.Header
 	if result.status >= 400 {
@@ -232,29 +232,29 @@ func (r *DashboardsListRequest) SendContext(ctx context.Context) (result *Dashbo
 	return
 }
 
-// DashboardsListResponse is the response for the 'list' method.
-type DashboardsListResponse struct {
+// CloudProvidersListResponse is the response for the 'list' method.
+type CloudProvidersListResponse struct {
 	status int
 	header http.Header
 	err    *errors.Error
 	page   *int
 	size   *int
 	total  *int
-	items  *DashboardList
+	items  *CloudProviderList
 }
 
 // Status returns the response status code.
-func (r *DashboardsListResponse) Status() int {
+func (r *CloudProvidersListResponse) Status() int {
 	return r.status
 }
 
 // Header returns header of the response.
-func (r *DashboardsListResponse) Header() http.Header {
+func (r *CloudProvidersListResponse) Header() http.Header {
 	return r.header
 }
 
 // Error returns the response error.
-func (r *DashboardsListResponse) Error() *errors.Error {
+func (r *CloudProvidersListResponse) Error() *errors.Error {
 	return r.err
 }
 
@@ -263,7 +263,7 @@ func (r *DashboardsListResponse) Error() *errors.Error {
 // Index of the requested page, where one corresponds to the first page.
 //
 // Default value is `1`.
-func (r *DashboardsListResponse) Page() int {
+func (r *CloudProvidersListResponse) Page() int {
 	if r != nil && r.page != nil {
 		return *r.page
 	}
@@ -276,7 +276,7 @@ func (r *DashboardsListResponse) Page() int {
 // Index of the requested page, where one corresponds to the first page.
 //
 // Default value is `1`.
-func (r *DashboardsListResponse) GetPage() (value int, ok bool) {
+func (r *CloudProvidersListResponse) GetPage() (value int, ok bool) {
 	ok = r != nil && r.page != nil
 	if ok {
 		value = *r.page
@@ -289,7 +289,7 @@ func (r *DashboardsListResponse) GetPage() (value int, ok bool) {
 // Maximum number of items that will be contained in the returned page.
 //
 // Default value is `100`.
-func (r *DashboardsListResponse) Size() int {
+func (r *CloudProvidersListResponse) Size() int {
 	if r != nil && r.size != nil {
 		return *r.size
 	}
@@ -302,7 +302,7 @@ func (r *DashboardsListResponse) Size() int {
 // Maximum number of items that will be contained in the returned page.
 //
 // Default value is `100`.
-func (r *DashboardsListResponse) GetSize() (value int, ok bool) {
+func (r *CloudProvidersListResponse) GetSize() (value int, ok bool) {
 	ok = r != nil && r.size != nil
 	if ok {
 		value = *r.size
@@ -314,7 +314,7 @@ func (r *DashboardsListResponse) GetSize() (value int, ok bool) {
 //
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
-func (r *DashboardsListResponse) Total() int {
+func (r *CloudProvidersListResponse) Total() int {
 	if r != nil && r.total != nil {
 		return *r.total
 	}
@@ -326,7 +326,7 @@ func (r *DashboardsListResponse) Total() int {
 //
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
-func (r *DashboardsListResponse) GetTotal() (value int, ok bool) {
+func (r *CloudProvidersListResponse) GetTotal() (value int, ok bool) {
 	ok = r != nil && r.total != nil
 	if ok {
 		value = *r.total
@@ -336,8 +336,8 @@ func (r *DashboardsListResponse) GetTotal() (value int, ok bool) {
 
 // Items returns the value of the 'items' parameter.
 //
-// Retrieved list of dashboards.
-func (r *DashboardsListResponse) Items() *DashboardList {
+// Retrieved list of cloud providers.
+func (r *CloudProvidersListResponse) Items() *CloudProviderList {
 	if r == nil {
 		return nil
 	}
@@ -347,8 +347,8 @@ func (r *DashboardsListResponse) Items() *DashboardList {
 // GetItems returns the value of the 'items' parameter and
 // a flag indicating if the parameter has a value.
 //
-// Retrieved list of dashboards.
-func (r *DashboardsListResponse) GetItems() (value *DashboardList, ok bool) {
+// Retrieved list of cloud providers.
+func (r *CloudProvidersListResponse) GetItems() (value *CloudProviderList, ok bool) {
 	ok = r != nil && r.items != nil
 	if ok {
 		value = r.items
@@ -358,10 +358,10 @@ func (r *DashboardsListResponse) GetItems() (value *DashboardList, ok bool) {
 
 // unmarshal is the method used internally to unmarshal responses to the
 // 'list' method.
-func (r *DashboardsListResponse) unmarshal(reader io.Reader) error {
+func (r *CloudProvidersListResponse) unmarshal(reader io.Reader) error {
 	var err error
 	decoder := json.NewDecoder(reader)
-	data := new(dashboardsListResponseData)
+	data := new(cloudProvidersListResponseData)
 	err = decoder.Decode(data)
 	if err != nil {
 		return err
@@ -376,11 +376,11 @@ func (r *DashboardsListResponse) unmarshal(reader io.Reader) error {
 	return err
 }
 
-// dashboardsListResponseData is the structure used internally to unmarshal
+// cloudProvidersListResponseData is the structure used internally to unmarshal
 // the response of the 'list' method.
-type dashboardsListResponseData struct {
-	Page  *int              "json:\"page,omitempty\""
-	Size  *int              "json:\"size,omitempty\""
-	Total *int              "json:\"total,omitempty\""
-	Items dashboardListData "json:\"items,omitempty\""
+type cloudProvidersListResponseData struct {
+	Page  *int                  "json:\"page,omitempty\""
+	Size  *int                  "json:\"size,omitempty\""
+	Total *int                  "json:\"total,omitempty\""
+	Items cloudProviderListData "json:\"items,omitempty\""
 }

--- a/clustersmgmt/v1/cloud_providers_server.go
+++ b/clustersmgmt/v1/cloud_providers_server.go
@@ -31,22 +31,22 @@ import (
 	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
-// DashboardsServer represents the interface the manages the 'dashboards' resource.
-type DashboardsServer interface {
+// CloudProvidersServer represents the interface the manages the 'cloud_providers' resource.
+type CloudProvidersServer interface {
 
 	// List handles a request for the 'list' method.
 	//
-	// Retrieves a list of dashboards.
-	List(ctx context.Context, request *DashboardsListServerRequest, response *DashboardsListServerResponse) error
+	// Retrieves the list of cloud providers.
+	List(ctx context.Context, request *CloudProvidersListServerRequest, response *CloudProvidersListServerResponse) error
 
-	// Dashboard returns the target 'dashboard' server for the given identifier.
+	// CloudProvider returns the target 'cloud_provider' server for the given identifier.
 	//
-	// Reference to the resource that manages a specific dashboard.
-	Dashboard(id string) DashboardServer
+	// Returns a reference to the service that manages an specific cloud provider.
+	CloudProvider(id string) CloudProviderServer
 }
 
-// DashboardsListServerRequest is the request for the 'list' method.
-type DashboardsListServerRequest struct {
+// CloudProvidersListServerRequest is the request for the 'list' method.
+type CloudProvidersListServerRequest struct {
 	page   *int
 	size   *int
 	search *string
@@ -59,7 +59,7 @@ type DashboardsListServerRequest struct {
 // Index of the requested page, where one corresponds to the first page.
 //
 // Default value is `1`.
-func (r *DashboardsListServerRequest) Page() int {
+func (r *CloudProvidersListServerRequest) Page() int {
 	if r != nil && r.page != nil {
 		return *r.page
 	}
@@ -72,7 +72,7 @@ func (r *DashboardsListServerRequest) Page() int {
 // Index of the requested page, where one corresponds to the first page.
 //
 // Default value is `1`.
-func (r *DashboardsListServerRequest) GetPage() (value int, ok bool) {
+func (r *CloudProvidersListServerRequest) GetPage() (value int, ok bool) {
 	ok = r != nil && r.page != nil
 	if ok {
 		value = *r.page
@@ -85,7 +85,7 @@ func (r *DashboardsListServerRequest) GetPage() (value int, ok bool) {
 // Maximum number of items that will be contained in the returned page.
 //
 // Default value is `100`.
-func (r *DashboardsListServerRequest) Size() int {
+func (r *CloudProvidersListServerRequest) Size() int {
 	if r != nil && r.size != nil {
 		return *r.size
 	}
@@ -98,7 +98,7 @@ func (r *DashboardsListServerRequest) Size() int {
 // Maximum number of items that will be contained in the returned page.
 //
 // Default value is `100`.
-func (r *DashboardsListServerRequest) GetSize() (value int, ok bool) {
+func (r *CloudProvidersListServerRequest) GetSize() (value int, ok bool) {
 	ok = r != nil && r.size != nil
 	if ok {
 		value = *r.size
@@ -111,18 +111,18 @@ func (r *DashboardsListServerRequest) GetSize() (value int, ok bool) {
 // Search criteria.
 //
 // The syntax of this parameter is similar to the syntax of the _where_ clause of a
-// SQL statement, but using the names of the attributes of the dashboard instead of
-// the names of the columns of a table. For example, in order to retrieve all the
-// dashboards with a name starting with `my` the value should be:
+// SQL statement, but using the names of the attributes of the cloud provider
+// instead of the names of the columns of a table. For example, in order to retrieve
+// all the cloud providers with a name starting with `A` the value should be:
 //
 // [source,sql]
 // ----
-// name like 'my%'
+// name like 'A%'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// dashboards that the user has permission to see will be returned.
-func (r *DashboardsListServerRequest) Search() string {
+// If the parameter isn't provided, or if the value is empty, then all the clusters
+// that the user has permission to see will be returned.
+func (r *CloudProvidersListServerRequest) Search() string {
 	if r != nil && r.search != nil {
 		return *r.search
 	}
@@ -135,18 +135,18 @@ func (r *DashboardsListServerRequest) Search() string {
 // Search criteria.
 //
 // The syntax of this parameter is similar to the syntax of the _where_ clause of a
-// SQL statement, but using the names of the attributes of the dashboard instead of
-// the names of the columns of a table. For example, in order to retrieve all the
-// dashboards with a name starting with `my` the value should be:
+// SQL statement, but using the names of the attributes of the cloud provider
+// instead of the names of the columns of a table. For example, in order to retrieve
+// all the cloud providers with a name starting with `A` the value should be:
 //
 // [source,sql]
 // ----
-// name like 'my%'
+// name like 'A%'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// dashboards that the user has permission to see will be returned.
-func (r *DashboardsListServerRequest) GetSearch() (value string, ok bool) {
+// If the parameter isn't provided, or if the value is empty, then all the clusters
+// that the user has permission to see will be returned.
+func (r *CloudProvidersListServerRequest) GetSearch() (value string, ok bool) {
 	ok = r != nil && r.search != nil
 	if ok {
 		value = *r.search
@@ -159,9 +159,9 @@ func (r *DashboardsListServerRequest) GetSearch() (value string, ok bool) {
 // Order criteria.
 //
 // The syntax of this parameter is similar to the syntax of the _order by_ clause of
-// a SQL statement, but using the names of the attributes of the dashboard instead of
-// the names of the columns of a table. For example, in order to sort the dashboards
-// descending by name the value should be:
+// a SQL statement, but using the names of the attributes of the cloud provider
+// instead of the names of the columns of a table. For example, in order to sort the
+// clusters descending by name identifier the value should be:
 //
 // [source,sql]
 // ----
@@ -170,7 +170,7 @@ func (r *DashboardsListServerRequest) GetSearch() (value string, ok bool) {
 //
 // If the parameter isn't provided, or if the value is empty, then the order of the
 // results is undefined.
-func (r *DashboardsListServerRequest) Order() string {
+func (r *CloudProvidersListServerRequest) Order() string {
 	if r != nil && r.order != nil {
 		return *r.order
 	}
@@ -183,9 +183,9 @@ func (r *DashboardsListServerRequest) Order() string {
 // Order criteria.
 //
 // The syntax of this parameter is similar to the syntax of the _order by_ clause of
-// a SQL statement, but using the names of the attributes of the dashboard instead of
-// the names of the columns of a table. For example, in order to sort the dashboards
-// descending by name the value should be:
+// a SQL statement, but using the names of the attributes of the cloud provider
+// instead of the names of the columns of a table. For example, in order to sort the
+// clusters descending by name identifier the value should be:
 //
 // [source,sql]
 // ----
@@ -194,7 +194,7 @@ func (r *DashboardsListServerRequest) Order() string {
 //
 // If the parameter isn't provided, or if the value is empty, then the order of the
 // results is undefined.
-func (r *DashboardsListServerRequest) GetOrder() (value string, ok bool) {
+func (r *CloudProvidersListServerRequest) GetOrder() (value string, ok bool) {
 	ok = r != nil && r.order != nil
 	if ok {
 		value = *r.order
@@ -206,7 +206,7 @@ func (r *DashboardsListServerRequest) GetOrder() (value string, ok bool) {
 //
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
-func (r *DashboardsListServerRequest) Total() int {
+func (r *CloudProvidersListServerRequest) Total() int {
 	if r != nil && r.total != nil {
 		return *r.total
 	}
@@ -218,7 +218,7 @@ func (r *DashboardsListServerRequest) Total() int {
 //
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
-func (r *DashboardsListServerRequest) GetTotal() (value int, ok bool) {
+func (r *CloudProvidersListServerRequest) GetTotal() (value int, ok bool) {
 	ok = r != nil && r.total != nil
 	if ok {
 		value = *r.total
@@ -226,14 +226,14 @@ func (r *DashboardsListServerRequest) GetTotal() (value int, ok bool) {
 	return
 }
 
-// DashboardsListServerResponse is the response for the 'list' method.
-type DashboardsListServerResponse struct {
+// CloudProvidersListServerResponse is the response for the 'list' method.
+type CloudProvidersListServerResponse struct {
 	status int
 	err    *errors.Error
 	page   *int
 	size   *int
 	total  *int
-	items  *DashboardList
+	items  *CloudProviderList
 }
 
 // Page sets the value of the 'page' parameter.
@@ -241,7 +241,7 @@ type DashboardsListServerResponse struct {
 // Index of the requested page, where one corresponds to the first page.
 //
 // Default value is `1`.
-func (r *DashboardsListServerResponse) Page(value int) *DashboardsListServerResponse {
+func (r *CloudProvidersListServerResponse) Page(value int) *CloudProvidersListServerResponse {
 	r.page = &value
 	return r
 }
@@ -251,7 +251,7 @@ func (r *DashboardsListServerResponse) Page(value int) *DashboardsListServerResp
 // Maximum number of items that will be contained in the returned page.
 //
 // Default value is `100`.
-func (r *DashboardsListServerResponse) Size(value int) *DashboardsListServerResponse {
+func (r *CloudProvidersListServerResponse) Size(value int) *CloudProvidersListServerResponse {
 	r.size = &value
 	return r
 }
@@ -260,31 +260,31 @@ func (r *DashboardsListServerResponse) Size(value int) *DashboardsListServerResp
 //
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
-func (r *DashboardsListServerResponse) Total(value int) *DashboardsListServerResponse {
+func (r *CloudProvidersListServerResponse) Total(value int) *CloudProvidersListServerResponse {
 	r.total = &value
 	return r
 }
 
 // Items sets the value of the 'items' parameter.
 //
-// Retrieved list of dashboards.
-func (r *DashboardsListServerResponse) Items(value *DashboardList) *DashboardsListServerResponse {
+// Retrieved list of cloud providers.
+func (r *CloudProvidersListServerResponse) Items(value *CloudProviderList) *CloudProvidersListServerResponse {
 	r.items = value
 	return r
 }
 
 // SetStatusCode sets the status code for a give response and returns the response object.
-func (r *DashboardsListServerResponse) SetStatusCode(status int) *DashboardsListServerResponse {
+func (r *CloudProvidersListServerResponse) SetStatusCode(status int) *CloudProvidersListServerResponse {
 	r.status = status
 	return r
 }
 
 // marshall is the method used internally to marshal responses for the
 // 'list' method.
-func (r *DashboardsListServerResponse) marshal(writer io.Writer) error {
+func (r *CloudProvidersListServerResponse) marshal(writer io.Writer) error {
 	var err error
 	encoder := json.NewEncoder(writer)
-	data := new(dashboardsListServerResponseData)
+	data := new(cloudProvidersListServerResponseData)
 	data.Page = r.page
 	data.Size = r.size
 	data.Total = r.total
@@ -296,40 +296,40 @@ func (r *DashboardsListServerResponse) marshal(writer io.Writer) error {
 	return err
 }
 
-// dashboardsListServerResponseData is the structure used internally to write the request of the
+// cloudProvidersListServerResponseData is the structure used internally to write the request of the
 // 'list' method.
-type dashboardsListServerResponseData struct {
-	Page  *int              "json:\"page,omitempty\""
-	Size  *int              "json:\"size,omitempty\""
-	Total *int              "json:\"total,omitempty\""
-	Items dashboardListData "json:\"items,omitempty\""
+type cloudProvidersListServerResponseData struct {
+	Page  *int                  "json:\"page,omitempty\""
+	Size  *int                  "json:\"size,omitempty\""
+	Total *int                  "json:\"total,omitempty\""
+	Items cloudProviderListData "json:\"items,omitempty\""
 }
 
-// DashboardsServerAdapter represents the structs that adapts Requests and Response to internal
+// CloudProvidersServerAdapter represents the structs that adapts Requests and Response to internal
 // structs.
-type DashboardsServerAdapter struct {
-	server DashboardsServer
+type CloudProvidersServerAdapter struct {
+	server CloudProvidersServer
 	router *mux.Router
 }
 
-func NewDashboardsServerAdapter(server DashboardsServer, router *mux.Router) *DashboardsServerAdapter {
-	adapter := new(DashboardsServerAdapter)
+func NewCloudProvidersServerAdapter(server CloudProvidersServer, router *mux.Router) *CloudProvidersServerAdapter {
+	adapter := new(CloudProvidersServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.dashboardHandler)
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.cloudProviderHandler)
 	adapter.router.Methods("GET").Path("").HandlerFunc(adapter.listHandler)
 	return adapter
 }
-func (a *DashboardsServerAdapter) dashboardHandler(w http.ResponseWriter, r *http.Request) {
+func (a *CloudProvidersServerAdapter) cloudProviderHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
-	target := a.server.Dashboard(id)
-	targetAdapter := NewDashboardServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
+	target := a.server.CloudProvider(id)
+	targetAdapter := NewCloudProviderServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
-func (a *DashboardsServerAdapter) readDashboardsListServerRequest(r *http.Request) (*DashboardsListServerRequest, error) {
+func (a *CloudProvidersServerAdapter) readCloudProvidersListServerRequest(r *http.Request) (*CloudProvidersListServerRequest, error) {
 	var err error
-	result := new(DashboardsListServerRequest)
+	result := new(CloudProvidersListServerRequest)
 	query := r.URL.Query()
 	result.page, err = helpers.ParseInteger(query, "page")
 	if err != nil {
@@ -353,7 +353,7 @@ func (a *DashboardsServerAdapter) readDashboardsListServerRequest(r *http.Reques
 	}
 	return result, err
 }
-func (a *DashboardsServerAdapter) writeDashboardsListServerResponse(w http.ResponseWriter, r *DashboardsListServerResponse) error {
+func (a *CloudProvidersServerAdapter) writeCloudProvidersListServerResponse(w http.ResponseWriter, r *CloudProvidersListServerResponse) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(r.status)
 	err := r.marshal(w)
@@ -362,8 +362,8 @@ func (a *DashboardsServerAdapter) writeDashboardsListServerResponse(w http.Respo
 	}
 	return nil
 }
-func (a *DashboardsServerAdapter) listHandler(w http.ResponseWriter, r *http.Request) {
-	req, err := a.readDashboardsListServerRequest(r)
+func (a *CloudProvidersServerAdapter) listHandler(w http.ResponseWriter, r *http.Request) {
+	req, err := a.readCloudProvidersListServerRequest(r)
 	if err != nil {
 		reason := fmt.Sprintf("An error occured while trying to read request from client: %v", err)
 		errorBody, _ := errors.NewError().
@@ -373,7 +373,7 @@ func (a *DashboardsServerAdapter) listHandler(w http.ResponseWriter, r *http.Req
 		errors.SendError(w, r, errorBody)
 		return
 	}
-	resp := new(DashboardsListServerResponse)
+	resp := new(CloudProvidersListServerResponse)
 	err = a.server.List(r.Context(), req, resp)
 	if err != nil {
 		reason := fmt.Sprintf("An error occured while trying to run method List: %v", err)
@@ -383,7 +383,7 @@ func (a *DashboardsServerAdapter) listHandler(w http.ResponseWriter, r *http.Req
 			Build()
 		errors.SendError(w, r, errorBody)
 	}
-	err = a.writeDashboardsListServerResponse(w, resp)
+	err = a.writeCloudProvidersListServerResponse(w, resp)
 	if err != nil {
 		reason := fmt.Sprintf("An error occured while trying to write response for client: %v", err)
 		errorBody, _ := errors.NewError().
@@ -393,6 +393,6 @@ func (a *DashboardsServerAdapter) listHandler(w http.ResponseWriter, r *http.Req
 		errors.SendError(w, r, errorBody)
 	}
 }
-func (a *DashboardsServerAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (a *CloudProvidersServerAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.router.ServeHTTP(w, r)
 }

--- a/clustersmgmt/v1/cloud_region_client.go
+++ b/clustersmgmt/v1/cloud_region_client.go
@@ -1,0 +1,192 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// CloudRegionClient is the client of the 'cloud_region' resource.
+//
+// Manages a specific cloud region.
+type CloudRegionClient struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+}
+
+// NewCloudRegionClient creates a new client for the 'cloud_region'
+// resource using the given transport to sned the requests and receive the
+// responses.
+func NewCloudRegionClient(transport http.RoundTripper, path string, metric string) *CloudRegionClient {
+	client := new(CloudRegionClient)
+	client.transport = transport
+	client.path = path
+	client.metric = metric
+	return client
+}
+
+// Get creates a request for the 'get' method.
+//
+// Retrieves the details of the region.
+func (c *CloudRegionClient) Get() *CloudRegionGetRequest {
+	request := new(CloudRegionGetRequest)
+	request.transport = c.transport
+	request.path = c.path
+	request.metric = c.metric
+	return request
+}
+
+// CloudRegionGetRequest is the request for the 'get' method.
+type CloudRegionGetRequest struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+	query     url.Values
+	header    http.Header
+}
+
+// Parameter adds a query parameter.
+func (r *CloudRegionGetRequest) Parameter(name string, value interface{}) *CloudRegionGetRequest {
+	helpers.AddValue(&r.query, name, value)
+	return r
+}
+
+// Header adds a request header.
+func (r *CloudRegionGetRequest) Header(name string, value interface{}) *CloudRegionGetRequest {
+	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Send sends this request, waits for the response, and returns it.
+//
+// This is a potentially lengthy operation, as it requires network communication.
+// Consider using a context and the SendContext method.
+func (r *CloudRegionGetRequest) Send() (result *CloudRegionGetResponse, err error) {
+	return r.SendContext(context.Background())
+}
+
+// SendContext sends this request, waits for the response, and returns it.
+func (r *CloudRegionGetRequest) SendContext(ctx context.Context) (result *CloudRegionGetResponse, err error) {
+	query := helpers.CopyQuery(r.query)
+	header := helpers.SetHeader(r.header, r.metric)
+	uri := &url.URL{
+		Path:     r.path,
+		RawQuery: query.Encode(),
+	}
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL:    uri,
+		Header: header,
+	}
+	if ctx != nil {
+		request = request.WithContext(ctx)
+	}
+	response, err := r.transport.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result = new(CloudRegionGetResponse)
+	result.status = response.StatusCode
+	result.header = response.Header
+	if result.status >= 400 {
+		result.err, err = errors.UnmarshalError(response.Body)
+		if err != nil {
+			return
+		}
+		err = result.err
+		return
+	}
+	err = result.unmarshal(response.Body)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// CloudRegionGetResponse is the response for the 'get' method.
+type CloudRegionGetResponse struct {
+	status int
+	header http.Header
+	err    *errors.Error
+	body   *CloudRegion
+}
+
+// Status returns the response status code.
+func (r *CloudRegionGetResponse) Status() int {
+	return r.status
+}
+
+// Header returns header of the response.
+func (r *CloudRegionGetResponse) Header() http.Header {
+	return r.header
+}
+
+// Error returns the response error.
+func (r *CloudRegionGetResponse) Error() *errors.Error {
+	return r.err
+}
+
+// Body returns the value of the 'body' parameter.
+//
+//
+func (r *CloudRegionGetResponse) Body() *CloudRegion {
+	if r == nil {
+		return nil
+	}
+	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *CloudRegionGetResponse) GetBody() (value *CloudRegion, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
+}
+
+// unmarshal is the method used internally to unmarshal responses to the
+// 'get' method.
+func (r *CloudRegionGetResponse) unmarshal(reader io.Reader) error {
+	var err error
+	decoder := json.NewDecoder(reader)
+	data := new(cloudRegionData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	r.body, err = data.unwrap()
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/clustersmgmt/v1/cloud_region_server.go
+++ b/clustersmgmt/v1/cloud_region_server.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+)
+
+// CloudRegionServer represents the interface the manages the 'cloud_region' resource.
+type CloudRegionServer interface {
+
+	// Get handles a request for the 'get' method.
+	//
+	// Retrieves the details of the region.
+	Get(ctx context.Context, request *CloudRegionGetServerRequest, response *CloudRegionGetServerResponse) error
+}
+
+// CloudRegionGetServerRequest is the request for the 'get' method.
+type CloudRegionGetServerRequest struct {
+}
+
+// CloudRegionGetServerResponse is the response for the 'get' method.
+type CloudRegionGetServerResponse struct {
+	status int
+	err    *errors.Error
+	body   *CloudRegion
+}
+
+// Body sets the value of the 'body' parameter.
+//
+//
+func (r *CloudRegionGetServerResponse) Body(value *CloudRegion) *CloudRegionGetServerResponse {
+	r.body = value
+	return r
+}
+
+// SetStatusCode sets the status code for a give response and returns the response object.
+func (r *CloudRegionGetServerResponse) SetStatusCode(status int) *CloudRegionGetServerResponse {
+	r.status = status
+	return r
+}
+
+// marshall is the method used internally to marshal responses for the
+// 'get' method.
+func (r *CloudRegionGetServerResponse) marshal(writer io.Writer) error {
+	var err error
+	encoder := json.NewEncoder(writer)
+	data, err := r.body.wrap()
+	if err != nil {
+		return err
+	}
+	err = encoder.Encode(data)
+	return err
+}
+
+// CloudRegionServerAdapter represents the structs that adapts Requests and Response to internal
+// structs.
+type CloudRegionServerAdapter struct {
+	server CloudRegionServer
+	router *mux.Router
+}
+
+func NewCloudRegionServerAdapter(server CloudRegionServer, router *mux.Router) *CloudRegionServerAdapter {
+	adapter := new(CloudRegionServerAdapter)
+	adapter.server = server
+	adapter.router = router
+	adapter.router.Methods("GET").Path("").HandlerFunc(adapter.getHandler)
+	return adapter
+}
+func (a *CloudRegionServerAdapter) readCloudRegionGetServerRequest(r *http.Request) (*CloudRegionGetServerRequest, error) {
+	var err error
+	result := new(CloudRegionGetServerRequest)
+	return result, err
+}
+func (a *CloudRegionServerAdapter) writeCloudRegionGetServerResponse(w http.ResponseWriter, r *CloudRegionGetServerResponse) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(r.status)
+	err := r.marshal(w)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (a *CloudRegionServerAdapter) getHandler(w http.ResponseWriter, r *http.Request) {
+	req, err := a.readCloudRegionGetServerRequest(r)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to read request from client: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+		return
+	}
+	resp := new(CloudRegionGetServerResponse)
+	err = a.server.Get(r.Context(), req, resp)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to run method Get: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+	}
+	err = a.writeCloudRegionGetServerResponse(w, resp)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to write response for client: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+	}
+}
+func (a *CloudRegionServerAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.router.ServeHTTP(w, r)
+}

--- a/clustersmgmt/v1/cloud_regions_client.go
+++ b/clustersmgmt/v1/cloud_regions_client.go
@@ -1,0 +1,299 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// CloudRegionsClient is the client of the 'cloud_regions' resource.
+//
+// Manages the collection of regions of a cloud provider.
+type CloudRegionsClient struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+}
+
+// NewCloudRegionsClient creates a new client for the 'cloud_regions'
+// resource using the given transport to sned the requests and receive the
+// responses.
+func NewCloudRegionsClient(transport http.RoundTripper, path string, metric string) *CloudRegionsClient {
+	client := new(CloudRegionsClient)
+	client.transport = transport
+	client.path = path
+	client.metric = metric
+	return client
+}
+
+// List creates a request for the 'list' method.
+//
+// Retrieves the list of regions of the cloud provider.
+//
+// IMPORTANT: This collection doesn't currently support paging or searching, so the returned
+// `page` will always be 1 and `size` and `total` will always be the total number of regions
+// of the provider.
+func (c *CloudRegionsClient) List() *CloudRegionsListRequest {
+	request := new(CloudRegionsListRequest)
+	request.transport = c.transport
+	request.path = c.path
+	request.metric = c.metric
+	return request
+}
+
+// Region returns the target 'cloud_region' resource for the given identifier.
+//
+// Reference to the service that manages an specific region.
+func (c *CloudRegionsClient) Region(id string) *CloudRegionClient {
+	return NewCloudRegionClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
+}
+
+// CloudRegionsListRequest is the request for the 'list' method.
+type CloudRegionsListRequest struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+	query     url.Values
+	header    http.Header
+}
+
+// Parameter adds a query parameter.
+func (r *CloudRegionsListRequest) Parameter(name string, value interface{}) *CloudRegionsListRequest {
+	helpers.AddValue(&r.query, name, value)
+	return r
+}
+
+// Header adds a request header.
+func (r *CloudRegionsListRequest) Header(name string, value interface{}) *CloudRegionsListRequest {
+	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Send sends this request, waits for the response, and returns it.
+//
+// This is a potentially lengthy operation, as it requires network communication.
+// Consider using a context and the SendContext method.
+func (r *CloudRegionsListRequest) Send() (result *CloudRegionsListResponse, err error) {
+	return r.SendContext(context.Background())
+}
+
+// SendContext sends this request, waits for the response, and returns it.
+func (r *CloudRegionsListRequest) SendContext(ctx context.Context) (result *CloudRegionsListResponse, err error) {
+	query := helpers.CopyQuery(r.query)
+	header := helpers.SetHeader(r.header, r.metric)
+	uri := &url.URL{
+		Path:     r.path,
+		RawQuery: query.Encode(),
+	}
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL:    uri,
+		Header: header,
+	}
+	if ctx != nil {
+		request = request.WithContext(ctx)
+	}
+	response, err := r.transport.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result = new(CloudRegionsListResponse)
+	result.status = response.StatusCode
+	result.header = response.Header
+	if result.status >= 400 {
+		result.err, err = errors.UnmarshalError(response.Body)
+		if err != nil {
+			return
+		}
+		err = result.err
+		return
+	}
+	err = result.unmarshal(response.Body)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// CloudRegionsListResponse is the response for the 'list' method.
+type CloudRegionsListResponse struct {
+	status int
+	header http.Header
+	err    *errors.Error
+	page   *int
+	size   *int
+	total  *int
+	items  *CloudRegionList
+}
+
+// Status returns the response status code.
+func (r *CloudRegionsListResponse) Status() int {
+	return r.status
+}
+
+// Header returns header of the response.
+func (r *CloudRegionsListResponse) Header() http.Header {
+	return r.header
+}
+
+// Error returns the response error.
+func (r *CloudRegionsListResponse) Error() *errors.Error {
+	return r.err
+}
+
+// Page returns the value of the 'page' parameter.
+//
+// Index of the returned page, where one corresponds to the first page. As this
+// collection doesn't support paging the result will always be `1`.
+func (r *CloudRegionsListResponse) Page() int {
+	if r != nil && r.page != nil {
+		return *r.page
+	}
+	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the returned page, where one corresponds to the first page. As this
+// collection doesn't support paging the result will always be `1`.
+func (r *CloudRegionsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
+}
+
+// Size returns the value of the 'size' parameter.
+//
+// Number of items that will be contained in the returned page. As this collection
+// doesn't support paging or searching the result will always be the total number of
+// regions of the provider.
+func (r *CloudRegionsListResponse) Size() int {
+	if r != nil && r.size != nil {
+		return *r.size
+	}
+	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Number of items that will be contained in the returned page. As this collection
+// doesn't support paging or searching the result will always be the total number of
+// regions of the provider.
+func (r *CloudRegionsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
+}
+
+// Total returns the value of the 'total' parameter.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page. As this collection doesn't support paging or
+// searching the result will always be the total number of regions of the provider.
+func (r *CloudRegionsListResponse) Total() int {
+	if r != nil && r.total != nil {
+		return *r.total
+	}
+	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page. As this collection doesn't support paging or
+// searching the result will always be the total number of regions of the provider.
+func (r *CloudRegionsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
+}
+
+// Items returns the value of the 'items' parameter.
+//
+// Retrieved list of cloud providers.
+func (r *CloudRegionsListResponse) Items() *CloudRegionList {
+	if r == nil {
+		return nil
+	}
+	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of cloud providers.
+func (r *CloudRegionsListResponse) GetItems() (value *CloudRegionList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
+}
+
+// unmarshal is the method used internally to unmarshal responses to the
+// 'list' method.
+func (r *CloudRegionsListResponse) unmarshal(reader io.Reader) error {
+	var err error
+	decoder := json.NewDecoder(reader)
+	data := new(cloudRegionsListResponseData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	r.page = data.Page
+	r.size = data.Size
+	r.total = data.Total
+	r.items, err = data.Items.unwrap()
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+// cloudRegionsListResponseData is the structure used internally to unmarshal
+// the response of the 'list' method.
+type cloudRegionsListResponseData struct {
+	Page  *int                "json:\"page,omitempty\""
+	Size  *int                "json:\"size,omitempty\""
+	Total *int                "json:\"total,omitempty\""
+	Items cloudRegionListData "json:\"items,omitempty\""
+}

--- a/clustersmgmt/v1/cloud_regions_server.go
+++ b/clustersmgmt/v1/cloud_regions_server.go
@@ -1,0 +1,203 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+)
+
+// CloudRegionsServer represents the interface the manages the 'cloud_regions' resource.
+type CloudRegionsServer interface {
+
+	// List handles a request for the 'list' method.
+	//
+	// Retrieves the list of regions of the cloud provider.
+	//
+	// IMPORTANT: This collection doesn't currently support paging or searching, so the returned
+	// `page` will always be 1 and `size` and `total` will always be the total number of regions
+	// of the provider.
+	List(ctx context.Context, request *CloudRegionsListServerRequest, response *CloudRegionsListServerResponse) error
+
+	// Region returns the target 'cloud_region' server for the given identifier.
+	//
+	// Reference to the service that manages an specific region.
+	Region(id string) CloudRegionServer
+}
+
+// CloudRegionsListServerRequest is the request for the 'list' method.
+type CloudRegionsListServerRequest struct {
+}
+
+// CloudRegionsListServerResponse is the response for the 'list' method.
+type CloudRegionsListServerResponse struct {
+	status int
+	err    *errors.Error
+	page   *int
+	size   *int
+	total  *int
+	items  *CloudRegionList
+}
+
+// Page sets the value of the 'page' parameter.
+//
+// Index of the returned page, where one corresponds to the first page. As this
+// collection doesn't support paging the result will always be `1`.
+func (r *CloudRegionsListServerResponse) Page(value int) *CloudRegionsListServerResponse {
+	r.page = &value
+	return r
+}
+
+// Size sets the value of the 'size' parameter.
+//
+// Number of items that will be contained in the returned page. As this collection
+// doesn't support paging or searching the result will always be the total number of
+// regions of the provider.
+func (r *CloudRegionsListServerResponse) Size(value int) *CloudRegionsListServerResponse {
+	r.size = &value
+	return r
+}
+
+// Total sets the value of the 'total' parameter.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page. As this collection doesn't support paging or
+// searching the result will always be the total number of regions of the provider.
+func (r *CloudRegionsListServerResponse) Total(value int) *CloudRegionsListServerResponse {
+	r.total = &value
+	return r
+}
+
+// Items sets the value of the 'items' parameter.
+//
+// Retrieved list of cloud providers.
+func (r *CloudRegionsListServerResponse) Items(value *CloudRegionList) *CloudRegionsListServerResponse {
+	r.items = value
+	return r
+}
+
+// SetStatusCode sets the status code for a give response and returns the response object.
+func (r *CloudRegionsListServerResponse) SetStatusCode(status int) *CloudRegionsListServerResponse {
+	r.status = status
+	return r
+}
+
+// marshall is the method used internally to marshal responses for the
+// 'list' method.
+func (r *CloudRegionsListServerResponse) marshal(writer io.Writer) error {
+	var err error
+	encoder := json.NewEncoder(writer)
+	data := new(cloudRegionsListServerResponseData)
+	data.Page = r.page
+	data.Size = r.size
+	data.Total = r.total
+	data.Items, err = r.items.wrap()
+	if err != nil {
+		return err
+	}
+	err = encoder.Encode(data)
+	return err
+}
+
+// cloudRegionsListServerResponseData is the structure used internally to write the request of the
+// 'list' method.
+type cloudRegionsListServerResponseData struct {
+	Page  *int                "json:\"page,omitempty\""
+	Size  *int                "json:\"size,omitempty\""
+	Total *int                "json:\"total,omitempty\""
+	Items cloudRegionListData "json:\"items,omitempty\""
+}
+
+// CloudRegionsServerAdapter represents the structs that adapts Requests and Response to internal
+// structs.
+type CloudRegionsServerAdapter struct {
+	server CloudRegionsServer
+	router *mux.Router
+}
+
+func NewCloudRegionsServerAdapter(server CloudRegionsServer, router *mux.Router) *CloudRegionsServerAdapter {
+	adapter := new(CloudRegionsServerAdapter)
+	adapter.server = server
+	adapter.router = router
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.regionHandler)
+	adapter.router.Methods("GET").Path("").HandlerFunc(adapter.listHandler)
+	return adapter
+}
+func (a *CloudRegionsServerAdapter) regionHandler(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	target := a.server.Region(id)
+	targetAdapter := NewCloudRegionServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
+	targetAdapter.ServeHTTP(w, r)
+	return
+}
+func (a *CloudRegionsServerAdapter) readCloudRegionsListServerRequest(r *http.Request) (*CloudRegionsListServerRequest, error) {
+	var err error
+	result := new(CloudRegionsListServerRequest)
+	return result, err
+}
+func (a *CloudRegionsServerAdapter) writeCloudRegionsListServerResponse(w http.ResponseWriter, r *CloudRegionsListServerResponse) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(r.status)
+	err := r.marshal(w)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (a *CloudRegionsServerAdapter) listHandler(w http.ResponseWriter, r *http.Request) {
+	req, err := a.readCloudRegionsListServerRequest(r)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to read request from client: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+		return
+	}
+	resp := new(CloudRegionsListServerResponse)
+	err = a.server.List(r.Context(), req, resp)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to run method List: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+	}
+	err = a.writeCloudRegionsListServerResponse(w, resp)
+	if err != nil {
+		reason := fmt.Sprintf("An error occured while trying to write response for client: %v", err)
+		errorBody, _ := errors.NewError().
+			Reason(reason).
+			ID("500").
+			Build()
+		errors.SendError(w, r, errorBody)
+	}
+}
+func (a *CloudRegionsServerAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.router.ServeHTTP(w, r)
+}

--- a/clustersmgmt/v1/clusters_client.go
+++ b/clustersmgmt/v1/clusters_client.go
@@ -98,6 +98,7 @@ type ClustersListRequest struct {
 	page      *int
 	size      *int
 	search    *string
+	order     *string
 	total     *int
 }
 
@@ -137,11 +138,11 @@ func (r *ClustersListRequest) Size(value int) *ClustersListRequest {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause
-// of an SQL statement, but using the names of the attributes of the cluster
-// instead of the names of the columns of a table. For example, in order to
-// retrieve all the clusters with a name starting with `my` in the
-// `us-east-1` region the value should be:
+// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+// SQL statement, but using the names of the attributes of the cluster instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// clusters with a name starting with `my` in the `us-east-1` region the value
+// should be:
 //
 // [source,sql]
 // ----
@@ -152,6 +153,27 @@ func (r *ClustersListRequest) Size(value int) *ClustersListRequest {
 // clusters that the user has permission to see will be returned.
 func (r *ClustersListRequest) Search(value string) *ClustersListRequest {
 	r.search = &value
+	return r
+}
+
+// Order sets the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the cluster instead of
+// the names of the columns of a table. For example, in order to sort the clusters
+// descending by region identifier the value should be:
+//
+// [source,sql]
+// ----
+// region.id desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *ClustersListRequest) Order(value string) *ClustersListRequest {
+	r.order = &value
 	return r
 }
 
@@ -183,6 +205,9 @@ func (r *ClustersListRequest) SendContext(ctx context.Context) (result *Clusters
 	}
 	if r.search != nil {
 		helpers.AddValue(&query, "search", *r.search)
+	}
+	if r.order != nil {
+		helpers.AddValue(&query, "order", *r.order)
 	}
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)

--- a/clustersmgmt/v1/clusters_server.go
+++ b/clustersmgmt/v1/clusters_server.go
@@ -57,6 +57,7 @@ type ClustersListServerRequest struct {
 	page   *int
 	size   *int
 	search *string
+	order  *string
 	total  *int
 }
 
@@ -116,11 +117,11 @@ func (r *ClustersListServerRequest) GetSize() (value int, ok bool) {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause
-// of an SQL statement, but using the names of the attributes of the cluster
-// instead of the names of the columns of a table. For example, in order to
-// retrieve all the clusters with a name starting with `my` in the
-// `us-east-1` region the value should be:
+// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+// SQL statement, but using the names of the attributes of the cluster instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// clusters with a name starting with `my` in the `us-east-1` region the value
+// should be:
 //
 // [source,sql]
 // ----
@@ -141,11 +142,11 @@ func (r *ClustersListServerRequest) Search() string {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause
-// of an SQL statement, but using the names of the attributes of the cluster
-// instead of the names of the columns of a table. For example, in order to
-// retrieve all the clusters with a name starting with `my` in the
-// `us-east-1` region the value should be:
+// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+// SQL statement, but using the names of the attributes of the cluster instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// clusters with a name starting with `my` in the `us-east-1` region the value
+// should be:
 //
 // [source,sql]
 // ----
@@ -158,6 +159,54 @@ func (r *ClustersListServerRequest) GetSearch() (value string, ok bool) {
 	ok = r != nil && r.search != nil
 	if ok {
 		value = *r.search
+	}
+	return
+}
+
+// Order returns the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the cluster instead of
+// the names of the columns of a table. For example, in order to sort the clusters
+// descending by region identifier the value should be:
+//
+// [source,sql]
+// ----
+// region.id desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *ClustersListServerRequest) Order() string {
+	if r != nil && r.order != nil {
+		return *r.order
+	}
+	return ""
+}
+
+// GetOrder returns the value of the 'order' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the cluster instead of
+// the names of the columns of a table. For example, in order to sort the clusters
+// descending by region identifier the value should be:
+//
+// [source,sql]
+// ----
+// region.id desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *ClustersListServerRequest) GetOrder() (value string, ok bool) {
+	ok = r != nil && r.order != nil
+	if ok {
+		value = *r.order
 	}
 	return
 }
@@ -379,6 +428,10 @@ func (a *ClustersServerAdapter) readClustersListServerRequest(r *http.Request) (
 		return nil, err
 	}
 	result.search, err = helpers.ParseString(query, "search")
+	if err != nil {
+		return nil, err
+	}
+	result.order, err = helpers.ParseString(query, "order")
 	if err != nil {
 		return nil, err
 	}

--- a/clustersmgmt/v1/flavours_client.go
+++ b/clustersmgmt/v1/flavours_client.go
@@ -96,6 +96,7 @@ type FlavoursListRequest struct {
 	page      *int
 	size      *int
 	search    *string
+	order     *string
 	total     *int
 }
 
@@ -135,20 +136,41 @@ func (r *FlavoursListRequest) Size(value int) *FlavoursListRequest {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause
-// of an SQL statement, but using the names of the attributes of the cluster
-// instead of the names of the columns of a table. For example, in order to
-// retrieve all the flavours with a name starting with `my`the value should be:
+// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// SQL statement, but using the names of the attributes of the flavour instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// flavours with a name starting with `my`the value should be:
 //
 // [source,sql]
 // ----
 // name like 'my%'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// flavours that the user has permission to see will be returned.
+// If the parameter isn't provided, or if the value is empty, then all the flavours
+// that the user has permission to see will be returned.
 func (r *FlavoursListRequest) Search(value string) *FlavoursListRequest {
 	r.search = &value
+	return r
+}
+
+// Order sets the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the flavour instead of
+// the names of the columns of a table. For example, in order to sort the flavours
+// descending by name the value should be:
+//
+// [source,sql]
+// ----
+// name desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *FlavoursListRequest) Order(value string) *FlavoursListRequest {
+	r.order = &value
 	return r
 }
 
@@ -180,6 +202,9 @@ func (r *FlavoursListRequest) SendContext(ctx context.Context) (result *Flavours
 	}
 	if r.search != nil {
 		helpers.AddValue(&query, "search", *r.search)
+	}
+	if r.order != nil {
+		helpers.AddValue(&query, "order", *r.order)
 	}
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)

--- a/clustersmgmt/v1/flavours_server.go
+++ b/clustersmgmt/v1/flavours_server.go
@@ -55,6 +55,7 @@ type FlavoursListServerRequest struct {
 	page   *int
 	size   *int
 	search *string
+	order  *string
 	total  *int
 }
 
@@ -114,18 +115,18 @@ func (r *FlavoursListServerRequest) GetSize() (value int, ok bool) {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause
-// of an SQL statement, but using the names of the attributes of the cluster
-// instead of the names of the columns of a table. For example, in order to
-// retrieve all the flavours with a name starting with `my`the value should be:
+// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// SQL statement, but using the names of the attributes of the flavour instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// flavours with a name starting with `my`the value should be:
 //
 // [source,sql]
 // ----
 // name like 'my%'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// flavours that the user has permission to see will be returned.
+// If the parameter isn't provided, or if the value is empty, then all the flavours
+// that the user has permission to see will be returned.
 func (r *FlavoursListServerRequest) Search() string {
 	if r != nil && r.search != nil {
 		return *r.search
@@ -138,22 +139,70 @@ func (r *FlavoursListServerRequest) Search() string {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause
-// of an SQL statement, but using the names of the attributes of the cluster
-// instead of the names of the columns of a table. For example, in order to
-// retrieve all the flavours with a name starting with `my`the value should be:
+// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// SQL statement, but using the names of the attributes of the flavour instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// flavours with a name starting with `my`the value should be:
 //
 // [source,sql]
 // ----
 // name like 'my%'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// flavours that the user has permission to see will be returned.
+// If the parameter isn't provided, or if the value is empty, then all the flavours
+// that the user has permission to see will be returned.
 func (r *FlavoursListServerRequest) GetSearch() (value string, ok bool) {
 	ok = r != nil && r.search != nil
 	if ok {
 		value = *r.search
+	}
+	return
+}
+
+// Order returns the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the flavour instead of
+// the names of the columns of a table. For example, in order to sort the flavours
+// descending by name the value should be:
+//
+// [source,sql]
+// ----
+// name desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *FlavoursListServerRequest) Order() string {
+	if r != nil && r.order != nil {
+		return *r.order
+	}
+	return ""
+}
+
+// GetOrder returns the value of the 'order' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the flavour instead of
+// the names of the columns of a table. For example, in order to sort the flavours
+// descending by name the value should be:
+//
+// [source,sql]
+// ----
+// name desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *FlavoursListServerRequest) GetOrder() (value string, ok bool) {
+	ok = r != nil && r.order != nil
+	if ok {
+		value = *r.order
 	}
 	return
 }
@@ -375,6 +424,10 @@ func (a *FlavoursServerAdapter) readFlavoursListServerRequest(r *http.Request) (
 		return nil, err
 	}
 	result.search, err = helpers.ParseString(query, "search")
+	if err != nil {
+		return nil, err
+	}
+	result.order, err = helpers.ParseString(query, "order")
 	if err != nil {
 		return nil, err
 	}

--- a/clustersmgmt/v1/root_client.go
+++ b/clustersmgmt/v1/root_client.go
@@ -44,6 +44,17 @@ func NewRootClient(transport http.RoundTripper, path string, metric string) *Roo
 	return client
 }
 
+// CloudProviders returns the target 'cloud_providers' resource.
+//
+// Reference to the resource that manages the collection of cloud providers.
+func (c *RootClient) CloudProviders() *CloudProvidersClient {
+	return NewCloudProvidersClient(
+		c.transport,
+		path.Join(c.path, "cloud_providers"),
+		path.Join(c.metric, "cloud_providers"),
+	)
+}
+
 // Clusters returns the target 'clusters' resource.
 //
 // Reference to the resource that manages the collection of clusters.

--- a/clustersmgmt/v1/root_server.go
+++ b/clustersmgmt/v1/root_server.go
@@ -28,6 +28,11 @@ import (
 // RootServer represents the interface the manages the 'root' resource.
 type RootServer interface {
 
+	// CloudProviders returns the target 'cloud_providers' resource.
+	//
+	// Reference to the resource that manages the collection of cloud providers.
+	CloudProviders() CloudProvidersServer
+
 	// Clusters returns the target 'clusters' resource.
 	//
 	// Reference to the resource that manages the collection of clusters.
@@ -60,11 +65,18 @@ func NewRootServerAdapter(server RootServer, router *mux.Router) *RootServerAdap
 	adapter := new(RootServerAdapter)
 	adapter.server = server
 	adapter.router = router
+	adapter.router.PathPrefix("/cloud_providers").HandlerFunc(adapter.cloudProvidersHandler)
 	adapter.router.PathPrefix("/clusters").HandlerFunc(adapter.clustersHandler)
 	adapter.router.PathPrefix("/dashboards").HandlerFunc(adapter.dashboardsHandler)
 	adapter.router.PathPrefix("/flavours").HandlerFunc(adapter.flavoursHandler)
 	adapter.router.PathPrefix("/versions").HandlerFunc(adapter.versionsHandler)
 	return adapter
+}
+func (a *RootServerAdapter) cloudProvidersHandler(w http.ResponseWriter, r *http.Request) {
+	target := a.server.CloudProviders()
+	targetAdapter := NewCloudProvidersServerAdapter(target, a.router.PathPrefix("/cloud_providers").Subrouter())
+	targetAdapter.ServeHTTP(w, r)
+	return
 }
 func (a *RootServerAdapter) clustersHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Clusters()

--- a/clustersmgmt/v1/versions_client.go
+++ b/clustersmgmt/v1/versions_client.go
@@ -83,6 +83,7 @@ type VersionsListRequest struct {
 	page      *int
 	size      *int
 	search    *string
+	order     *string
 	total     *int
 }
 
@@ -122,7 +123,7 @@ func (r *VersionsListRequest) Size(value int) *VersionsListRequest {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// The syntax of this parameter is similar to the syntax of the _where_ clause of a
 // SQL statement, but using the names of the attributes of the version instead of
 // the names of the columns of a table. For example, in order to retrieve all the
 // versions that are enabled:
@@ -132,10 +133,31 @@ func (r *VersionsListRequest) Size(value int) *VersionsListRequest {
 // enabled = 't'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// versoins that the user has permission to see will be returned.
+// If the parameter isn't provided, or if the value is empty, then all the versions
+// that the user has permission to see will be returned.
 func (r *VersionsListRequest) Search(value string) *VersionsListRequest {
 	r.search = &value
+	return r
+}
+
+// Order sets the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the version instead of
+// the names of the columns of a table. For example, in order to sort the versions
+// descending by identifier the value should be:
+//
+// [source,sql]
+// ----
+// id desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *VersionsListRequest) Order(value string) *VersionsListRequest {
+	r.order = &value
 	return r
 }
 
@@ -167,6 +189,9 @@ func (r *VersionsListRequest) SendContext(ctx context.Context) (result *Versions
 	}
 	if r.search != nil {
 		helpers.AddValue(&query, "search", *r.search)
+	}
+	if r.order != nil {
+		helpers.AddValue(&query, "order", *r.order)
 	}
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)

--- a/clustersmgmt/v1/versions_server.go
+++ b/clustersmgmt/v1/versions_server.go
@@ -50,6 +50,7 @@ type VersionsListServerRequest struct {
 	page   *int
 	size   *int
 	search *string
+	order  *string
 	total  *int
 }
 
@@ -109,7 +110,7 @@ func (r *VersionsListServerRequest) GetSize() (value int, ok bool) {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// The syntax of this parameter is similar to the syntax of the _where_ clause of a
 // SQL statement, but using the names of the attributes of the version instead of
 // the names of the columns of a table. For example, in order to retrieve all the
 // versions that are enabled:
@@ -119,8 +120,8 @@ func (r *VersionsListServerRequest) GetSize() (value int, ok bool) {
 // enabled = 't'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// versoins that the user has permission to see will be returned.
+// If the parameter isn't provided, or if the value is empty, then all the versions
+// that the user has permission to see will be returned.
 func (r *VersionsListServerRequest) Search() string {
 	if r != nil && r.search != nil {
 		return *r.search
@@ -133,7 +134,7 @@ func (r *VersionsListServerRequest) Search() string {
 //
 // Search criteria.
 //
-// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// The syntax of this parameter is similar to the syntax of the _where_ clause of a
 // SQL statement, but using the names of the attributes of the version instead of
 // the names of the columns of a table. For example, in order to retrieve all the
 // versions that are enabled:
@@ -143,12 +144,60 @@ func (r *VersionsListServerRequest) Search() string {
 // enabled = 't'
 // ----
 //
-// If the parameter isn't provided, or if the value is empty, then all the
-// versoins that the user has permission to see will be returned.
+// If the parameter isn't provided, or if the value is empty, then all the versions
+// that the user has permission to see will be returned.
 func (r *VersionsListServerRequest) GetSearch() (value string, ok bool) {
 	ok = r != nil && r.search != nil
 	if ok {
 		value = *r.search
+	}
+	return
+}
+
+// Order returns the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the version instead of
+// the names of the columns of a table. For example, in order to sort the versions
+// descending by identifier the value should be:
+//
+// [source,sql]
+// ----
+// id desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *VersionsListServerRequest) Order() string {
+	if r != nil && r.order != nil {
+		return *r.order
+	}
+	return ""
+}
+
+// GetOrder returns the value of the 'order' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the version instead of
+// the names of the columns of a table. For example, in order to sort the versions
+// descending by identifier the value should be:
+//
+// [source,sql]
+// ----
+// id desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *VersionsListServerRequest) GetOrder() (value string, ok bool) {
+	ok = r != nil && r.order != nil
+	if ok {
+		value = *r.order
 	}
 	return
 }
@@ -291,6 +340,10 @@ func (a *VersionsServerAdapter) readVersionsListServerRequest(r *http.Request) (
 		return nil, err
 	}
 	result.search, err = helpers.ParseString(query, "search")
+	if err != nil {
+		return nil, err
+	}
+	result.order, err = helpers.ParseString(query, "order")
 	if err != nil {
 		return nil, err
 	}

--- a/examples/list_cloud_providers.go
+++ b/examples/list_cloud_providers.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This example shows how to list the cloud providers and their regions.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func main() {
+	// Create a context:
+	ctx := context.Background()
+
+	// Create a logger that has the debug level enabled:
+	logger, err := sdk.NewGoLoggerBuilder().
+		Debug(true).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection, and remember to close it:
+	token := os.Getenv("OCM_TOKEN")
+	connection, err := sdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(token).
+		BuildContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	providersCollection := connection.ClustersMgmt().V1().CloudProviders()
+
+	// Retrieve the first page of cloud providers and print them:
+	providersResponse, err := providersCollection.List().SendContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve providers: %v\n", err)
+		os.Exit(1)
+	}
+	providersResponse.Items().Each(func(provider *cmv1.CloudProvider) bool {
+		providerID := provider.ID()
+		regionsCollection := providersCollection.CloudProvider(providerID).Regions()
+		regionsResponse, err := regionsCollection.List().SendContext(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Can't retrieve regions: %v\n", err)
+			os.Exit(1)
+		}
+		regionsResponse.Items().Each(func(region *cmv1.CloudRegion) bool {
+			regionID := region.ID()
+			fmt.Printf("%s - %s\n", providerID, regionID)
+			return true
+		})
+		return true
+	})
+}

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.33"
+const Version = "0.1.34"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Use access token that is about to expire if there is no other mechanism to
  obtain a new one.

- Update to model 0.0.3:
    - Add `order` parameter to the collections that suport it.
    - Add cloud providers collection.
