### PR TITLE
Release 0.1.63

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,15 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.63 Dec 2 2019
+
+- Update to model 0.0.26:
+** Remove obsolete `aws` and `version` fields from the `Flavour` type.
+** Add instance type fields to the `Flavour` type.
+** Add `AWSVolume` and `AWSFlavour` types.
+** Add attributes required for _BYOC_.
+** Fix direction of `Body` parameters of updates.
+
 == 0.1.62 Nov 28 2019
 
 - Update to model 0.0.25:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.62"
+const Version = "0.1.63"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.26:
** Remove obsolete `aws` and `version` fields from the `Flavour` type.
** Add instance type fields to the `Flavour` type.
** Add `AWSVolume` and `AWSFlavour` types.
** Add attributes required for _BYOC_.
** Fix direction of `Body` parameters of updates.