### PR TITLE
Release 0.1.91

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.91 Mar 5 2020
+
+- Update to model 0.0.42:
+** Add `client_secret` attribute to _GitHub_ identity provider.
+
 == 0.1.90 Mar 2 2020
 
 - Request new tokens when the _OpenID_ server returns error code `invalid_grant`

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.90"
+const Version = "0.1.91"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.42:
** Add `client_secret` attribute to _GitHub_ identity provider.