### PR TITLE
check non-json response and return error

### DIFF
--- a/send.go
+++ b/send.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -189,5 +190,41 @@ func (c *Connection) send(ctx context.Context, request *http.Request) (response 
 		}
 	}
 
+	// check if json
+	if !strings.EqualFold(response.Header.Get("Content-Type"), "application/json") {
+		err = fmt.Errorf("expected JSON content type but received '%s'; %s",
+			response.Header.Get("Content-Type"),
+			getResponseInfo(response))
+		return
+	}
+
 	return
+}
+
+func getResponseInfo(response *http.Response) string {
+	info := fmt.Sprintf("request: %s %s; response status: %d %s",
+		response.Request.Method,
+		response.Request.URL,
+		response.StatusCode,
+		response.Status,
+	)
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		info = fmt.Sprintf("%s; can't read response body: %v", info, err)
+		return info
+	}
+	err = response.Body.Close()
+	if err != nil {
+		info = fmt.Sprintf("%s; can't close response body: %v", info, err)
+		return info
+	}
+	response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	bodyStr := []rune(string(body))
+	if len(bodyStr) > 200 {
+		bodyStr = bodyStr[:200]
+	}
+	info = fmt.Sprintf("%s; response body: %s", info, string(bodyStr))
+	return info
 }


### PR DESCRIPTION
@jhernand @cben pls review.

- check if `content-type` is not `application/json`, raise error so the response is not parsed by clients;
- the error contains some context info so can be logged by client code; (response body is limited to 200 chars)

error example,
```
expected JSON content type but received 'application/html'; request: GET http://127.0.0.1:42469/mypath; response status: 200 200 OK; response body: <textarea class="Playground-input js-playgroundCodeEl" spellcheck="false" aria-label="Try Go">// You can edit this code! // Click here and start typing. package main import "fmt" func main() { fmt.Pri
```