### PR TITLE
Interpret HTML entities in logged summary of error response

### DIFF
--- a/send.go
+++ b/send.go
@@ -22,6 +22,7 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"mime"
 	"net/http"
@@ -206,7 +207,7 @@ func (c *Connection) contentSummary(mediaType string, response *http.Response) (
 	limit := 250
 	runes := []rune(string(body))
 	if strings.EqualFold(mediaType, "text/html") && len(runes) > limit {
-		content := strip.StripTags(string(body))
+		content := html.UnescapeString(strip.StripTags(string(body)))
 		content = wsRegex.ReplaceAllString(strings.TrimSpace(content), " ")
 		runes = []rune(content)
 	}


### PR DESCRIPTION
This will fix the logging to be more readable. Full message for the test case:
```
expected response content type 'application/json' but received 'text/html' and content 'Access Denied Access Denied You don't have permission to access "http://sso.redhat.com/AK_PM_VPATH0/" on this server. Reference #18.3500e8ac.1601993172.3a9c59e < > " & € ∭'
```

@igoihman @ciaranRoche please review.