### PR TITLE
Move `golangci-lint` configuration to a separate file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#  skip-dirs: (metamodel|accountsmgmt|authorizations|clustersmgmt|errors|helpers)
+run:
+  skip-dirs:
+  - accountsmgmt
+  - authorizations
+  - clustersmgmt
+  - errors
+  - helpers
+  - metamodel
+  deadline: 15m
+  issues-exit-code: 1
+linters:
+  disable-all: true
+  enable:
+  - deadcode
+  - gas
+  - goconst
+  - gofmt
+  - golint
+  - ineffassign
+  - interfacer
+  - lll
+  - megacheck
+  - misspell
+  - structcheck
+  - unconvert
+  - varcheck

--- a/Makefile
+++ b/Makefile
@@ -43,30 +43,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	golangci-lint run \
-		--no-config \
-		--issues-exit-code=1 \
-		--deadline=15m \
-		--skip-dirs=accountsmgmt \
-		--skip-dirs=authorizations \
-		--skip-dirs=clustersmgmt \
-		--skip-dirs=errors \
-		--skip-dirs=helpers \
-		--disable-all \
-		--enable=deadcode \
-		--enable=gas \
-		--enable=goconst \
-		--enable=gofmt \
-		--enable=golint \
-		--enable=ineffassign \
-		--enable=interfacer \
-		--enable=lll \
-		--enable=megacheck \
-		--enable=misspell \
-		--enable=structcheck \
-		--enable=unconvert \
-		--enable=varcheck \
-		$(NULL)
+	golangci-lint run
 
 .PHONY: generate
 generate: model metamodel


### PR DESCRIPTION
This patch moves the configuration of the `golangci-lint` tool to a
separate file.