### PR TITLE
add a new label to metrics to identify the service

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -20,6 +20,7 @@ package sdk
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"strings"
 )
 
 // registerMetrics registers the metrics with the Prometheus library.
@@ -117,11 +118,30 @@ func (c *Connection) registerMetrics(subsystem string) error {
 	return nil
 }
 
+func (c *Connection) GetAPIServiceLabelFromPath(path string) string {
+	if strings.HasPrefix(path, "/api/accounts_mgmt") {
+		return "ocm-accounts-service"
+	} else if strings.HasPrefix(path, "/api/clusters_mgmt") {
+		return "ocm-clusters-service"
+	} else if strings.HasPrefix(path, "/api/authorizations") {
+		return "ocm-authorizations-service"
+	} else if strings.HasPrefix(path, "/api/service_logs") {
+		return "ocm-logs-service"
+	} else {
+		pathParts := strings.Split(path, "/")
+		if len(pathParts) > 3 {
+			pathParts = pathParts[:3]
+		}
+		return "ocm-" + strings.Join(pathParts, "/")
+	}
+}
+
 // Names of the labels added to metrics:
 const (
-	metricsCodeLabel   = "code"
-	metricsMethodLabel = "method"
-	metricsPathLabel   = "path"
+	metricsAPIServiceLabel = "apiservice"
+	metricsCodeLabel       = "code"
+	metricsMethodLabel     = "method"
+	metricsPathLabel       = "path"
 )
 
 // Array of labels added to token metrics:
@@ -131,6 +151,7 @@ var tokenMetricsLabels = []string{
 
 // Array of labels added to call metrics:
 var callMetricsLabels = []string{
+	metricsAPIServiceLabel,
 	metricsCodeLabel,
 	metricsMethodLabel,
 	metricsPathLabel,

--- a/send.go
+++ b/send.go
@@ -67,9 +67,10 @@ func (c *Connection) RoundTrip(request *http.Request) (response *http.Response, 
 			code = response.StatusCode
 		}
 		labels := map[string]string{
-			metricsMethodLabel: request.Method,
-			metricsPathLabel:   metric,
-			metricsCodeLabel:   strconv.Itoa(code),
+			metricsAPIServiceLabel: c.GetAPIServiceLabelFromPath(request.URL.Path),
+			metricsMethodLabel:     request.Method,
+			metricsPathLabel:       metric,
+			metricsCodeLabel:       strconv.Itoa(code),
 		}
 		if c.callCountMetric != nil {
 			c.callCountMetric.With(labels).Inc()


### PR DESCRIPTION
unlike api inbound call, these outbound calls can have different destination services. I suggest adding a new label to identify its service,
```
api_outbound_request_duration_sum{apiservice="ocm-clusters-service",code="404",method="GET",path="/api/clusters_mgmt/v1/clusters/-"} 0.791109426
api_outbound_request_duration_count{apiservice="ocm-clusters-service",code="404",method="GET",path="/api/clusters_mgmt/v1/clusters/-"} 1
// from other client...
api_outbound_request_duration_sum{apiservice="quay.io",code="201",method="POST",path="/v2"} 0.791109426
api_outbound_request_duration_count{apiservice="quay.io",code="201",method="POST",path="/v2"} 1
```