### PR TITLE
Fix metrics example

### DIFF
--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -54,7 +54,7 @@ func main() {
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).
-		Metrics("my").
+		Metrics("api_outbound").
 		BuildContext(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)


### PR DESCRIPTION
This patch changes the metrics prefix used in the `prometheuus_metrics.go`
example so that it matches the comment describing it.