### PR TITLE
Update to metamodel 0.0.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ model_version:=v0.0.41
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.23
+metamodel_version:=v0.0.24
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples

--- a/accountsmgmt/v1/accounts_resource_json.go
+++ b/accountsmgmt/v1/accounts_resource_json.go
@@ -104,6 +104,8 @@ func readAccountsListResponse(response *AccountsListResponse, reader io.Reader) 
 	return iterator.Error
 }
 func writeAccountsListResponse(response *AccountsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/current_access_resource_json.go
+++ b/accountsmgmt/v1/current_access_resource_json.go
@@ -80,6 +80,8 @@ func readCurrentAccessListResponse(response *CurrentAccessListResponse, reader i
 	return iterator.Error
 }
 func writeCurrentAccessListResponse(response *CurrentAccessListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/organizations_resource_json.go
+++ b/accountsmgmt/v1/organizations_resource_json.go
@@ -100,6 +100,8 @@ func readOrganizationsListResponse(response *OrganizationsListResponse, reader i
 	return iterator.Error
 }
 func writeOrganizationsListResponse(response *OrganizationsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/permissions_resource_json.go
+++ b/accountsmgmt/v1/permissions_resource_json.go
@@ -96,6 +96,8 @@ func readPermissionsListResponse(response *PermissionsListResponse, reader io.Re
 	return iterator.Error
 }
 func writePermissionsListResponse(response *PermissionsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/quota_summary_resource_json.go
+++ b/accountsmgmt/v1/quota_summary_resource_json.go
@@ -84,6 +84,8 @@ func readQuotaSummaryListResponse(response *QuotaSummaryListResponse, reader io.
 	return iterator.Error
 }
 func writeQuotaSummaryListResponse(response *QuotaSummaryListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/registries_resource_json.go
+++ b/accountsmgmt/v1/registries_resource_json.go
@@ -80,6 +80,8 @@ func readRegistriesListResponse(response *RegistriesListResponse, reader io.Read
 	return iterator.Error
 }
 func writeRegistriesListResponse(response *RegistriesListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/registry_credentials_resource_json.go
+++ b/accountsmgmt/v1/registry_credentials_resource_json.go
@@ -104,6 +104,8 @@ func readRegistryCredentialsListResponse(response *RegistryCredentialsListRespon
 	return iterator.Error
 }
 func writeRegistryCredentialsListResponse(response *RegistryCredentialsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/resource_quotas_resource_json.go
+++ b/accountsmgmt/v1/resource_quotas_resource_json.go
@@ -100,6 +100,8 @@ func readResourceQuotasListResponse(response *ResourceQuotasListResponse, reader
 	return iterator.Error
 }
 func writeResourceQuotasListResponse(response *ResourceQuotasListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/role_bindings_resource_json.go
+++ b/accountsmgmt/v1/role_bindings_resource_json.go
@@ -100,6 +100,8 @@ func readRoleBindingsListResponse(response *RoleBindingsListResponse, reader io.
 	return iterator.Error
 }
 func writeRoleBindingsListResponse(response *RoleBindingsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/roles_resource_json.go
+++ b/accountsmgmt/v1/roles_resource_json.go
@@ -100,6 +100,8 @@ func readRolesListResponse(response *RolesListResponse, reader io.Reader) error 
 	return iterator.Error
 }
 func writeRolesListResponse(response *RolesListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/skus_resource_json.go
+++ b/accountsmgmt/v1/skus_resource_json.go
@@ -84,6 +84,8 @@ func readSKUSListResponse(response *SKUSListResponse, reader io.Reader) error {
 	return iterator.Error
 }
 func writeSKUSListResponse(response *SKUSListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/subscription_reserved_resources_resource_json.go
+++ b/accountsmgmt/v1/subscription_reserved_resources_resource_json.go
@@ -80,6 +80,8 @@ func readSubscriptionReservedResourcesListResponse(response *SubscriptionReserve
 	return iterator.Error
 }
 func writeSubscriptionReservedResourcesListResponse(response *SubscriptionReservedResourcesListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/accountsmgmt/v1/subscriptions_resource_json.go
+++ b/accountsmgmt/v1/subscriptions_resource_json.go
@@ -92,6 +92,8 @@ func readSubscriptionsListResponse(response *SubscriptionsListResponse, reader i
 	return iterator.Error
 }
 func writeSubscriptionsListResponse(response *SubscriptionsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/add_on_installations_resource_json.go
+++ b/clustersmgmt/v1/add_on_installations_resource_json.go
@@ -104,6 +104,8 @@ func readAddOnInstallationsListResponse(response *AddOnInstallationsListResponse
 	return iterator.Error
 }
 func writeAddOnInstallationsListResponse(response *AddOnInstallationsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/add_ons_resource_json.go
+++ b/clustersmgmt/v1/add_ons_resource_json.go
@@ -104,6 +104,8 @@ func readAddOnsListResponse(response *AddOnsListResponse, reader io.Reader) erro
 	return iterator.Error
 }
 func writeAddOnsListResponse(response *AddOnsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grants_resource_json.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grants_resource_json.go
@@ -104,6 +104,8 @@ func readAWSInfrastructureAccessRoleGrantsListResponse(response *AWSInfrastructu
 	return iterator.Error
 }
 func writeAWSInfrastructureAccessRoleGrantsListResponse(response *AWSInfrastructureAccessRoleGrantsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/aws_infrastructure_access_roles_resource_json.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_roles_resource_json.go
@@ -88,6 +88,8 @@ func readAWSInfrastructureAccessRolesListResponse(response *AWSInfrastructureAcc
 	return iterator.Error
 }
 func writeAWSInfrastructureAccessRolesListResponse(response *AWSInfrastructureAccessRolesListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/cloud_providers_resource_json.go
+++ b/clustersmgmt/v1/cloud_providers_resource_json.go
@@ -88,6 +88,8 @@ func readCloudProvidersListResponse(response *CloudProvidersListResponse, reader
 	return iterator.Error
 }
 func writeCloudProvidersListResponse(response *CloudProvidersListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/cloud_regions_resource_json.go
+++ b/clustersmgmt/v1/cloud_regions_resource_json.go
@@ -80,6 +80,8 @@ func readCloudRegionsListResponse(response *CloudRegionsListResponse, reader io.
 	return iterator.Error
 }
 func writeCloudRegionsListResponse(response *CloudRegionsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/clusters_resource_json.go
+++ b/clustersmgmt/v1/clusters_resource_json.go
@@ -104,6 +104,8 @@ func readClustersListResponse(response *ClustersListResponse, reader io.Reader) 
 	return iterator.Error
 }
 func writeClustersListResponse(response *ClustersListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/dashboards_resource_json.go
+++ b/clustersmgmt/v1/dashboards_resource_json.go
@@ -88,6 +88,8 @@ func readDashboardsListResponse(response *DashboardsListResponse, reader io.Read
 	return iterator.Error
 }
 func writeDashboardsListResponse(response *DashboardsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/flavours_resource_json.go
+++ b/clustersmgmt/v1/flavours_resource_json.go
@@ -104,6 +104,8 @@ func readFlavoursListResponse(response *FlavoursListResponse, reader io.Reader) 
 	return iterator.Error
 }
 func writeFlavoursListResponse(response *FlavoursListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/groups_resource_json.go
+++ b/clustersmgmt/v1/groups_resource_json.go
@@ -80,6 +80,8 @@ func readGroupsListResponse(response *GroupsListResponse, reader io.Reader) erro
 	return iterator.Error
 }
 func writeGroupsListResponse(response *GroupsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/identity_providers_resource_json.go
+++ b/clustersmgmt/v1/identity_providers_resource_json.go
@@ -96,6 +96,8 @@ func readIdentityProvidersListResponse(response *IdentityProvidersListResponse, 
 	return iterator.Error
 }
 func writeIdentityProvidersListResponse(response *IdentityProvidersListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/logs_resource_json.go
+++ b/clustersmgmt/v1/logs_resource_json.go
@@ -80,6 +80,8 @@ func readLogsListResponse(response *LogsListResponse, reader io.Reader) error {
 	return iterator.Error
 }
 func writeLogsListResponse(response *LogsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/machine_types_resource_json.go
+++ b/clustersmgmt/v1/machine_types_resource_json.go
@@ -88,6 +88,8 @@ func readMachineTypesListResponse(response *MachineTypesListResponse, reader io.
 	return iterator.Error
 }
 func writeMachineTypesListResponse(response *MachineTypesListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/users_resource_json.go
+++ b/clustersmgmt/v1/users_resource_json.go
@@ -96,6 +96,8 @@ func readUsersListResponse(response *UsersListResponse, reader io.Reader) error 
 	return iterator.Error
 }
 func writeUsersListResponse(response *UsersListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/clustersmgmt/v1/versions_resource_json.go
+++ b/clustersmgmt/v1/versions_resource_json.go
@@ -88,6 +88,8 @@ func readVersionsListResponse(response *VersionsListResponse, reader io.Reader) 
 	return iterator.Error
 }
 func writeVersionsListResponse(response *VersionsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -299,7 +299,7 @@ func SendPanic(w http.ResponseWriter, r *http.Request) {
 // SendNotFound sends a generic 404 error.
 func SendNotFound(w http.ResponseWriter, r *http.Request) {
 	reason := fmt.Sprintf(
-		"Can't find resource for path '%s''",
+		"Can't find resource for path '%s'",
 		r.URL.Path,
 	)
 	body, err := NewError().
@@ -316,7 +316,7 @@ func SendNotFound(w http.ResponseWriter, r *http.Request) {
 // SendMethodNotAllowed sends a generic 405 error.
 func SendMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
 	reason := fmt.Sprintf(
-		"Method '%s' isn't supported for path '%s''",
+		"Method '%s' isn't supported for path '%s'",
 		r.Method, r.URL.Path,
 	)
 	body, err := NewError().

--- a/server.go
+++ b/server.go
@@ -49,6 +49,13 @@ type Server interface {
 // Dispatch navigates the servers tree till it finds one that matches the given set
 // of path segments, and then invokes it.
 func Dispatch(w http.ResponseWriter, r *http.Request, server Server, segments []string) {
+	if len(segments) > 0 && segments[0] == "api" {
+		dispatch(w, r, server, segments[1:])
+		return
+	}
+	errors.SendNotFound(w, r)
+}
+func dispatch(w http.ResponseWriter, r *http.Request, server Server, segments []string) {
 	if len(segments) == 0 {
 		// TODO: This should send the metadata.
 		errors.SendMethodNotAllowed(w, r)

--- a/servicelogs/v1/cluster_logs_resource_json.go
+++ b/servicelogs/v1/cluster_logs_resource_json.go
@@ -104,6 +104,8 @@ func readClusterLogsListResponse(response *ClusterLogsListResponse, reader io.Re
 	return iterator.Error
 }
 func writeClusterLogsListResponse(response *ClusterLogsListServerResponse, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.status)
 	stream := helpers.NewStream(w)
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Add `Content-Type` to responses sent by the generated server code.
- Don't require developer to explicitly remove the `/api` when using the
  server code.
- Remove redundant quotes from error responses sent by the generated
  server code.