### PR TITLE
Release 0.1.68

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.68 Dec 12 2019
+
+- Update to metamodel 0.0.19:
+** Don't fail on wrong kind.
+
 == 0.1.67 Dec 12 2019
 
 - Don't check kinds of add-ons installations.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.67"
+const Version = "0.1.68"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.19:
  - Don't fail on wrong kind.