### PR TITLE
Don't require POST body

### DIFF
--- a/methods_test.go
+++ b/methods_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega/ghttp"
 )
 
-var _ = Describe("Get", func() {
+var _ = Describe("Methods", func() {
 	// Servers used during the tests:
 	var oidServer *Server
 	var apiServer *Server
@@ -86,164 +86,201 @@ var _ = Describe("Get", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Sends path", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			VerifyRequest(http.MethodGet, "/mypath"),
-		)
+	Describe("Get", func() {
+		It("Sends path", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				VerifyRequest(http.MethodGet, "/mypath"),
+			)
 
-		// Send the request:
-		_, err := connection.Get().
-			Path("/mypath").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-	})
+			// Send the request:
+			_, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	It("Sends accept header", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			VerifyHeaderKV("Accept", "application/json"),
-		)
+		It("Sends accept header", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				VerifyHeaderKV("Accept", "application/json"),
+			)
 
-		// Send the request:
-		_, err := connection.Get().
-			Path("/mypath").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-	})
+			// Send the request:
+			_, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	It("Sends one query parameter", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			VerifyFormKV("myparameter", "myvalue"),
-		)
-
-		// Send the request:
-		_, err := connection.Get().
-			Path("/mypath").
-			Parameter("myparameter", "myvalue").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("Sends two query parameters", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			CombineHandlers(
+		It("Sends one query parameter", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
 				VerifyFormKV("myparameter", "myvalue"),
-				VerifyFormKV("yourparameter", "yourvalue"),
-			),
-		)
+			)
 
-		// Send the request:
-		_, err := connection.Get().
-			Path("/mypath").
-			Parameter("myparameter", "myvalue").
-			Parameter("yourparameter", "yourvalue").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-	})
+			// Send the request:
+			_, err := connection.Get().
+				Path("/mypath").
+				Parameter("myparameter", "myvalue").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	It("Sends one header", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			VerifyHeaderKV("myheader", "myvalue"),
-		)
+		It("Sends two query parameters", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				CombineHandlers(
+					VerifyFormKV("myparameter", "myvalue"),
+					VerifyFormKV("yourparameter", "yourvalue"),
+				),
+			)
 
-		// Send the request:
-		_, err := connection.Get().
-			Path("/mypath").
-			Header("myheader", "myvalue").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-	})
+			// Send the request:
+			_, err := connection.Get().
+				Path("/mypath").
+				Parameter("myparameter", "myvalue").
+				Parameter("yourparameter", "yourvalue").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	It("Sends two headers", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			CombineHandlers(
+		It("Sends one header", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
 				VerifyHeaderKV("myheader", "myvalue"),
-				VerifyHeaderKV("yourheader", "yourvalue"),
-			),
-		)
+			)
 
-		// Send the request:
-		_, err := connection.Get().
-			Path("/mypath").
-			Header("myheader", "myvalue").
-			Header("yourheader", "yourvalue").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
+			// Send the request:
+			_, err := connection.Get().
+				Path("/mypath").
+				Header("myheader", "myvalue").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Sends two headers", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				CombineHandlers(
+					VerifyHeaderKV("myheader", "myvalue"),
+					VerifyHeaderKV("yourheader", "yourvalue"),
+				),
+			)
+
+			// Send the request:
+			_, err := connection.Get().
+				Path("/mypath").
+				Header("myheader", "myvalue").
+				Header("yourheader", "yourvalue").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Receives body", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusOK, "mybody"),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Status()).To(Equal(http.StatusOK))
+			Expect(response.String()).To(Equal("mybody"))
+			Expect(response.Bytes()).To(Equal([]byte("mybody")))
+		})
+
+		It("Receives status code 200", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusOK, nil),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Status()).To(Equal(http.StatusOK))
+		})
+
+		It("Receives status code 400", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusBadRequest, nil),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Status()).To(Equal(http.StatusBadRequest))
+		})
+
+		It("Receives status code 500", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusInternalServerError, nil),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Status()).To(Equal(http.StatusInternalServerError))
+		})
+
+		It("Fails if no path is given", func() {
+			response, err := connection.Get().
+				Send()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("path"))
+			Expect(err.Error()).To(ContainSubstring("mandatory"))
+			Expect(response).To(BeNil())
+		})
+
 	})
 
-	It("Receives body", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			RespondWith(http.StatusOK, "mybody"),
-		)
+	Describe("Post", func() {
+		It("Accepts empty body", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusOK, nil),
+			)
 
-		// Send the request:
-		response, err := connection.Get().
-			Path("/mypath").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		Expect(response.Status()).To(Equal(http.StatusOK))
-		Expect(response.String()).To(Equal("mybody"))
-		Expect(response.Bytes()).To(Equal([]byte("mybody")))
+			// Send the request:
+			response, err := connection.Post().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Status()).To(Equal(http.StatusOK))
+		})
 	})
 
-	It("Receives status code 200", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			RespondWith(http.StatusOK, nil),
-		)
+	Describe("Patch", func() {
+		It("Accepts empty body", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				RespondWith(http.StatusOK, nil),
+			)
 
-		// Send the request:
-		response, err := connection.Get().
-			Path("/mypath").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		Expect(response.Status()).To(Equal(http.StatusOK))
-	})
-
-	It("Receives status code 400", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			RespondWith(http.StatusBadRequest, nil),
-		)
-
-		// Send the request:
-		response, err := connection.Get().
-			Path("/mypath").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		Expect(response.Status()).To(Equal(http.StatusBadRequest))
-	})
-
-	It("Receives status code 500", func() {
-		// Configure the server:
-		apiServer.AppendHandlers(
-			RespondWith(http.StatusInternalServerError, nil),
-		)
-
-		// Send the request:
-		response, err := connection.Get().
-			Path("/mypath").
-			Send()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		Expect(response.Status()).To(Equal(http.StatusInternalServerError))
-	})
-
-	It("Fails if no path is given", func() {
-		response, err := connection.Get().
-			Send()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("path"))
-		Expect(err.Error()).To(ContainSubstring("mandatory"))
-		Expect(response).To(BeNil())
+			// Send the request:
+			response, err := connection.Patch().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Status()).To(Equal(http.StatusOK))
+		})
 	})
 })

--- a/send.go
+++ b/send.go
@@ -107,13 +107,8 @@ func (c *Connection) send(ctx context.Context, request *http.Request) (response 
 			return
 		}
 	case http.MethodPost, http.MethodPatch:
-		if request.Body == nil {
-			err = fmt.Errorf(
-				"request body is mandatory for the '%s' method",
-				request.Method,
-			)
-			return
-		}
+		// POST and PATCH don't need to have a body. It is up to the server to decide if
+		// this is acceptable.
 	default:
 		err = fmt.Errorf("method '%s' is not allowed", request.Method)
 		return


### PR DESCRIPTION
Currently the SDK doesn't accept POST requests without a body. But there
are some resources in the server that required this. For example the
resource that generates access tokens uses the POST method but it
doesn't require any input. This patch removes that restriction from the
SDK.