### PR TITLE
Release 0.1.78

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.78 Jan 8 2020
+
+- Fix URL prefix for the logs service.
+- Update to metamodel 0.0.21:
+** Use JSON iterator instead of the default JSON Go package.
+
 == 0.1.77 Jan 8 2020
 
 - Don't require Go 1.13.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.77"
+const Version = "0.1.78"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fix URL prefix for the logs service.
- Update to metamodel 0.0.21:
  - Use JSON iterator instead of the default JSON Go package.