### PR TITLE
Update to metamodel 0.0.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ model_version:=v0.0.41
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.25
+metamodel_version:=v0.0.26
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Add `operation_id` attribute to error objects and error messages.

Related: https://github.com/openshift-online/ocm-sdk-go/issues/150