### PR TITLE
Release 0.1.79

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.79 Jan 9 2020
+
+- Update to metamodel 0.0.22:
+** Fix generation of _OpenAPI_ paths so that all the characters are lower case.
+
 == 0.1.78 Jan 8 2020
 
 - Fix URL prefix for the logs service.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.78"
+const Version = "0.1.79"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.22:
  - Fix generation of _OpenAPI_ paths so that all the characters are lower case.