### PR TITLE
Release v0.1.104

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,7 +3,7 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
-== 0.1.103 May 15 2020
+== 0.1.104 May 15 2020
 
 - Update to model v0.0.58
 ** AddOns: Add docs_link attribute

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.103"
+const Version = "0.1.104"


### PR DESCRIPTION
Release v0.1.103 failed checksum in the golang proxy due to a mistake in
the tag. Releasing a new tag with the same changes to fix it.