### PR TITLE
Release 0.1.56

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.56 Nov 17 2019
+
+- Update to model 0.0.22:
+** Add `socket_total_by_node_roles_os` metric query.
+
 == 0.1.55 Nov 17 2019
 
 - Update to model 0.0.21:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.55"
+const Version = "0.1.56"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.22:
** Add `socket_total_by_node_roles_os` metric query.