### PR TITLE
Release 0.1.58

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,12 +3,17 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
-== 0.1.58 Nov 17 2019
+== 0.1.58 Nov 19 2019
+
+- Update to metamodel 0.0.16:
+** Add simple conversion from AsciiDoc to Markdown.
+
+== 0.1.57 Nov 19 2019
 
 - Update to metamodel 0.0.15:
 ** Add support for the version metadata resource.
 
-== 0.1.56 Nov 17 2019
+== 0.1.56 Nov 19 2019
 
 - Update to model 0.0.22:
 ** Add `socket_total_by_node_roles_os` metric query.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.57"
+const Version = "0.1.58"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.16:
** Add simple conversion from AsciiDoc to Markdown.