### PR TITLE
Drop support for _developers.redhat.com_

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -46,15 +46,6 @@ const (
 	DefaultAgent        = "OCM/" + Version
 )
 
-// Alternative default values used in combination with the now deprecated `developers.redhat.com`:
-const (
-	// #nosec G101
-	deprecatedTokenURL     = "https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/token"
-	deprecatedClientID     = "uhc"
-	deprecatedClientSecret = ""
-	deprecatedIssuer       = "developers.redhat.com"
-)
-
 // DefaultScopes is the ser of scopes used by default:
 var DefaultScopes = []string{
 	"openid",
@@ -144,22 +135,17 @@ func (b *ConnectionBuilder) Logger(logger Logger) *ConnectionBuilder {
 }
 
 // TokenURL sets the URL that will be used to request OpenID access tokens. The default is
-// `https://sso.redhat.com/auth/realms/cloud-services/protocol/openid-connect/token` except when
-// authentication is performed with user name and password or with a token issued by
-// _developers.redhat.com_. In that case the default will be the deprecated
-// `https://developers.redhat.com/auth/realms/uhc/protocol/openid-connect/token`.
+// `https://sso.redhat.com/auth/realms/cloud-services/protocol/openid-connect/token`.
 func (b *ConnectionBuilder) TokenURL(url string) *ConnectionBuilder {
 	b.tokenURL = url
 	return b
 }
 
 // Client sets OpenID client identifier and secret that will be used to request OpenID tokens. The
-// default identifier is `cloud-services` except when authentication is performed with user name and
-// password or with token issued by _developers.redhat.com_. In that case the default will be the
-// deprecated `uhc`. The default secret is the empty string. When these two values are provided and
-// no user name and password is provided, the connection will use the client credentials grant to
-// obtain the token. For example, to create a connection using the client credentials grant do the
-// following:
+// default identifier is `cloud-services`. The default secret is the empty string. When these two
+// values are provided and no user name and password is provided, the connection will use the client
+// credentials grant to obtain the token. For example, to create a connection using the client
+// credentials grant do the following:
 //
 //	// Use the client credentials grant:
 //	connection, err := client.NewConnectionBuilder().
@@ -403,39 +389,10 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 		logger.Debug(ctx, "Logger wasn't provided, will use Go log")
 	}
 
-	// Use the default OpenID server unless authentication is performed with user name and
-	// password or with a token issued by the deprecated OpenID server:
-	defaultTokenURL := DefaultTokenURL
-	defaultClientID := DefaultClientID
-	defaultClientSecret := DefaultClientSecret
-	if havePassword {
-		defaultTokenURL = deprecatedTokenURL
-		defaultClientID = deprecatedClientID
-		defaultClientSecret = deprecatedClientSecret
-	} else if haveTokens {
-		var issuerURL *url.URL
-		if accessToken != nil {
-			issuerURL, err = tokenIssuer(accessToken)
-			if err != nil {
-				return
-			}
-		} else if refreshToken != nil {
-			issuerURL, err = tokenIssuer(refreshToken)
-			if err != nil {
-				return
-			}
-		}
-		if issuerURL != nil && strings.EqualFold(issuerURL.Hostname(), deprecatedIssuer) {
-			defaultTokenURL = deprecatedTokenURL
-			defaultClientID = deprecatedClientID
-			defaultClientSecret = deprecatedClientSecret
-		}
-	}
-
 	// Set the default authentication details, if needed:
 	rawTokenURL := b.tokenURL
 	if rawTokenURL == "" {
-		rawTokenURL = defaultTokenURL
+		rawTokenURL = DefaultTokenURL
 		logger.Debug(
 			ctx,
 			"OpenID token URL wasn't provided, will use '%s'",
@@ -449,7 +406,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 	}
 	clientID := b.clientID
 	if clientID == "" {
-		clientID = defaultClientID
+		clientID = DefaultClientID
 		logger.Debug(
 			ctx,
 			"OpenID client identifier wasn't provided, will use '%s'",
@@ -458,7 +415,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 	}
 	clientSecret := b.clientSecret
 	if clientSecret == "" {
-		clientSecret = defaultClientSecret
+		clientSecret = DefaultClientSecret
 		logger.Debug(
 			ctx,
 			"OpenID client secret wasn't provided, will use '%s'",

--- a/connection_test.go
+++ b/connection_test.go
@@ -138,80 +138,9 @@ var _ = Describe("Connection", func() {
 		Expect(clientSecret).To(Equal(DefaultClientSecret))
 	})
 
-	It("Selects deprecated OpenID with user name and password", func() {
-		connection, err := NewConnectionBuilder().
-			User("myuser", "mypassword").
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		defer connection.Close()
-		tokenURL := connection.TokenURL()
-		Expect(tokenURL).To(Equal(deprecatedTokenURL))
-		clientID, clientSecret := connection.Client()
-		Expect(clientID).To(Equal(deprecatedClientID))
-		Expect(clientSecret).To(Equal(deprecatedClientSecret))
-	})
-
-	It("Selects deprecated OpenID server with deprecated access token", func() {
-		accessToken := DeprecatedToken("Bearer", 5*time.Minute)
-		connection, err := NewConnectionBuilder().
-			Tokens(accessToken).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		defer connection.Close()
-		tokenURL := connection.TokenURL()
-		Expect(tokenURL).To(Equal(deprecatedTokenURL))
-		clientID, clientSecret := connection.Client()
-		Expect(clientID).To(Equal(deprecatedClientID))
-		Expect(clientSecret).To(Equal(deprecatedClientSecret))
-	})
-
-	It("Selects deprecated OpenID server with deprecated refresh token", func() {
-		refreshToken := DeprecatedToken("Refresh", 10*time.Hour)
-		connection, err := NewConnectionBuilder().
-			Tokens(refreshToken).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		defer connection.Close()
-		tokenURL := connection.TokenURL()
-		Expect(tokenURL).To(Equal(deprecatedTokenURL))
-		clientID, clientSecret := connection.Client()
-		Expect(clientID).To(Equal(deprecatedClientID))
-		Expect(clientSecret).To(Equal(deprecatedClientSecret))
-	})
-
-	It("Selects deprecated OpenID server with deprecated offline access token", func() {
-		offlineToken := DeprecatedToken("Offline", 0)
-		connection, err := NewConnectionBuilder().
-			Tokens(offlineToken).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		defer connection.Close()
-		tokenURL := connection.TokenURL()
-		Expect(tokenURL).To(Equal(deprecatedTokenURL))
-		clientID, clientSecret := connection.Client()
-		Expect(clientID).To(Equal(deprecatedClientID))
-		Expect(clientSecret).To(Equal(deprecatedClientSecret))
-	})
-
 	It("Honours explicitly provided OpenID server with user name and password", func() {
 		connection, err := NewConnectionBuilder().
 			User("myuser", "mypassword").
-			TokenURL(DefaultTokenURL).
-			Client(DefaultClientID, DefaultClientSecret).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		defer connection.Close()
-		tokenURL := connection.TokenURL()
-		Expect(tokenURL).To(Equal(DefaultTokenURL))
-		clientID, clientSecret := connection.Client()
-		Expect(clientID).To(Equal(DefaultClientID))
-		Expect(clientSecret).To(Equal(DefaultClientSecret))
-	})
-
-	It("Honours explicitly provided OpenID server with deprecated token", func() {
-		offlineToken := DeprecatedToken("Offline", 0)
-		connection, err := NewConnectionBuilder().
-			Tokens(offlineToken).
 			TokenURL(DefaultTokenURL).
 			Client(DefaultClientID, DefaultClientSecret).
 			Build()

--- a/main_test.go
+++ b/main_test.go
@@ -128,14 +128,6 @@ func DefaultToken(typ string, life time.Duration) string {
 	return issueToken("https://sso.redhat.com/auth/realms/redhat-external", typ, life)
 }
 
-// DeprecatedToken generates a token issued by the deprecated OpenID server and with of the given
-// type and with the given life. If the life is zero the token will never expire. If the life is
-// positive the token will be valid, and expire after that time.  If the life is negative the token
-// will be already expired that time ago.
-func DeprecatedToken(typ string, life time.Duration) string {
-	return issueToken("https://developers.redhat.com/auth/realms/rhd", typ, life)
-}
-
 // issueToken generates a token issued by the given issuer, the given type and the given life time.
 func issueToken(issuer string, typ string, life time.Duration) string {
 	iat := time.Now()

--- a/token.go
+++ b/token.go
@@ -384,24 +384,3 @@ func tokenExpiry(token *jwt.Token, now time.Time) (expires bool,
 	}
 	return
 }
-
-// tokenIssuer extracts the URL of the issuer of the token from the `iss` claim. Returns nil if
-// there is no such claim.
-func tokenIssuer(token *jwt.Token) (issuer *url.URL, err error) {
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		err = fmt.Errorf("expected map claims bug got %T", claims)
-		return
-	}
-	claim, ok := claims["iss"]
-	if !ok {
-		return
-	}
-	value, ok := claim.(string)
-	if !ok {
-		err = fmt.Errorf("expected string 'iss' but got %T", claim)
-		return
-	}
-	issuer, err = url.Parse(value)
-	return
-}


### PR DESCRIPTION
This patch drops support for the deprecated _developers.redhat.com_
authentication service, as it is no longer supported by the server.