### PR TITLE
Release 0.1.90

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,17 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.90 Mar 2 2020
+
+- Request new tokens when the _OpenID_ server returns error code `invalid_grant`
+during the refresh token grant.
+
+- Check that responses from the _OpenID_ server contain `application/json` in
+the `Content-Type` header, and improve the error messages generated in that
+case so that they contain a summary of the content.
+
+- Honor cookies sent by the _OpenID_ and API servers.
+
 == 0.1.89 Feb 26 2020
 
 - Update to metamodel 0.0.26.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.89"
+const Version = "0.1.90"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Request new tokens when the _OpenID_ server returns error code `invalid_grant`
during the refresh token grant.

- Check that responses from the _OpenID_ server contain `application/json` in
the `Content-Type` header, and improve the error messages generated in that
case so that they contain a summary of the content.

- Honor cookies sent by the _OpenID_ and API servers.