### PR TITLE
Add body details in case of error from token provider

### DIFF
--- a/token.go
+++ b/token.go
@@ -284,11 +284,6 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	}
 
 	// Check the response status and content type:
-	code = response.StatusCode
-	if response.StatusCode != http.StatusOK {
-		err = fmt.Errorf("token response status is: %s", response.Status)
-		return
-	}
 	header = response.Header
 	content := header.Get("Content-Type")
 	if content != "application/json" {
@@ -309,6 +304,10 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 			return
 		}
 		err = fmt.Errorf("%s", *msg.Error)
+		return
+	}
+	if response.StatusCode != http.StatusOK {
+		err = fmt.Errorf("token response status is: %s", response.Status)
 		return
 	}
 	if msg.TokenType != nil && *msg.TokenType != "bearer" {


### PR DESCRIPTION
We see from time to time 400 bad request returning but we do not print the error reason.
This PR should handle it by only catching the 5xx errors at first, and in case of other errors, it will be handled later in the flow.

@jhernand @nimrodshn @vkareh PTAL