### PR TITLE
Remove `authorizations` directory when generating code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ lint:
 generate: model metamodel
 	rm -rf \
 		accountsmgmt \
+		authorizations \
 		clustersmgmt \
 		errors \
 		helpers


### PR DESCRIPTION
The `auhtorizations` service was recently added to the model, but we
forgot to update the _Makefile_ to remove it when running the `generate`
target. This patch fixes that.