### PR TITLE
Release 0.1.71

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.71 Dec 19 2019
+
+- Authentication handler sends 401 instead of 511.
+- Authentication handler sends the `WWW-Authenticate` response header.
+- Authentication handler doesn't send authentication failures to the log.
+
 == 0.1.70 Dec 18 2019
 
 - Update to metamodel 0.0.20:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.70"
+const Version = "0.1.71"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Authentication handler sends 401 instead of 511.
- Authentication handler sends the `WWW-Authenticate` response header.
- Authentication handler doesn't send authentication failures to the log.