### PR TITLE
Add a CONTRIBUTING document detailing release process

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,118 @@
+= Contributing to the OCM SDK
+
+== Updating the OCM API Model
+
+If new api types or endpoints need to be added, the
+link:https://github.com/openshift-online/ocm-api-model[ocm-api-model] will need to be updated.
+
+Fork and clone the link:https://github.com/openshift-online/ocm-api-model[ocm-api-model] repository to
+get started.
+
+Models are organized within ocm-api-model/models by api and version. For example, clusters-mgmt api types
+can be found in ocm-api-model/model/clusters_mgmt/v1.
+
+Add any new models or update existing models by hand. Note that all files should have the `.model` extension.
+These files are not golang files but are a very similar syntax. Use the existing types as references when adding
+new or updating existing types.
+
+Submit an MR with any changes after validation. The MR should be reviewed before merge.
+
+=== Validating model updates
+
+The easiest way to validate changes to the ocm-api-model is to generate the sdk based on the updated model.
+Ensure ocm-sdk-go is cloned locally alongside your cloned ocm-api-model directory where changes are made.
+
+In ocm-sdk-go, run the following to generate the sdk using the local ocm-api-model. Replace
+`/path/to/ocm-api-model` with the path to your cloned ocm-api-model repository where changes have been made.
+Replace `HEAD` with the commit SHA in ocm-api-model to build against if necessary.
+
+[source,bash]
+----
+make clean
+make model_version=HEAD model_url=/path/to/ocm-api-model generate
+----
+
+Review the output for errors. If none, the changes are at least syntactically proper.
+
+=== Style notes
+
+Comments can be added to types with the `//` notation. Comments should be added to each type's attribute where
+possible.
+
+Hard tabs are required rather than spaces.
+
+== Releasing a new OCM API Model version
+
+To use any updates to the link:https://github.com/openshift-online/ocm-api-model[ocm-api-model], the version
+must be incremented for consumption in ocm-sdk-go generation. The version is defined by the latest git tag.
+The version is also defined in the ocm-api-model/CHANGES.adoc file.
+
+Once all changes to the OCM API Model have been committed to the master branch, submit a separate change with
+an update to ocm-api-model/CHANGES.adoc. This update should indicate the version and describe the changes
+included with the version update. The following is an example update to version 0.0.9:
+
+[source]
+----
+== 0.0.9 Oct 7 2019
+
+- Add `type` attribute to the `ResourceQuota` type.
+- Add `config_managed` attribute to the `RoleBinding` type.
+
+----
+
+Submit an MR with the CHANGES.adoc modification and review/merge.
+
+Finally, create and submit a new tag with the new version following the below example:
+
+[source,bash]
+----
+git checkout master
+git pull
+git tag -a -m 'Release 0.0.9' v0.0.9
+git push origin v0.0.9
+----
+
+Note that a repository administrator may need to push the tag to the repository due to access restrictions.
+
+== Updating the OCM SDK
+
+The OCM SDK can be generated simply by running the following after all changes have been made:
+
+[source,bash]
+----
+make generate
+----
+
+In most cases, the ocm-api-model version will be incremented prior to generation. To increment the ocm-api-model
+version, update the `model_version` constant in link:./Makefile[].
+
+== Releasing a new OCM SDK Version
+
+Releasing a new version requires submitting an MR for review/merge with an update to the `Version` constant in
+link:./version.go[]. Additionally, update the link:./CHANGES.adoc[] file to include the new version and
+describe all changes included.
+
+Below is an example CHANGES.adoc update:
+[source]
+----
+== 0.1.39 Oct 7 2019
+
+- Update to model 0.0.9:
+** Add `type` attribute to the `ResourceQuota` type.
+** Add `config_managed` attribute to the `RoleBinding` type.
+
+----
+
+Submit an MR for review/merge with the CHANGES.adoc and Makefile update.
+
+Finally, create and submit a new tag with the new version following the below example:
+
+[source,bash]
+----
+git checkout master
+git pull
+git tag -a -m 'Release 0.1.39' v0.1.39
+git push origin v0.1.39
+----
+
+Note that a repository administrator may need to push the tag to the repository due to access restrictions.

--- a/README.adoc
+++ b/README.adoc
@@ -125,6 +125,11 @@ accountsmgmt/v1::
 This package contains the types and clients for version 1 of the accounts
 management service.
 
+authorizations/v1::
+
+This package contains the types and clients for version 1 of the
+authorizations service.
+
 clustersmgmt/v1::
 
 This package contains the types and clients for version 1 of the clusters
@@ -172,7 +177,7 @@ closed when no longer needed.
 === Using _types_
 
 The Go types that correspond to the API data types live in the
-`accountsmgmt/v1` and `clustersmgmt/v1` packages. These types are pure data
+`accountsmgmt/v1`, `authorizations/v1`, and `clustersmgmt/v1` packages. These types are pure data
 containers, they don't have any logic or operation.  Instances can be created
 at will.
 


### PR DESCRIPTION
Additionally, this updates the README to mention the authorizations package alongside the accountsmgmt and clustersmgmt packages.

@jhernand PTAL, this should be a good starting point for documentation moving forward. We still need some solid documentation on the expected syntax of the ocm-api-model

I also did not mention ocm-api-metamodel at all, since I have not touched it.