### PR TITLE
Release 0.1.54

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,13 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.54 Nov 17 2019
+
+- Drop support for _developers.redhat.com_.
+
+- Update to metamodel 0.0.14:
+** Add `Poll` method to clients that have a `Get` method.
+
 == 0.1.53 Nov 14 2019
 
 - Update to model 0.0.20:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.53"
+const Version = "0.1.54"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Drop support for _developers.redhat.com_.

- Update to metamodel 0.0.14:
** Add `Poll` method to clients that have a `Get` method.