### PR TITLE
Release 0.1.38

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.38 Sep 17 2019
+
+- Update to model 0.0.8:
+** Update methods don't return body.
+
 == 0.1.37 Sep 16 2019
 
 - Update to model 0.0.7:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.37"
+const Version = "0.1.38"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.8:
    - Update methods don't return body.