### PR TITLE
Release 0.1.40

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,9 +3,14 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.40 Oct 7 2019
+
+- Update to model 0.0.10:
+** Add `cpu_total_by_node_roles_os` metric query.
+
 == 0.1.39 Oct 7 2019
 
-- Update to model: 0.0.8
+- Update to model 0.0.9:
 ** Add `type` attribute to the `ResourceQuota` type.
 ** Add `config_managed` attribute to the `RoleBinding` type.
 

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.39"
+const Version = "0.1.40"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.10:
** Add `cpu_total_by_node_roles_os` metric query.