### PR TITLE
Release 0.1.76

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,15 +3,21 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
-== 0.1.75 Jan 01 2020
+== 0.1.76 Jan 3 2020
+
+- Update to model 0.0.36:
+** Add types and resources for AWS infrastructure access roles.
+** Add GCP flavour and change AWS flavour to contain also the instance type.
+
+== 0.1.75 Jan 1 2020
 
 - Update to model 0.0.35:
-** Added CurrentAccess Support
+** Add `CurrentAccess` support.
 
 == 0.1.74 Dec 31 2019
 
 - Update to model 0.0.33:
-** Adding the CreatedAt and UpdatedAt fields to the Subscription type.
+** Add the `CreatedAt` and `UpdatedAt` attributes to the `Subscription` type.
 
 == 0.1.73 Dec 24 2019
 

--- a/clustersmgmt/v1/aws_infrastructure_access_role_builder.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_builder.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+// AWSInfrastructureAccessRoleBuilder contains the data and logic needed to build 'AWS_infrastructure_access_role' objects.
+//
+// A set of acces permissions for AWS resources
+type AWSInfrastructureAccessRoleBuilder struct {
+	id          *string
+	href        *string
+	link        bool
+	description *string
+	displayName *string
+}
+
+// NewAWSInfrastructureAccessRole creates a new builder of 'AWS_infrastructure_access_role' objects.
+func NewAWSInfrastructureAccessRole() *AWSInfrastructureAccessRoleBuilder {
+	return new(AWSInfrastructureAccessRoleBuilder)
+}
+
+// ID sets the identifier of the object.
+func (b *AWSInfrastructureAccessRoleBuilder) ID(value string) *AWSInfrastructureAccessRoleBuilder {
+	b.id = &value
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *AWSInfrastructureAccessRoleBuilder) HREF(value string) *AWSInfrastructureAccessRoleBuilder {
+	b.href = &value
+	return b
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *AWSInfrastructureAccessRoleBuilder) Link(value bool) *AWSInfrastructureAccessRoleBuilder {
+	b.link = value
+	return b
+}
+
+// Description sets the value of the 'description' attribute
+// to the given value.
+//
+//
+func (b *AWSInfrastructureAccessRoleBuilder) Description(value string) *AWSInfrastructureAccessRoleBuilder {
+	b.description = &value
+	return b
+}
+
+// DisplayName sets the value of the 'display_name' attribute
+// to the given value.
+//
+//
+func (b *AWSInfrastructureAccessRoleBuilder) DisplayName(value string) *AWSInfrastructureAccessRoleBuilder {
+	b.displayName = &value
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AWSInfrastructureAccessRoleBuilder) Copy(object *AWSInfrastructureAccessRole) *AWSInfrastructureAccessRoleBuilder {
+	if object == nil {
+		return b
+	}
+	b.id = object.id
+	b.href = object.href
+	b.link = object.link
+	b.description = object.description
+	b.displayName = object.displayName
+	return b
+}
+
+// Build creates a 'AWS_infrastructure_access_role' object using the configuration stored in the builder.
+func (b *AWSInfrastructureAccessRoleBuilder) Build() (object *AWSInfrastructureAccessRole, err error) {
+	object = new(AWSInfrastructureAccessRole)
+	object.id = b.id
+	object.href = b.href
+	object.link = b.link
+	if b.description != nil {
+		object.description = b.description
+	}
+	if b.displayName != nil {
+		object.displayName = b.displayName
+	}
+	return
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_client.go
@@ -1,0 +1,323 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// AWSInfrastructureAccessRoleClient is the client of the 'AWS_infrastructure_access_role' resource.
+//
+// Manages a specific aws infrastructure access role.
+type AWSInfrastructureAccessRoleClient struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+}
+
+// NewAWSInfrastructureAccessRoleClient creates a new client for the 'AWS_infrastructure_access_role'
+// resource using the given transport to sned the requests and receive the
+// responses.
+func NewAWSInfrastructureAccessRoleClient(transport http.RoundTripper, path string, metric string) *AWSInfrastructureAccessRoleClient {
+	client := new(AWSInfrastructureAccessRoleClient)
+	client.transport = transport
+	client.path = path
+	client.metric = metric
+	return client
+}
+
+// Get creates a request for the 'get' method.
+//
+// Retrieves the details of the aws infrastructure access role.
+func (c *AWSInfrastructureAccessRoleClient) Get() *AWSInfrastructureAccessRoleGetRequest {
+	request := new(AWSInfrastructureAccessRoleGetRequest)
+	request.transport = c.transport
+	request.path = c.path
+	request.metric = c.metric
+	return request
+}
+
+// AWSInfrastructureAccessRolePollRequest is the request for the Poll method.
+type AWSInfrastructureAccessRolePollRequest struct {
+	request    *AWSInfrastructureAccessRoleGetRequest
+	interval   time.Duration
+	statuses   []int
+	predicates []func(interface{}) bool
+}
+
+// Parameter adds a query parameter to all the requests that will be used to retrieve the object.
+func (r *AWSInfrastructureAccessRolePollRequest) Parameter(name string, value interface{}) *AWSInfrastructureAccessRolePollRequest {
+	r.request.Parameter(name, value)
+	return r
+}
+
+// Header adds a request header to all the requests that will be used to retrieve the object.
+func (r *AWSInfrastructureAccessRolePollRequest) Header(name string, value interface{}) *AWSInfrastructureAccessRolePollRequest {
+	r.request.Header(name, value)
+	return r
+}
+
+// Interval sets the polling interval. This parameter is mandatory and must be greater than zero.
+func (r *AWSInfrastructureAccessRolePollRequest) Interval(value time.Duration) *AWSInfrastructureAccessRolePollRequest {
+	r.interval = value
+	return r
+}
+
+// Status set the expected status of the response. Multiple values can be set calling this method
+// multiple times. The response will be considered successful if the status is any of those values.
+func (r *AWSInfrastructureAccessRolePollRequest) Status(value int) *AWSInfrastructureAccessRolePollRequest {
+	r.statuses = append(r.statuses, value)
+	return r
+}
+
+// Predicate adds a predicate that the response should satisfy be considered successful. Multiple
+// predicates can be set calling this method multiple times. The response will be considered successful
+// if all the predicates are satisfied.
+func (r *AWSInfrastructureAccessRolePollRequest) Predicate(value func(*AWSInfrastructureAccessRoleGetResponse) bool) *AWSInfrastructureAccessRolePollRequest {
+	r.predicates = append(r.predicates, func(response interface{}) bool {
+		return value(response.(*AWSInfrastructureAccessRoleGetResponse))
+	})
+	return r
+}
+
+// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// the values specified with the Status method and if all the predicates specified with the Predicate
+// method return nil.
+//
+// The context must have a timeout or deadline, otherwise this method will immediately return an error.
+func (r *AWSInfrastructureAccessRolePollRequest) StartContext(ctx context.Context) (response *AWSInfrastructureAccessRolePollResponse, err error) {
+	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+	if result != nil {
+		response = &AWSInfrastructureAccessRolePollResponse{
+			response: result.(*AWSInfrastructureAccessRoleGetResponse),
+		}
+	}
+	return
+}
+
+// task adapts the types of the request/response types so that they can be used with the generic
+// polling function from the helpers package.
+func (r *AWSInfrastructureAccessRolePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
+	response, err := r.request.SendContext(ctx)
+	if response != nil {
+		status = response.Status()
+		result = response
+	}
+	return
+}
+
+// AWSInfrastructureAccessRolePollResponse is the response for the Poll method.
+type AWSInfrastructureAccessRolePollResponse struct {
+	response *AWSInfrastructureAccessRoleGetResponse
+}
+
+// Status returns the response status code.
+func (r *AWSInfrastructureAccessRolePollResponse) Status() int {
+	if r == nil {
+		return 0
+	}
+	return r.response.Status()
+}
+
+// Header returns header of the response.
+func (r *AWSInfrastructureAccessRolePollResponse) Header() http.Header {
+	if r == nil {
+		return nil
+	}
+	return r.response.Header()
+}
+
+// Error returns the response error.
+func (r *AWSInfrastructureAccessRolePollResponse) Error() *errors.Error {
+	if r == nil {
+		return nil
+	}
+	return r.response.Error()
+}
+
+// Body returns the value of the 'body' parameter.
+//
+//
+func (r *AWSInfrastructureAccessRolePollResponse) Body() *AWSInfrastructureAccessRole {
+	return r.response.Body()
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *AWSInfrastructureAccessRolePollResponse) GetBody() (value *AWSInfrastructureAccessRole, ok bool) {
+	return r.response.GetBody()
+}
+
+// Poll creates a request to repeatedly retrieve the object till the response has one of a given set
+// of states and satisfies a set of predicates.
+func (c *AWSInfrastructureAccessRoleClient) Poll() *AWSInfrastructureAccessRolePollRequest {
+	return &AWSInfrastructureAccessRolePollRequest{
+		request: c.Get(),
+	}
+}
+
+// AWSInfrastructureAccessRoleGetRequest is the request for the 'get' method.
+type AWSInfrastructureAccessRoleGetRequest struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+	query     url.Values
+	header    http.Header
+}
+
+// Parameter adds a query parameter.
+func (r *AWSInfrastructureAccessRoleGetRequest) Parameter(name string, value interface{}) *AWSInfrastructureAccessRoleGetRequest {
+	helpers.AddValue(&r.query, name, value)
+	return r
+}
+
+// Header adds a request header.
+func (r *AWSInfrastructureAccessRoleGetRequest) Header(name string, value interface{}) *AWSInfrastructureAccessRoleGetRequest {
+	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Send sends this request, waits for the response, and returns it.
+//
+// This is a potentially lengthy operation, as it requires network communication.
+// Consider using a context and the SendContext method.
+func (r *AWSInfrastructureAccessRoleGetRequest) Send() (result *AWSInfrastructureAccessRoleGetResponse, err error) {
+	return r.SendContext(context.Background())
+}
+
+// SendContext sends this request, waits for the response, and returns it.
+func (r *AWSInfrastructureAccessRoleGetRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRoleGetResponse, err error) {
+	query := helpers.CopyQuery(r.query)
+	header := helpers.SetHeader(r.header, r.metric)
+	uri := &url.URL{
+		Path:     r.path,
+		RawQuery: query.Encode(),
+	}
+	request := &http.Request{
+		Method: "GET",
+		URL:    uri,
+		Header: header,
+	}
+	if ctx != nil {
+		request = request.WithContext(ctx)
+	}
+	response, err := r.transport.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result = new(AWSInfrastructureAccessRoleGetResponse)
+	result.status = response.StatusCode
+	result.header = response.Header
+	if result.status >= 400 {
+		result.err, err = errors.UnmarshalError(response.Body)
+		if err != nil {
+			return
+		}
+		err = result.err
+		return
+	}
+	err = result.unmarshal(response.Body)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// AWSInfrastructureAccessRoleGetResponse is the response for the 'get' method.
+type AWSInfrastructureAccessRoleGetResponse struct {
+	status int
+	header http.Header
+	err    *errors.Error
+	body   *AWSInfrastructureAccessRole
+}
+
+// Status returns the response status code.
+func (r *AWSInfrastructureAccessRoleGetResponse) Status() int {
+	if r == nil {
+		return 0
+	}
+	return r.status
+}
+
+// Header returns header of the response.
+func (r *AWSInfrastructureAccessRoleGetResponse) Header() http.Header {
+	if r == nil {
+		return nil
+	}
+	return r.header
+}
+
+// Error returns the response error.
+func (r *AWSInfrastructureAccessRoleGetResponse) Error() *errors.Error {
+	if r == nil {
+		return nil
+	}
+	return r.err
+}
+
+// Body returns the value of the 'body' parameter.
+//
+//
+func (r *AWSInfrastructureAccessRoleGetResponse) Body() *AWSInfrastructureAccessRole {
+	if r == nil {
+		return nil
+	}
+	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *AWSInfrastructureAccessRoleGetResponse) GetBody() (value *AWSInfrastructureAccessRole, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
+}
+
+// unmarshal is the method used internally to unmarshal responses to the
+// 'get' method.
+func (r *AWSInfrastructureAccessRoleGetResponse) unmarshal(reader io.Reader) error {
+	var err error
+	decoder := json.NewDecoder(reader)
+	data := new(awsInfrastructureAccessRoleData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	r.body, err = data.unwrap()
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_list_builder.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_list_builder.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+// AWSInfrastructureAccessRoleListBuilder contains the data and logic needed to build
+// 'AWS_infrastructure_access_role' objects.
+type AWSInfrastructureAccessRoleListBuilder struct {
+	items []*AWSInfrastructureAccessRoleBuilder
+}
+
+// NewAWSInfrastructureAccessRoleList creates a new builder of 'AWS_infrastructure_access_role' objects.
+func NewAWSInfrastructureAccessRoleList() *AWSInfrastructureAccessRoleListBuilder {
+	return new(AWSInfrastructureAccessRoleListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AWSInfrastructureAccessRoleListBuilder) Items(values ...*AWSInfrastructureAccessRoleBuilder) *AWSInfrastructureAccessRoleListBuilder {
+	b.items = make([]*AWSInfrastructureAccessRoleBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Build creates a list of 'AWS_infrastructure_access_role' objects using the
+// configuration stored in the builder.
+func (b *AWSInfrastructureAccessRoleListBuilder) Build() (list *AWSInfrastructureAccessRoleList, err error) {
+	items := make([]*AWSInfrastructureAccessRole, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AWSInfrastructureAccessRoleList)
+	list.items = items
+	return
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_list_reader.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_list_reader.go
@@ -1,0 +1,134 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// awsInfrastructureAccessRoleListData is type used internally to marshal and unmarshal lists of objects
+// of type 'AWS_infrastructure_access_role'.
+type awsInfrastructureAccessRoleListData []*awsInfrastructureAccessRoleData
+
+// UnmarshalAWSInfrastructureAccessRoleList reads a list of values of the 'AWS_infrastructure_access_role'
+// from the given source, which can be a slice of bytes, a string, an io.Reader or a
+// json.Decoder.
+func UnmarshalAWSInfrastructureAccessRoleList(source interface{}) (list *AWSInfrastructureAccessRoleList, err error) {
+	decoder, err := helpers.NewDecoder(source)
+	if err != nil {
+		return
+	}
+	var data awsInfrastructureAccessRoleListData
+	err = decoder.Decode(&data)
+	if err != nil {
+		return
+	}
+	list, err = data.unwrap()
+	return
+}
+
+// wrap is the method used internally to convert a list of values of the
+// 'AWS_infrastructure_access_role' value to a JSON document.
+func (l *AWSInfrastructureAccessRoleList) wrap() (data awsInfrastructureAccessRoleListData, err error) {
+	if l == nil {
+		return
+	}
+	data = make(awsInfrastructureAccessRoleListData, len(l.items))
+	for i, item := range l.items {
+		data[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// unwrap is the function used internally to convert the JSON unmarshalled data to a
+// list of values of the 'AWS_infrastructure_access_role' type.
+func (d awsInfrastructureAccessRoleListData) unwrap() (list *AWSInfrastructureAccessRoleList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*AWSInfrastructureAccessRole, len(d))
+	for i, item := range d {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AWSInfrastructureAccessRoleList)
+	list.items = items
+	return
+}
+
+// awsInfrastructureAccessRoleListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'AWS_infrastructure_access_role'.
+type awsInfrastructureAccessRoleListLinkData struct {
+	Kind  *string                            "json:\"kind,omitempty\""
+	HREF  *string                            "json:\"href,omitempty\""
+	Items []*awsInfrastructureAccessRoleData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'AWS_infrastructure_access_role' value to a link.
+func (l *AWSInfrastructureAccessRoleList) wrapLink() (data *awsInfrastructureAccessRoleListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*awsInfrastructureAccessRoleData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(awsInfrastructureAccessRoleListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = AWSInfrastructureAccessRoleListLinkKind
+	} else {
+		*data.Kind = AWSInfrastructureAccessRoleListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'AWS_infrastructure_access_role' type to a list.
+func (d *awsInfrastructureAccessRoleListLinkData) unwrapLink() (list *AWSInfrastructureAccessRoleList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*AWSInfrastructureAccessRole, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AWSInfrastructureAccessRoleList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		list.link = *d.Kind == AWSInfrastructureAccessRoleListLinkKind
+	}
+	return
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_reader.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_reader.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// awsInfrastructureAccessRoleData is the data structure used internally to marshal and unmarshal
+// objects of type 'AWS_infrastructure_access_role'.
+type awsInfrastructureAccessRoleData struct {
+	Kind        *string "json:\"kind,omitempty\""
+	ID          *string "json:\"id,omitempty\""
+	HREF        *string "json:\"href,omitempty\""
+	Description *string "json:\"description,omitempty\""
+	DisplayName *string "json:\"display_name,omitempty\""
+}
+
+// MarshalAWSInfrastructureAccessRole writes a value of the 'AWS_infrastructure_access_role' to the given target,
+// which can be a writer or a JSON encoder.
+func MarshalAWSInfrastructureAccessRole(object *AWSInfrastructureAccessRole, target interface{}) error {
+	encoder, err := helpers.NewEncoder(target)
+	if err != nil {
+		return err
+	}
+	data, err := object.wrap()
+	if err != nil {
+		return err
+	}
+	return encoder.Encode(data)
+}
+
+// wrap is the method used internally to convert a value of the 'AWS_infrastructure_access_role'
+// value to a JSON document.
+func (o *AWSInfrastructureAccessRole) wrap() (data *awsInfrastructureAccessRoleData, err error) {
+	if o == nil {
+		return
+	}
+	data = new(awsInfrastructureAccessRoleData)
+	data.ID = o.id
+	data.HREF = o.href
+	data.Kind = new(string)
+	if o.link {
+		*data.Kind = AWSInfrastructureAccessRoleLinkKind
+	} else {
+		*data.Kind = AWSInfrastructureAccessRoleKind
+	}
+	data.Description = o.description
+	data.DisplayName = o.displayName
+	return
+}
+
+// UnmarshalAWSInfrastructureAccessRole reads a value of the 'AWS_infrastructure_access_role' type from the given
+// source, which can be an slice of bytes, a string, a reader or a JSON decoder.
+func UnmarshalAWSInfrastructureAccessRole(source interface{}) (object *AWSInfrastructureAccessRole, err error) {
+	decoder, err := helpers.NewDecoder(source)
+	if err != nil {
+		return
+	}
+	data := new(awsInfrastructureAccessRoleData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return
+	}
+	object, err = data.unwrap()
+	return
+}
+
+// unwrap is the function used internally to convert the JSON unmarshalled data to a
+// value of the 'AWS_infrastructure_access_role' type.
+func (d *awsInfrastructureAccessRoleData) unwrap() (object *AWSInfrastructureAccessRole, err error) {
+	if d == nil {
+		return
+	}
+	object = new(AWSInfrastructureAccessRole)
+	object.id = d.ID
+	object.href = d.HREF
+	if d.Kind != nil {
+		object.link = *d.Kind == AWSInfrastructureAccessRoleLinkKind
+	}
+	object.description = d.Description
+	object.displayName = d.DisplayName
+	return
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_server.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_server.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+)
+
+// AWSInfrastructureAccessRoleServer represents the interface the manages the 'AWS_infrastructure_access_role' resource.
+type AWSInfrastructureAccessRoleServer interface {
+
+	// Get handles a request for the 'get' method.
+	//
+	// Retrieves the details of the aws infrastructure access role.
+	Get(ctx context.Context, request *AWSInfrastructureAccessRoleGetServerRequest, response *AWSInfrastructureAccessRoleGetServerResponse) error
+}
+
+// AWSInfrastructureAccessRoleGetServerRequest is the request for the 'get' method.
+type AWSInfrastructureAccessRoleGetServerRequest struct {
+}
+
+// AWSInfrastructureAccessRoleGetServerResponse is the response for the 'get' method.
+type AWSInfrastructureAccessRoleGetServerResponse struct {
+	status int
+	err    *errors.Error
+	body   *AWSInfrastructureAccessRole
+}
+
+// Body sets the value of the 'body' parameter.
+//
+//
+func (r *AWSInfrastructureAccessRoleGetServerResponse) Body(value *AWSInfrastructureAccessRole) *AWSInfrastructureAccessRoleGetServerResponse {
+	r.body = value
+	return r
+}
+
+// Status sets the status code.
+func (r *AWSInfrastructureAccessRoleGetServerResponse) Status(value int) *AWSInfrastructureAccessRoleGetServerResponse {
+	r.status = value
+	return r
+}
+
+// marshall is the method used internally to marshal responses for the
+// 'get' method.
+func (r *AWSInfrastructureAccessRoleGetServerResponse) marshal(writer io.Writer) error {
+	var err error
+	encoder := json.NewEncoder(writer)
+	data, err := r.body.wrap()
+	if err != nil {
+		return err
+	}
+	err = encoder.Encode(data)
+	return err
+}
+
+// dispatchAWSInfrastructureAccessRole navigates the servers tree rooted at the given server
+// till it finds one that matches the given set of path segments, and then invokes
+// the corresponding server.
+func dispatchAWSInfrastructureAccessRole(w http.ResponseWriter, r *http.Request, server AWSInfrastructureAccessRoleServer, segments []string) {
+	if len(segments) == 0 {
+		switch r.Method {
+		case "GET":
+			adaptAWSInfrastructureAccessRoleGetRequest(w, r, server)
+		default:
+			errors.SendMethodNotAllowed(w, r)
+			return
+		}
+	} else {
+		switch segments[0] {
+		default:
+			errors.SendNotFound(w, r)
+			return
+		}
+	}
+}
+
+// readAWSInfrastructureAccessRoleGetRequest reads the given HTTP requests and translates it
+// into an object of type AWSInfrastructureAccessRoleGetServerRequest.
+func readAWSInfrastructureAccessRoleGetRequest(r *http.Request) (*AWSInfrastructureAccessRoleGetServerRequest, error) {
+	var err error
+	result := new(AWSInfrastructureAccessRoleGetServerRequest)
+	return result, err
+}
+
+// writeAWSInfrastructureAccessRoleGetResponse translates the given request object into an
+// HTTP response.
+func writeAWSInfrastructureAccessRoleGetResponse(w http.ResponseWriter, r *AWSInfrastructureAccessRoleGetServerResponse) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(r.status)
+	err := r.marshal(w)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// adaptAWSInfrastructureAccessRoleGetRequest translates the given HTTP request into a call to
+// the corresponding method of the given server. Then it translates the
+// results returned by that method into an HTTP response.
+func adaptAWSInfrastructureAccessRoleGetRequest(w http.ResponseWriter, r *http.Request, server AWSInfrastructureAccessRoleServer) {
+	request, err := readAWSInfrastructureAccessRoleGetRequest(r)
+	if err != nil {
+		glog.Errorf(
+			"Can't read request for method '%s' and path '%s': %v",
+			r.Method, r.URL.Path, err,
+		)
+		errors.SendInternalServerError(w, r)
+		return
+	}
+	response := new(AWSInfrastructureAccessRoleGetServerResponse)
+	response.status = 200
+	err = server.Get(r.Context(), request, response)
+	if err != nil {
+		glog.Errorf(
+			"Can't process request for method '%s' and path '%s': %v",
+			r.Method, r.URL.Path, err,
+		)
+		errors.SendInternalServerError(w, r)
+		return
+	}
+	err = writeAWSInfrastructureAccessRoleGetResponse(w, response)
+	if err != nil {
+		glog.Errorf(
+			"Can't write response for method '%s' and path '%s': %v",
+			r.Method, r.URL.Path, err,
+		)
+		return
+	}
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_type.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_type.go
@@ -1,0 +1,269 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+// AWSInfrastructureAccessRoleKind is the name of the type used to represent objects
+// of type 'AWS_infrastructure_access_role'.
+const AWSInfrastructureAccessRoleKind = "AWSInfrastructureAccessRole"
+
+// AWSInfrastructureAccessRoleLinkKind is the name of the type used to represent links
+// to objects of type 'AWS_infrastructure_access_role'.
+const AWSInfrastructureAccessRoleLinkKind = "AWSInfrastructureAccessRoleLink"
+
+// AWSInfrastructureAccessRoleNilKind is the name of the type used to nil references
+// to objects of type 'AWS_infrastructure_access_role'.
+const AWSInfrastructureAccessRoleNilKind = "AWSInfrastructureAccessRoleNil"
+
+// AWSInfrastructureAccessRole represents the values of the 'AWS_infrastructure_access_role' type.
+//
+// A set of acces permissions for AWS resources
+type AWSInfrastructureAccessRole struct {
+	id          *string
+	href        *string
+	link        bool
+	description *string
+	displayName *string
+}
+
+// Kind returns the name of the type of the object.
+func (o *AWSInfrastructureAccessRole) Kind() string {
+	if o == nil {
+		return AWSInfrastructureAccessRoleNilKind
+	}
+	if o.link {
+		return AWSInfrastructureAccessRoleLinkKind
+	}
+	return AWSInfrastructureAccessRoleKind
+}
+
+// ID returns the identifier of the object.
+func (o *AWSInfrastructureAccessRole) ID() string {
+	if o != nil && o.id != nil {
+		return *o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *AWSInfrastructureAccessRole) GetID() (value string, ok bool) {
+	ok = o != nil && o.id != nil
+	if ok {
+		value = *o.id
+	}
+	return
+}
+
+// Link returns true iif this is a link.
+func (o *AWSInfrastructureAccessRole) Link() bool {
+	return o != nil && o.link
+}
+
+// HREF returns the link to the object.
+func (o *AWSInfrastructureAccessRole) HREF() string {
+	if o != nil && o.href != nil {
+		return *o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *AWSInfrastructureAccessRole) GetHREF() (value string, ok bool) {
+	ok = o != nil && o.href != nil
+	if ok {
+		value = *o.href
+	}
+	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AWSInfrastructureAccessRole) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.description == nil &&
+		o.displayName == nil &&
+		true)
+}
+
+// Description returns the value of the 'description' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Description of the role.
+func (o *AWSInfrastructureAccessRole) Description() string {
+	if o != nil && o.description != nil {
+		return *o.description
+	}
+	return ""
+}
+
+// GetDescription returns the value of the 'description' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Description of the role.
+func (o *AWSInfrastructureAccessRole) GetDescription() (value string, ok bool) {
+	ok = o != nil && o.description != nil
+	if ok {
+		value = *o.description
+	}
+	return
+}
+
+// DisplayName returns the value of the 'display_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Human friendly identifier of the role, for example `Read only`.
+func (o *AWSInfrastructureAccessRole) DisplayName() string {
+	if o != nil && o.displayName != nil {
+		return *o.displayName
+	}
+	return ""
+}
+
+// GetDisplayName returns the value of the 'display_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Human friendly identifier of the role, for example `Read only`.
+func (o *AWSInfrastructureAccessRole) GetDisplayName() (value string, ok bool) {
+	ok = o != nil && o.displayName != nil
+	if ok {
+		value = *o.displayName
+	}
+	return
+}
+
+// AWSInfrastructureAccessRoleListKind is the name of the type used to represent list of
+// objects of type 'AWS_infrastructure_access_role'.
+const AWSInfrastructureAccessRoleListKind = "AWSInfrastructureAccessRoleList"
+
+// AWSInfrastructureAccessRoleListLinkKind is the name of the type used to represent links
+// to list of objects of type 'AWS_infrastructure_access_role'.
+const AWSInfrastructureAccessRoleListLinkKind = "AWSInfrastructureAccessRoleListLink"
+
+// AWSInfrastructureAccessRoleNilKind is the name of the type used to nil lists of
+// objects of type 'AWS_infrastructure_access_role'.
+const AWSInfrastructureAccessRoleListNilKind = "AWSInfrastructureAccessRoleListNil"
+
+// AWSInfrastructureAccessRoleList is a list of values of the 'AWS_infrastructure_access_role' type.
+type AWSInfrastructureAccessRoleList struct {
+	href  *string
+	link  bool
+	items []*AWSInfrastructureAccessRole
+}
+
+// Kind returns the name of the type of the object.
+func (l *AWSInfrastructureAccessRoleList) Kind() string {
+	if l == nil {
+		return AWSInfrastructureAccessRoleListNilKind
+	}
+	if l.link {
+		return AWSInfrastructureAccessRoleListLinkKind
+	}
+	return AWSInfrastructureAccessRoleListKind
+}
+
+// Link returns true iif this is a link.
+func (l *AWSInfrastructureAccessRoleList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *AWSInfrastructureAccessRoleList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *AWSInfrastructureAccessRoleList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
+}
+
+// Len returns the length of the list.
+func (l *AWSInfrastructureAccessRoleList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *AWSInfrastructureAccessRoleList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AWSInfrastructureAccessRoleList) Get(i int) *AWSInfrastructureAccessRole {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AWSInfrastructureAccessRoleList) Slice() []*AWSInfrastructureAccessRole {
+	var slice []*AWSInfrastructureAccessRole
+	if l == nil {
+		slice = make([]*AWSInfrastructureAccessRole, 0)
+	} else {
+		slice = make([]*AWSInfrastructureAccessRole, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AWSInfrastructureAccessRoleList) Each(f func(item *AWSInfrastructureAccessRole) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AWSInfrastructureAccessRoleList) Range(f func(index int, item *AWSInfrastructureAccessRole) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
@@ -1,0 +1,370 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// AWSInfrastructureAccessRolesClient is the client of the 'AWS_infrastructure_access_roles' resource.
+//
+// Manages the collection of aws infrastructure access roles.
+type AWSInfrastructureAccessRolesClient struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+}
+
+// NewAWSInfrastructureAccessRolesClient creates a new client for the 'AWS_infrastructure_access_roles'
+// resource using the given transport to sned the requests and receive the
+// responses.
+func NewAWSInfrastructureAccessRolesClient(transport http.RoundTripper, path string, metric string) *AWSInfrastructureAccessRolesClient {
+	client := new(AWSInfrastructureAccessRolesClient)
+	client.transport = transport
+	client.path = path
+	client.metric = metric
+	return client
+}
+
+// List creates a request for the 'list' method.
+//
+//
+func (c *AWSInfrastructureAccessRolesClient) List() *AWSInfrastructureAccessRolesListRequest {
+	request := new(AWSInfrastructureAccessRolesListRequest)
+	request.transport = c.transport
+	request.path = c.path
+	request.metric = c.metric
+	return request
+}
+
+// AWSInfrastructureAccessRole returns the target 'AWS_infrastructure_access_role' resource for the given identifier.
+//
+// Reference to the resource that manages a specific role.
+func (c *AWSInfrastructureAccessRolesClient) AWSInfrastructureAccessRole(id string) *AWSInfrastructureAccessRoleClient {
+	return NewAWSInfrastructureAccessRoleClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
+}
+
+// AWSInfrastructureAccessRolesListRequest is the request for the 'list' method.
+type AWSInfrastructureAccessRolesListRequest struct {
+	transport http.RoundTripper
+	path      string
+	metric    string
+	query     url.Values
+	header    http.Header
+	order     *string
+	page      *int
+	search    *string
+	size      *int
+}
+
+// Parameter adds a query parameter.
+func (r *AWSInfrastructureAccessRolesListRequest) Parameter(name string, value interface{}) *AWSInfrastructureAccessRolesListRequest {
+	helpers.AddValue(&r.query, name, value)
+	return r
+}
+
+// Header adds a request header.
+func (r *AWSInfrastructureAccessRolesListRequest) Header(name string, value interface{}) *AWSInfrastructureAccessRolesListRequest {
+	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Order sets the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the role instead of
+// the names of the columns of a table. For example, in order to sort the roles
+// descending by dislay_name the value should be:
+//
+// [source,sql]
+// ----
+// display_name desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *AWSInfrastructureAccessRolesListRequest) Order(value string) *AWSInfrastructureAccessRolesListRequest {
+	r.order = &value
+	return r
+}
+
+// Page sets the value of the 'page' parameter.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *AWSInfrastructureAccessRolesListRequest) Page(value int) *AWSInfrastructureAccessRolesListRequest {
+	r.page = &value
+	return r
+}
+
+// Search sets the value of the 'search' parameter.
+//
+// Search criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// SQL statement, but using the names of the attributes of the role instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// role with a name starting with `my`the value should be:
+//
+// [source,sql]
+// ----
+// display_name like 'my%'
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then all the roles
+// that the user has permission to see will be returned.
+func (r *AWSInfrastructureAccessRolesListRequest) Search(value string) *AWSInfrastructureAccessRolesListRequest {
+	r.search = &value
+	return r
+}
+
+// Size sets the value of the 'size' parameter.
+//
+// Maximum number of items that will be contained in the returned page.
+func (r *AWSInfrastructureAccessRolesListRequest) Size(value int) *AWSInfrastructureAccessRolesListRequest {
+	r.size = &value
+	return r
+}
+
+// Send sends this request, waits for the response, and returns it.
+//
+// This is a potentially lengthy operation, as it requires network communication.
+// Consider using a context and the SendContext method.
+func (r *AWSInfrastructureAccessRolesListRequest) Send() (result *AWSInfrastructureAccessRolesListResponse, err error) {
+	return r.SendContext(context.Background())
+}
+
+// SendContext sends this request, waits for the response, and returns it.
+func (r *AWSInfrastructureAccessRolesListRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRolesListResponse, err error) {
+	query := helpers.CopyQuery(r.query)
+	if r.order != nil {
+		helpers.AddValue(&query, "order", *r.order)
+	}
+	if r.page != nil {
+		helpers.AddValue(&query, "page", *r.page)
+	}
+	if r.search != nil {
+		helpers.AddValue(&query, "search", *r.search)
+	}
+	if r.size != nil {
+		helpers.AddValue(&query, "size", *r.size)
+	}
+	header := helpers.SetHeader(r.header, r.metric)
+	uri := &url.URL{
+		Path:     r.path,
+		RawQuery: query.Encode(),
+	}
+	request := &http.Request{
+		Method: "GET",
+		URL:    uri,
+		Header: header,
+	}
+	if ctx != nil {
+		request = request.WithContext(ctx)
+	}
+	response, err := r.transport.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result = new(AWSInfrastructureAccessRolesListResponse)
+	result.status = response.StatusCode
+	result.header = response.Header
+	if result.status >= 400 {
+		result.err, err = errors.UnmarshalError(response.Body)
+		if err != nil {
+			return
+		}
+		err = result.err
+		return
+	}
+	err = result.unmarshal(response.Body)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// AWSInfrastructureAccessRolesListResponse is the response for the 'list' method.
+type AWSInfrastructureAccessRolesListResponse struct {
+	status int
+	header http.Header
+	err    *errors.Error
+	items  *AWSInfrastructureAccessRoleList
+	page   *int
+	size   *int
+	total  *int
+}
+
+// Status returns the response status code.
+func (r *AWSInfrastructureAccessRolesListResponse) Status() int {
+	if r == nil {
+		return 0
+	}
+	return r.status
+}
+
+// Header returns header of the response.
+func (r *AWSInfrastructureAccessRolesListResponse) Header() http.Header {
+	if r == nil {
+		return nil
+	}
+	return r.header
+}
+
+// Error returns the response error.
+func (r *AWSInfrastructureAccessRolesListResponse) Error() *errors.Error {
+	if r == nil {
+		return nil
+	}
+	return r.err
+}
+
+// Items returns the value of the 'items' parameter.
+//
+// Retrieved list of roles.
+func (r *AWSInfrastructureAccessRolesListResponse) Items() *AWSInfrastructureAccessRoleList {
+	if r == nil {
+		return nil
+	}
+	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of roles.
+func (r *AWSInfrastructureAccessRolesListResponse) GetItems() (value *AWSInfrastructureAccessRoleList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
+}
+
+// Page returns the value of the 'page' parameter.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *AWSInfrastructureAccessRolesListResponse) Page() int {
+	if r != nil && r.page != nil {
+		return *r.page
+	}
+	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *AWSInfrastructureAccessRolesListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
+}
+
+// Size returns the value of the 'size' parameter.
+//
+// Maximum number of items that will be contained in the returned page.
+func (r *AWSInfrastructureAccessRolesListResponse) Size() int {
+	if r != nil && r.size != nil {
+		return *r.size
+	}
+	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+func (r *AWSInfrastructureAccessRolesListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
+}
+
+// Total returns the value of the 'total' parameter.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *AWSInfrastructureAccessRolesListResponse) Total() int {
+	if r != nil && r.total != nil {
+		return *r.total
+	}
+	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *AWSInfrastructureAccessRolesListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
+}
+
+// unmarshal is the method used internally to unmarshal responses to the
+// 'list' method.
+func (r *AWSInfrastructureAccessRolesListResponse) unmarshal(reader io.Reader) error {
+	var err error
+	decoder := json.NewDecoder(reader)
+	data := new(awsInfrastructureAccessRolesListResponseData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	r.items, err = data.Items.unwrap()
+	if err != nil {
+		return err
+	}
+	r.page = data.Page
+	r.size = data.Size
+	r.total = data.Total
+	return err
+}
+
+// awsInfrastructureAccessRolesListResponseData is the structure used internally to unmarshal
+// the response of the 'list' method.
+type awsInfrastructureAccessRolesListResponseData struct {
+	Items awsInfrastructureAccessRoleListData "json:\"items,omitempty\""
+	Page  *int                                "json:\"page,omitempty\""
+	Size  *int                                "json:\"size,omitempty\""
+	Total *int                                "json:\"total,omitempty\""
+}

--- a/clustersmgmt/v1/aws_infrastructure_access_roles_server.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_roles_server.go
@@ -1,0 +1,370 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// AWSInfrastructureAccessRolesServer represents the interface the manages the 'AWS_infrastructure_access_roles' resource.
+type AWSInfrastructureAccessRolesServer interface {
+
+	// List handles a request for the 'list' method.
+	//
+	//
+	List(ctx context.Context, request *AWSInfrastructureAccessRolesListServerRequest, response *AWSInfrastructureAccessRolesListServerResponse) error
+
+	// AWSInfrastructureAccessRole returns the target 'AWS_infrastructure_access_role' server for the given identifier.
+	//
+	// Reference to the resource that manages a specific role.
+	AWSInfrastructureAccessRole(id string) AWSInfrastructureAccessRoleServer
+}
+
+// AWSInfrastructureAccessRolesListServerRequest is the request for the 'list' method.
+type AWSInfrastructureAccessRolesListServerRequest struct {
+	order  *string
+	page   *int
+	search *string
+	size   *int
+}
+
+// Order returns the value of the 'order' parameter.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the role instead of
+// the names of the columns of a table. For example, in order to sort the roles
+// descending by dislay_name the value should be:
+//
+// [source,sql]
+// ----
+// display_name desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *AWSInfrastructureAccessRolesListServerRequest) Order() string {
+	if r != nil && r.order != nil {
+		return *r.order
+	}
+	return ""
+}
+
+// GetOrder returns the value of the 'order' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Order criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+// a SQL statement, but using the names of the attributes of the role instead of
+// the names of the columns of a table. For example, in order to sort the roles
+// descending by dislay_name the value should be:
+//
+// [source,sql]
+// ----
+// display_name desc
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then the order of the
+// results is undefined.
+func (r *AWSInfrastructureAccessRolesListServerRequest) GetOrder() (value string, ok bool) {
+	ok = r != nil && r.order != nil
+	if ok {
+		value = *r.order
+	}
+	return
+}
+
+// Page returns the value of the 'page' parameter.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *AWSInfrastructureAccessRolesListServerRequest) Page() int {
+	if r != nil && r.page != nil {
+		return *r.page
+	}
+	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *AWSInfrastructureAccessRolesListServerRequest) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
+}
+
+// Search returns the value of the 'search' parameter.
+//
+// Search criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// SQL statement, but using the names of the attributes of the role instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// role with a name starting with `my`the value should be:
+//
+// [source,sql]
+// ----
+// display_name like 'my%'
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then all the roles
+// that the user has permission to see will be returned.
+func (r *AWSInfrastructureAccessRolesListServerRequest) Search() string {
+	if r != nil && r.search != nil {
+		return *r.search
+	}
+	return ""
+}
+
+// GetSearch returns the value of the 'search' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Search criteria.
+//
+// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+// SQL statement, but using the names of the attributes of the role instead of
+// the names of the columns of a table. For example, in order to retrieve all the
+// role with a name starting with `my`the value should be:
+//
+// [source,sql]
+// ----
+// display_name like 'my%'
+// ----
+//
+// If the parameter isn't provided, or if the value is empty, then all the roles
+// that the user has permission to see will be returned.
+func (r *AWSInfrastructureAccessRolesListServerRequest) GetSearch() (value string, ok bool) {
+	ok = r != nil && r.search != nil
+	if ok {
+		value = *r.search
+	}
+	return
+}
+
+// Size returns the value of the 'size' parameter.
+//
+// Maximum number of items that will be contained in the returned page.
+func (r *AWSInfrastructureAccessRolesListServerRequest) Size() int {
+	if r != nil && r.size != nil {
+		return *r.size
+	}
+	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+func (r *AWSInfrastructureAccessRolesListServerRequest) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
+}
+
+// AWSInfrastructureAccessRolesListServerResponse is the response for the 'list' method.
+type AWSInfrastructureAccessRolesListServerResponse struct {
+	status int
+	err    *errors.Error
+	items  *AWSInfrastructureAccessRoleList
+	page   *int
+	size   *int
+	total  *int
+}
+
+// Items sets the value of the 'items' parameter.
+//
+// Retrieved list of roles.
+func (r *AWSInfrastructureAccessRolesListServerResponse) Items(value *AWSInfrastructureAccessRoleList) *AWSInfrastructureAccessRolesListServerResponse {
+	r.items = value
+	return r
+}
+
+// Page sets the value of the 'page' parameter.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *AWSInfrastructureAccessRolesListServerResponse) Page(value int) *AWSInfrastructureAccessRolesListServerResponse {
+	r.page = &value
+	return r
+}
+
+// Size sets the value of the 'size' parameter.
+//
+// Maximum number of items that will be contained in the returned page.
+func (r *AWSInfrastructureAccessRolesListServerResponse) Size(value int) *AWSInfrastructureAccessRolesListServerResponse {
+	r.size = &value
+	return r
+}
+
+// Total sets the value of the 'total' parameter.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *AWSInfrastructureAccessRolesListServerResponse) Total(value int) *AWSInfrastructureAccessRolesListServerResponse {
+	r.total = &value
+	return r
+}
+
+// Status sets the status code.
+func (r *AWSInfrastructureAccessRolesListServerResponse) Status(value int) *AWSInfrastructureAccessRolesListServerResponse {
+	r.status = value
+	return r
+}
+
+// marshall is the method used internally to marshal responses for the
+// 'list' method.
+func (r *AWSInfrastructureAccessRolesListServerResponse) marshal(writer io.Writer) error {
+	var err error
+	encoder := json.NewEncoder(writer)
+	data := new(awsInfrastructureAccessRolesListServerResponseData)
+	data.Items, err = r.items.wrap()
+	if err != nil {
+		return err
+	}
+	data.Page = r.page
+	data.Size = r.size
+	data.Total = r.total
+	err = encoder.Encode(data)
+	return err
+}
+
+// awsInfrastructureAccessRolesListServerResponseData is the structure used internally to write the request of the
+// 'list' method.
+type awsInfrastructureAccessRolesListServerResponseData struct {
+	Items awsInfrastructureAccessRoleListData "json:\"items,omitempty\""
+	Page  *int                                "json:\"page,omitempty\""
+	Size  *int                                "json:\"size,omitempty\""
+	Total *int                                "json:\"total,omitempty\""
+}
+
+// dispatchAWSInfrastructureAccessRoles navigates the servers tree rooted at the given server
+// till it finds one that matches the given set of path segments, and then invokes
+// the corresponding server.
+func dispatchAWSInfrastructureAccessRoles(w http.ResponseWriter, r *http.Request, server AWSInfrastructureAccessRolesServer, segments []string) {
+	if len(segments) == 0 {
+		switch r.Method {
+		case "GET":
+			adaptAWSInfrastructureAccessRolesListRequest(w, r, server)
+		default:
+			errors.SendMethodNotAllowed(w, r)
+			return
+		}
+	} else {
+		switch segments[0] {
+		default:
+			target := server.AWSInfrastructureAccessRole(segments[0])
+			if target == nil {
+				errors.SendNotFound(w, r)
+				return
+			}
+			dispatchAWSInfrastructureAccessRole(w, r, target, segments[1:])
+		}
+	}
+}
+
+// readAWSInfrastructureAccessRolesListRequest reads the given HTTP requests and translates it
+// into an object of type AWSInfrastructureAccessRolesListServerRequest.
+func readAWSInfrastructureAccessRolesListRequest(r *http.Request) (*AWSInfrastructureAccessRolesListServerRequest, error) {
+	var err error
+	result := new(AWSInfrastructureAccessRolesListServerRequest)
+	query := r.URL.Query()
+	result.order, err = helpers.ParseString(query, "order")
+	if err != nil {
+		return nil, err
+	}
+	result.page, err = helpers.ParseInteger(query, "page")
+	if err != nil {
+		return nil, err
+	}
+	if result.page == nil {
+		result.page = helpers.NewInteger(1)
+	}
+	result.search, err = helpers.ParseString(query, "search")
+	if err != nil {
+		return nil, err
+	}
+	result.size, err = helpers.ParseInteger(query, "size")
+	if err != nil {
+		return nil, err
+	}
+	if result.size == nil {
+		result.size = helpers.NewInteger(100)
+	}
+	return result, err
+}
+
+// writeAWSInfrastructureAccessRolesListResponse translates the given request object into an
+// HTTP response.
+func writeAWSInfrastructureAccessRolesListResponse(w http.ResponseWriter, r *AWSInfrastructureAccessRolesListServerResponse) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(r.status)
+	err := r.marshal(w)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// adaptAWSInfrastructureAccessRolesListRequest translates the given HTTP request into a call to
+// the corresponding method of the given server. Then it translates the
+// results returned by that method into an HTTP response.
+func adaptAWSInfrastructureAccessRolesListRequest(w http.ResponseWriter, r *http.Request, server AWSInfrastructureAccessRolesServer) {
+	request, err := readAWSInfrastructureAccessRolesListRequest(r)
+	if err != nil {
+		glog.Errorf(
+			"Can't read request for method '%s' and path '%s': %v",
+			r.Method, r.URL.Path, err,
+		)
+		errors.SendInternalServerError(w, r)
+		return
+	}
+	response := new(AWSInfrastructureAccessRolesListServerResponse)
+	response.status = 200
+	err = server.List(r.Context(), request, response)
+	if err != nil {
+		glog.Errorf(
+			"Can't process request for method '%s' and path '%s': %v",
+			r.Method, r.URL.Path, err,
+		)
+		errors.SendInternalServerError(w, r)
+		return
+	}
+	err = writeAWSInfrastructureAccessRolesListResponse(w, response)
+	if err != nil {
+		glog.Errorf(
+			"Can't write response for method '%s' and path '%s': %v",
+			r.Method, r.URL.Path, err,
+		)
+		return
+	}
+}

--- a/clustersmgmt/v1/gcp_flavour_builder.go
+++ b/clustersmgmt/v1/gcp_flavour_builder.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+// GCPFlavourBuilder contains the data and logic needed to build 'GCP_flavour' objects.
+//
+// Specification for different classes of nodes inside a flavour.
+type GCPFlavourBuilder struct {
+	computeInstanceType *string
+	infraInstanceType   *string
+	masterInstanceType  *string
+}
+
+// NewGCPFlavour creates a new builder of 'GCP_flavour' objects.
+func NewGCPFlavour() *GCPFlavourBuilder {
+	return new(GCPFlavourBuilder)
+}
+
+// ComputeInstanceType sets the value of the 'compute_instance_type' attribute
+// to the given value.
+//
+//
+func (b *GCPFlavourBuilder) ComputeInstanceType(value string) *GCPFlavourBuilder {
+	b.computeInstanceType = &value
+	return b
+}
+
+// InfraInstanceType sets the value of the 'infra_instance_type' attribute
+// to the given value.
+//
+//
+func (b *GCPFlavourBuilder) InfraInstanceType(value string) *GCPFlavourBuilder {
+	b.infraInstanceType = &value
+	return b
+}
+
+// MasterInstanceType sets the value of the 'master_instance_type' attribute
+// to the given value.
+//
+//
+func (b *GCPFlavourBuilder) MasterInstanceType(value string) *GCPFlavourBuilder {
+	b.masterInstanceType = &value
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GCPFlavourBuilder) Copy(object *GCPFlavour) *GCPFlavourBuilder {
+	if object == nil {
+		return b
+	}
+	b.computeInstanceType = object.computeInstanceType
+	b.infraInstanceType = object.infraInstanceType
+	b.masterInstanceType = object.masterInstanceType
+	return b
+}
+
+// Build creates a 'GCP_flavour' object using the configuration stored in the builder.
+func (b *GCPFlavourBuilder) Build() (object *GCPFlavour, err error) {
+	object = new(GCPFlavour)
+	if b.computeInstanceType != nil {
+		object.computeInstanceType = b.computeInstanceType
+	}
+	if b.infraInstanceType != nil {
+		object.infraInstanceType = b.infraInstanceType
+	}
+	if b.masterInstanceType != nil {
+		object.masterInstanceType = b.masterInstanceType
+	}
+	return
+}

--- a/clustersmgmt/v1/gcp_flavour_list_builder.go
+++ b/clustersmgmt/v1/gcp_flavour_list_builder.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+// GCPFlavourListBuilder contains the data and logic needed to build
+// 'GCP_flavour' objects.
+type GCPFlavourListBuilder struct {
+	items []*GCPFlavourBuilder
+}
+
+// NewGCPFlavourList creates a new builder of 'GCP_flavour' objects.
+func NewGCPFlavourList() *GCPFlavourListBuilder {
+	return new(GCPFlavourListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GCPFlavourListBuilder) Items(values ...*GCPFlavourBuilder) *GCPFlavourListBuilder {
+	b.items = make([]*GCPFlavourBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Build creates a list of 'GCP_flavour' objects using the
+// configuration stored in the builder.
+func (b *GCPFlavourListBuilder) Build() (list *GCPFlavourList, err error) {
+	items := make([]*GCPFlavour, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GCPFlavourList)
+	list.items = items
+	return
+}

--- a/clustersmgmt/v1/gcp_flavour_list_reader.go
+++ b/clustersmgmt/v1/gcp_flavour_list_reader.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// gcpFlavourListData is type used internally to marshal and unmarshal lists of objects
+// of type 'GCP_flavour'.
+type gcpFlavourListData []*gcpFlavourData
+
+// UnmarshalGCPFlavourList reads a list of values of the 'GCP_flavour'
+// from the given source, which can be a slice of bytes, a string, an io.Reader or a
+// json.Decoder.
+func UnmarshalGCPFlavourList(source interface{}) (list *GCPFlavourList, err error) {
+	decoder, err := helpers.NewDecoder(source)
+	if err != nil {
+		return
+	}
+	var data gcpFlavourListData
+	err = decoder.Decode(&data)
+	if err != nil {
+		return
+	}
+	list, err = data.unwrap()
+	return
+}
+
+// wrap is the method used internally to convert a list of values of the
+// 'GCP_flavour' value to a JSON document.
+func (l *GCPFlavourList) wrap() (data gcpFlavourListData, err error) {
+	if l == nil {
+		return
+	}
+	data = make(gcpFlavourListData, len(l.items))
+	for i, item := range l.items {
+		data[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// unwrap is the function used internally to convert the JSON unmarshalled data to a
+// list of values of the 'GCP_flavour' type.
+func (d gcpFlavourListData) unwrap() (list *GCPFlavourList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*GCPFlavour, len(d))
+	for i, item := range d {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GCPFlavourList)
+	list.items = items
+	return
+}

--- a/clustersmgmt/v1/gcp_flavour_reader.go
+++ b/clustersmgmt/v1/gcp_flavour_reader.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+import (
+	"github.com/openshift-online/ocm-sdk-go/helpers"
+)
+
+// gcpFlavourData is the data structure used internally to marshal and unmarshal
+// objects of type 'GCP_flavour'.
+type gcpFlavourData struct {
+	ComputeInstanceType *string "json:\"compute_instance_type,omitempty\""
+	InfraInstanceType   *string "json:\"infra_instance_type,omitempty\""
+	MasterInstanceType  *string "json:\"master_instance_type,omitempty\""
+}
+
+// MarshalGCPFlavour writes a value of the 'GCP_flavour' to the given target,
+// which can be a writer or a JSON encoder.
+func MarshalGCPFlavour(object *GCPFlavour, target interface{}) error {
+	encoder, err := helpers.NewEncoder(target)
+	if err != nil {
+		return err
+	}
+	data, err := object.wrap()
+	if err != nil {
+		return err
+	}
+	return encoder.Encode(data)
+}
+
+// wrap is the method used internally to convert a value of the 'GCP_flavour'
+// value to a JSON document.
+func (o *GCPFlavour) wrap() (data *gcpFlavourData, err error) {
+	if o == nil {
+		return
+	}
+	data = new(gcpFlavourData)
+	data.ComputeInstanceType = o.computeInstanceType
+	data.InfraInstanceType = o.infraInstanceType
+	data.MasterInstanceType = o.masterInstanceType
+	return
+}
+
+// UnmarshalGCPFlavour reads a value of the 'GCP_flavour' type from the given
+// source, which can be an slice of bytes, a string, a reader or a JSON decoder.
+func UnmarshalGCPFlavour(source interface{}) (object *GCPFlavour, err error) {
+	decoder, err := helpers.NewDecoder(source)
+	if err != nil {
+		return
+	}
+	data := new(gcpFlavourData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return
+	}
+	object, err = data.unwrap()
+	return
+}
+
+// unwrap is the function used internally to convert the JSON unmarshalled data to a
+// value of the 'GCP_flavour' type.
+func (d *gcpFlavourData) unwrap() (object *GCPFlavour, err error) {
+	if d == nil {
+		return
+	}
+	object = new(GCPFlavour)
+	object.computeInstanceType = d.ComputeInstanceType
+	object.infraInstanceType = d.InfraInstanceType
+	object.masterInstanceType = d.MasterInstanceType
+	return
+}

--- a/clustersmgmt/v1/gcp_flavour_type.go
+++ b/clustersmgmt/v1/gcp_flavour_type.go
@@ -1,0 +1,182 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
+
+// GCPFlavour represents the values of the 'GCP_flavour' type.
+//
+// Specification for different classes of nodes inside a flavour.
+type GCPFlavour struct {
+	computeInstanceType *string
+	infraInstanceType   *string
+	masterInstanceType  *string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GCPFlavour) Empty() bool {
+	return o == nil || (o.computeInstanceType == nil &&
+		o.infraInstanceType == nil &&
+		o.masterInstanceType == nil &&
+		true)
+}
+
+// ComputeInstanceType returns the value of the 'compute_instance_type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// GCP default instance type for the worker volume.
+//
+// User can be overridden specifying in the cluster itself a type for compute node.
+func (o *GCPFlavour) ComputeInstanceType() string {
+	if o != nil && o.computeInstanceType != nil {
+		return *o.computeInstanceType
+	}
+	return ""
+}
+
+// GetComputeInstanceType returns the value of the 'compute_instance_type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// GCP default instance type for the worker volume.
+//
+// User can be overridden specifying in the cluster itself a type for compute node.
+func (o *GCPFlavour) GetComputeInstanceType() (value string, ok bool) {
+	ok = o != nil && o.computeInstanceType != nil
+	if ok {
+		value = *o.computeInstanceType
+	}
+	return
+}
+
+// InfraInstanceType returns the value of the 'infra_instance_type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// GCP default instance type for the infra volume.
+func (o *GCPFlavour) InfraInstanceType() string {
+	if o != nil && o.infraInstanceType != nil {
+		return *o.infraInstanceType
+	}
+	return ""
+}
+
+// GetInfraInstanceType returns the value of the 'infra_instance_type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// GCP default instance type for the infra volume.
+func (o *GCPFlavour) GetInfraInstanceType() (value string, ok bool) {
+	ok = o != nil && o.infraInstanceType != nil
+	if ok {
+		value = *o.infraInstanceType
+	}
+	return
+}
+
+// MasterInstanceType returns the value of the 'master_instance_type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// GCP default instance type for the master volume.
+func (o *GCPFlavour) MasterInstanceType() string {
+	if o != nil && o.masterInstanceType != nil {
+		return *o.masterInstanceType
+	}
+	return ""
+}
+
+// GetMasterInstanceType returns the value of the 'master_instance_type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// GCP default instance type for the master volume.
+func (o *GCPFlavour) GetMasterInstanceType() (value string, ok bool) {
+	ok = o != nil && o.masterInstanceType != nil
+	if ok {
+		value = *o.masterInstanceType
+	}
+	return
+}
+
+// GCPFlavourList is a list of values of the 'GCP_flavour' type.
+type GCPFlavourList struct {
+	items []*GCPFlavour
+}
+
+// Len returns the length of the list.
+func (l *GCPFlavourList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *GCPFlavourList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GCPFlavourList) Get(i int) *GCPFlavour {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GCPFlavourList) Slice() []*GCPFlavour {
+	var slice []*GCPFlavour
+	if l == nil {
+		slice = make([]*GCPFlavour, 0)
+	} else {
+		slice = make([]*GCPFlavour, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GCPFlavourList) Each(f func(item *GCPFlavour) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GCPFlavourList) Range(f func(index int, item *GCPFlavour) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.36:
  - Add types and resources for AWS infrastructure access roles.
  - Add GCP flavour and change AWS flavour to contain also the instance type.