### PR TITLE
"got tokens on attempt 1" is not interesting

### DIFF
--- a/token.go
+++ b/token.go
@@ -71,7 +71,7 @@ func (c *Connection) TokensContext(ctx context.Context) (access, refresh string,
 			return backoff.Permanent(err)
 		}
 
-		if attempt > 0 {
+		if attempt > 1 {
 			c.logger.Info(ctx, "OCM auth: got tokens on attempt %d.", attempt)
 		} else {
 			c.logger.Debug(ctx, "OCM auth: got tokens on attempt %d.", attempt)


### PR DESCRIPTION
initially wrote for 0-based attempt counting, forgot to adjust condition when I made it start at 1.

@vkareh @igoihman please review.
Replaces #240.  (we're having a longer discussion about whether SDK info logs are interesting to CLI users...)