### PR TITLE
Release 0.1.72

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.72 Dec 19 2019
+
+- Update to model 0.0.31:
+** Add `ban_code` attribute to `Account` type.
+
 == 0.1.71 Dec 19 2019
 
 - Authentication handler sends 401 instead of 511.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.71"
+const Version = "0.1.72"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.31:
  - Add `ban_code` attribute to `Account` type.