### PR TITLE
Don't check kinds of add-ons installations

### DIFF
--- a/clustersmgmt/v1/add_on_installation_list_reader.go
+++ b/clustersmgmt/v1/add_on_installation_list_reader.go
@@ -20,8 +20,6 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"fmt"
-
 	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
@@ -129,21 +127,26 @@ func (d *addOnInstallationListLinkData) unwrapLink() (list *AddOnInstallationLis
 	list = new(AddOnInstallationList)
 	list.items = items
 	list.href = d.HREF
-	if d.Kind != nil {
-		switch *d.Kind {
-		case AddOnInstallationListKind:
-			list.link = false
-		case AddOnInstallationListLinkKind:
-			list.link = true
-		default:
-			err = fmt.Errorf(
-				"expected kind '%s' or '%s' but got '%s'",
-				AddOnInstallationListKind,
-				AddOnInstallationListLinkKind,
-				*d.Kind,
-			)
-			return
+	// TODO: We can't currently do this because the server is returning an incorrect kind
+	// for add-on installations.
+	/*
+		if d.Kind != nil {
+			switch *d.Kind {
+			case AddOnInstallationListKind:
+				list.link = false
+			case AddOnInstallationListLinkKind:
+				list.link = true
+			default:
+				err = fmt.Errorf(
+					"expected kind '%s' or '%s' but got '%s'",
+					AddOnInstallationListKind,
+					AddOnInstallationListLinkKind,
+					*d.Kind,
+				)
+				return
+			}
 		}
-	}
+	*/
+	list.link = true
 	return
 }

--- a/clustersmgmt/v1/add_on_installation_reader.go
+++ b/clustersmgmt/v1/add_on_installation_reader.go
@@ -20,8 +20,6 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
-	"fmt"
-
 	"github.com/openshift-online/ocm-sdk-go/helpers"
 )
 
@@ -100,22 +98,27 @@ func (d *addOnInstallationData) unwrap() (object *AddOnInstallation, err error) 
 	object = new(AddOnInstallation)
 	object.id = d.ID
 	object.href = d.HREF
-	if d.Kind != nil {
-		switch *d.Kind {
-		case AddOnInstallationKind:
-			object.link = false
-		case AddOnInstallationLinkKind:
-			object.link = true
-		default:
-			err = fmt.Errorf(
-				"expected kind '%s' or '%s' but got '%s'",
-				AddOnInstallationKind,
-				AddOnInstallationLinkKind,
-				*d.Kind,
-			)
-			return
+	// TODO: We can't currently do this because the server is returning an incorrect kind for
+	// add-ons.
+	/*
+		if d.Kind != nil {
+			switch *d.Kind {
+			case AddOnInstallationKind:
+				object.link = false
+			case AddOnInstallationLinkKind:
+				object.link = true
+			default:
+				err = fmt.Errorf(
+					"expected kind '%s' or '%s' but got '%s'",
+					AddOnInstallationKind,
+					AddOnInstallationLinkKind,
+					*d.Kind,
+				)
+				return
+			}
 		}
-	}
+	*/
+	object.link = false
 	object.addon, err = d.Addon.unwrap()
 	if err != nil {
 		return

--- a/examples/list_clusters.go
+++ b/examples/list_clusters.go
@@ -73,7 +73,7 @@ func main() {
 
 		// Display the page:
 		response.Items().Each(func(cluster *cmv1.Cluster) bool {
-			fmt.Printf("%s - %s\n", cluster.ID(), cluster.Name())
+			fmt.Printf("%s - %s - %s\n", cluster.ID(), cluster.Name(), cluster.State())
 			return true
 		})
 


### PR DESCRIPTION
Currently the server isn't returning correctly the `kind` attribute of
add-on installations. This affects clusters as even if they don't have
add-ons installed because each cluster contains a link to the collection
of add-on installations.

This patch chages the SDK so that it will ignore that `kind` attribute.
It will be reverted when the server is fixed.