### PR TITLE
Release 0.1.47

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.47 Oct 25 2019
+
+- Update to metamodel 0.0.10:
+** Make HTTP adapters stateless.
+
 == 0.1.46 Oct 24 2019
 
 - Update to model 0.0.15:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.46"
+const Version = "0.1.47"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.10:
    - Make HTTP adapters stateless.