### PR TITLE
Use `GOPROXY`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+# Enable Go modules:
+export GO111MODULE=on
+export GOPROXY=https://proxy.golang.org
+
 # Details of the model to use:
 model_version:=v0.0.11
 model_url:=https://github.com/openshift-online/ocm-api-model.git


### PR DESCRIPTION
This patch changes the build process so that it uses the Go proxy that
was introduced with Go 1.13.