### PR TITLE
Update to metamodel 0.0.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ model_version:=v0.0.19
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.12
+metamodel_version:=v0.0.13
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Fix imports of `helpers` and `errors` packages.