### PR TITLE
Release 0.1.77

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,13 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.77 Jan 8 2020
+
+- Don't require Go 1.13.
+- Update to model 0.0.37:
+** Add new `service_logs` service.
+** Add types and resources for machine types.
+
 == 0.1.76 Jan 3 2020
 
 - Update to model 0.0.36:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.75"
+const Version = "0.1.77"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Don't require Go 1.13.
- Update to model 0.0.37:
** Add new `service_logs` service.
** Add types and resources for machine types.