### PR TITLE
Update to metamodel 0.0.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ model_version:=v0.0.41
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.24
+metamodel_version:=v0.0.25
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples

--- a/accountsmgmt/v1/access_token_type_json.go
+++ b/accountsmgmt/v1/access_token_type_json.go
@@ -47,7 +47,7 @@ func writeAccessToken(object *AccessToken, stream *jsoniter.Stream) {
 		stream.WriteObjectStart()
 		keys := make([]string, len(object.auths))
 		i := 0
-		for key, _ := range object.auths {
+		for key := range object.auths {
 			keys[i] = key
 			i++
 		}

--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -38,7 +38,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/ghodss/yaml"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authentication/main_test.go
+++ b/authentication/main_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func TestAuthentication(t *testing.T) {

--- a/clustersmgmt/v1/cluster_type_json.go
+++ b/clustersmgmt/v1/cluster_type_json.go
@@ -270,7 +270,7 @@ func writeCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectStart()
 		keys := make([]string, len(object.properties))
 		i := 0
-		for key, _ := range object.properties {
+		for key := range object.properties {
 			keys[i] = key
 			i++
 		}

--- a/clustersmgmt/v1/open_id_identity_provider_type_json.go
+++ b/clustersmgmt/v1/open_id_identity_provider_type_json.go
@@ -87,7 +87,7 @@ func writeOpenIDIdentityProvider(object *OpenIDIdentityProvider, stream *jsonite
 		stream.WriteObjectStart()
 		keys := make([]string, len(object.extraAuthorizeParameters))
 		i := 0
-		for key, _ := range object.extraAuthorizeParameters {
+		for key := range object.extraAuthorizeParameters {
 			keys[i] = key
 			i++
 		}

--- a/connection_test.go
+++ b/connection_test.go
@@ -19,9 +19,10 @@ limitations under the License.
 package sdk
 
 import (
-	"github.com/onsi/gomega/gbytes"
 	"net/http"
 	"time"
+
+	"github.com/onsi/gomega/gbytes"
 
 	. "github.com/onsi/ginkgo" // nolint
 	. "github.com/onsi/gomega" // nolint

--- a/examples/client_credentials_grant.go
+++ b/examples/client_credentials_grant.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/create_cluster.go
+++ b/examples/create_cluster.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/delete_cluster.go
+++ b/examples/delete_cluster.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {

--- a/examples/delete_subscription.go
+++ b/examples/delete_subscription.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {

--- a/examples/existing_token.go
+++ b/examples/existing_token.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/export_control_review.go
+++ b/examples/export_control_review.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	azv1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
 )
 

--- a/examples/get_cluster.go
+++ b/examples/get_cluster.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {

--- a/examples/get_cluster_credentials.go
+++ b/examples/get_cluster_credentials.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {

--- a/examples/get_cluster_logs.go
+++ b/examples/get_cluster_logs.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/get_cluster_metrics.go
+++ b/examples/get_cluster_metrics.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/get_metadata.go
+++ b/examples/get_metadata.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {

--- a/examples/list_cloud_providers.go
+++ b/examples/list_cloud_providers.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/list_cluster_creators.go
+++ b/examples/list_cluster_creators.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/list_clusters.go
+++ b/examples/list_clusters.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/list_quota_summary.go
+++ b/examples/list_quota_summary.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 

--- a/examples/list_versions.go
+++ b/examples/list_versions.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/resource_review.go
+++ b/examples/resource_review.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	azv1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
 )
 

--- a/examples/run_cluster_operator_metrics.go
+++ b/examples/run_cluster_operator_metrics.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	// Print the results:
-	for _, operator := range response.Body().Operators(){
+	for _, operator := range response.Body().Operators() {
 		fmt.Printf("Name: %v\n", operator.Name())
 		fmt.Printf("Reason: %s\n", operator.Reason())
 		fmt.Printf("Time: %f\n", operator.Time())

--- a/examples/run_metric_query.go
+++ b/examples/run_metric_query.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 func main() {

--- a/examples/sync_addons.go
+++ b/examples/sync_addons.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/examples/transport_wrapper.go
+++ b/examples/transport_wrapper.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 type LoggingTransport struct {

--- a/examples/update_cluster.go
+++ b/examples/update_cluster.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Run the `gofmt` command only once for all generated files instead of running
  it once per each generated file.
- Avoid generating code with constructs that would then be simplified by the
  `-s` flag of the `gofmt` command.