### PR TITLE
Add cookie support

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -20,14 +20,77 @@ limitations under the License.
 package sdk
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 
 	"gitlab.com/c0b/go-ordered-json"
 )
+
+// dumpRoundTripper is a round tripper that dumps the details of the requests and the responses to
+// the log.
+type dumpRoundTripper struct {
+	logger Logger
+	next   http.RoundTripper
+}
+
+// Make sure that we implement the http.RoundTripper interface:
+var _ http.RoundTripper = &dumpRoundTripper{}
+
+// RoundTrip is he implementation of the http.RoundTripper interface.
+func (d *dumpRoundTripper) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	// Get the context:
+	ctx := request.Context()
+
+	// Read the complete body in memory, in order to send it to the log, and replace it with a
+	// reader that reads it from memory:
+	if request.Body != nil {
+		var body []byte
+		body, err = ioutil.ReadAll(request.Body)
+		if err != nil {
+			return
+		}
+		err = request.Body.Close()
+		if err != nil {
+			return
+		}
+		d.dumpRequest(ctx, request, body)
+		request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	} else {
+		d.dumpRequest(ctx, request, nil)
+	}
+
+	// Call the next round tripper:
+	response, err = d.next.RoundTrip(request)
+	if err != nil {
+		return
+	}
+
+	// Read the complete response body in memory, in order to send it the log, and replace it
+	// with a reader that reads it from memory:
+	if response.Body != nil {
+		var body []byte
+		body, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			return
+		}
+		err = response.Body.Close()
+		if err != nil {
+			return
+		}
+		d.dumpResponse(ctx, response, body)
+		response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	} else {
+		d.dumpResponse(ctx, response, nil)
+	}
+
+	return
+}
 
 const (
 	// redactionStr replaces sensitive values in output.
@@ -47,9 +110,9 @@ var redactFields = map[string]bool{
 }
 
 // dumpRequest dumps to the log, in debug level, the details of the given HTTP request.
-func (c *Connection) dumpRequest(ctx context.Context, request *http.Request, body []byte) {
-	c.logger.Debug(ctx, "Request method is %s", request.Method)
-	c.logger.Debug(ctx, "Request URL is '%s'", request.URL)
+func (d *dumpRoundTripper) dumpRequest(ctx context.Context, request *http.Request, body []byte) {
+	d.logger.Debug(ctx, "Request method is %s", request.Method)
+	d.logger.Debug(ctx, "Request URL is '%s'", request.URL)
 	header := request.Header
 	names := make([]string, len(header))
 	i := 0
@@ -62,22 +125,21 @@ func (c *Connection) dumpRequest(ctx context.Context, request *http.Request, bod
 		values := header[name]
 		for _, value := range values {
 			if strings.ToLower(name) == "authorization" {
-				c.logger.Debug(ctx, "Request header '%s' is omitted", name)
+				d.logger.Debug(ctx, "Request header '%s' is omitted", name)
 			} else {
-				c.logger.Debug(ctx, "Request header '%s' is '%s'", name, value)
+				d.logger.Debug(ctx, "Request header '%s' is '%s'", name, value)
 			}
 		}
 	}
 	if body != nil {
-		c.logger.Debug(ctx, "Request body follows")
-		c.dumpBody(ctx, header, body)
+		d.logger.Debug(ctx, "Request body follows")
+		d.dumpBody(ctx, header, body)
 	}
 }
 
 // dumpResponse dumps to the log, in debug level, the details of the given HTTP response.
-func (c *Connection) dumpResponse(ctx context.Context, response *http.Response, body []byte) {
-	c.logger.Debug(ctx, "Response status is '%s'", response.Status)
-	c.logger.Debug(ctx, "Response status code %d", response.StatusCode)
+func (d *dumpRoundTripper) dumpResponse(ctx context.Context, response *http.Response, body []byte) {
+	d.logger.Debug(ctx, "Response status is '%s'", response.Status)
 	header := response.Header
 	names := make([]string, len(header))
 	i := 0
@@ -89,53 +151,107 @@ func (c *Connection) dumpResponse(ctx context.Context, response *http.Response, 
 	for _, name := range names {
 		values := header[name]
 		for _, value := range values {
-			c.logger.Debug(ctx, "Response header '%s' is '%s'", name, value)
+			d.logger.Debug(ctx, "Response header '%s' is '%s'", name, value)
 		}
 	}
 	if body != nil {
-		c.logger.Debug(ctx, "Response body follows")
-		c.dumpBody(ctx, header, body)
+		d.logger.Debug(ctx, "Response body follows")
+		d.dumpBody(ctx, header, body)
 	}
 }
 
 // dumpBody checks the content type used in the given header and then it dumps the given body in a
 // format suitable for that content type.
-func (c *Connection) dumpBody(ctx context.Context, header http.Header, body []byte) {
+func (d *dumpRoundTripper) dumpBody(ctx context.Context, header http.Header, body []byte) {
 	switch header.Get("Content-Type") {
+	case "application/x-www-form-urlencoded":
+		d.dumpForm(ctx, body)
 	case "application/json", "":
-		c.dumpJSON(ctx, body)
+		d.dumpJSON(ctx, body)
 	default:
-		c.dumpBytes(ctx, body)
+		d.dumpBytes(ctx, body)
 	}
+}
+
+// dumpForm sends to the log the contents of the given form data, excluding security sensitive
+// fields.
+func (d *dumpRoundTripper) dumpForm(ctx context.Context, data []byte) {
+	// Parse the form:
+	form, err := url.ParseQuery(string(data))
+	if err != nil {
+		d.dumpBytes(ctx, data)
+		return
+	}
+
+	// Redact values corresponding to security sensitive fields:
+	for name, values := range form {
+		if redactFields[name] {
+			for i := range values {
+				values[i] = redactionStr
+			}
+		}
+	}
+
+	// Get and sort the names of the fields of the form, so that the generated output will be
+	// predictable:
+	names := make([]string, 0, len(form))
+	for name := range form {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Write the names and values to the buffer while redacting the sensitive fields:
+	buffer := &bytes.Buffer{}
+	for _, name := range names {
+		key := url.QueryEscape(name)
+		values := form[name]
+		for _, value := range values {
+			var redacted string
+			if redactFields[name] {
+				redacted = "***"
+			} else {
+				redacted = url.QueryEscape(value)
+			}
+			if buffer.Len() > 0 {
+				buffer.WriteByte('&') // #nosec G104
+			}
+			buffer.WriteString(key) // #nosec G104
+			buffer.WriteByte('=') // #nosec G104
+			buffer.WriteString(redacted) // #nosec G104
+		}
+	}
+
+	// Send the redacted data to the log:
+	d.dumpBytes(ctx, buffer.Bytes())
 }
 
 // dumpJSON tries to parse the given data as a JSON document. If that works, then it dumps it
 // indented, otherwise dumps it as is.
-func (c *Connection) dumpJSON(ctx context.Context, data []byte) {
+func (d *dumpRoundTripper) dumpJSON(ctx context.Context, data []byte) {
 	parsed := ordered.NewOrderedMap()
 	err := json.Unmarshal(data, parsed)
 	if err != nil {
-		c.logger.Debug(ctx, "%s", data)
+		d.logger.Debug(ctx, "%s", data)
 	} else {
 		// remove sensitive information
-		c.redactSensitive(parsed)
+		d.redactSensitive(parsed)
 
 		indented, err := json.MarshalIndent(parsed, "", "  ")
 		if err != nil {
-			c.logger.Debug(ctx, "%s", data)
+			d.logger.Debug(ctx, "%s", data)
 		} else {
-			c.logger.Debug(ctx, "%s", indented)
+			d.logger.Debug(ctx, "%s", indented)
 		}
 	}
 }
 
 // dumpBytes dump the given data as an array of bytes.
-func (c *Connection) dumpBytes(ctx context.Context, data []byte) {
-	c.logger.Debug(ctx, "%s", data)
+func (d *dumpRoundTripper) dumpBytes(ctx context.Context, data []byte) {
+	d.logger.Debug(ctx, "%s", data)
 }
 
 // redactSensitive replaces sensitive fields within a response with redactionStr.
-func (c *Connection) redactSensitive(body *ordered.OrderedMap) {
+func (d *dumpRoundTripper) redactSensitive(body *ordered.OrderedMap) {
 	iterator := body.EntriesIter()
 	for {
 		pair, ok := iterator()

--- a/token.go
+++ b/token.go
@@ -245,27 +245,6 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	}
 
 	// Send the HTTP request:
-	if c.logger.DebugEnabled() {
-		var censoredBody bytes.Buffer
-		// Unlike real url.Values.Encode(), this doesn't sort keys.
-		for name, values := range form {
-			for _, value := range values {
-				// Buffer.Write*() don't require error checking but golangci-lint v1.10.2
-				// on Jenkins flags them (maybe https://github.com/securego/gosec/issues/267).
-				if censoredBody.Len() > 0 {
-					censoredBody.WriteByte('&') // #nosec G104
-				}
-				censoredBody.WriteString(url.QueryEscape(name) + "=") // #nosec G104
-
-				if redactFields[name] {
-					censoredBody.WriteString(redactionStr) // #nosec G104
-				} else {
-					censoredBody.WriteString(url.QueryEscape(value)) // #nosec G104
-				}
-			}
-		}
-		c.dumpRequest(ctx, request, censoredBody.Bytes())
-	}
 	response, err := c.client.Do(request)
 	if err != nil {
 		err = fmt.Errorf("can't send request: %v", err)
@@ -278,9 +257,6 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	if err != nil {
 		err = fmt.Errorf("can't read response: %v", err)
 		return
-	}
-	if c.logger.DebugEnabled() {
-		c.dumpResponse(ctx, response, body)
 	}
 
 	// Check the response status and content type:


### PR DESCRIPTION
This patch changes the SDK so that it honors the `Set-Cookie` headers
sent by the server. That itself is quite simple, but it requires
important changes in the code that sends requests to the log so that the
`Cookie` header is reported correctly. The reason is that the `Cookie`
header is built internally by the `Do` method of the HTTP client. In
order to send them to the log it is necessary to move the code that
dumps requests to a round tripper that is called *after* the `Do` method
has added them.