### PR TITLE
Release 0.1.61

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.61 Nov 25 2019
+
+- Update to metamodel 0.0.18:
+** Add stage URL and `securitySchemes` to the generated _OpenAPI_
+   specifications.
+
 == 0.1.60 Nov 23 2019
 
 - Update to model 0.0.24:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.60"
+const Version = "0.1.61"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.18:
** Add stage URL and `securitySchemes` to the generated _OpenAPI_
   specifications.