### PR TITLE
Add functions to simplify tests that require responses

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -39,16 +39,34 @@ func TestClient(t *testing.T) {
 var _ = BeforeSuite(func() {
 	var err error
 
-	// Load the keys used to sign and verify tokens:j
+	// Load the keys used to sign and verify tokens:
 	jwtPublicKey, err = jwt.ParseRSAPublicKeyFromPEM([]byte(jwtPublicKeyPEM))
 	Expect(err).ToNot(HaveOccurred())
 	jwtPrivateKey, err = jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtPrivateKeyPEM))
 	Expect(err).ToNot(HaveOccurred())
 })
 
-// RespondWithTemplate responds with the given status code and with a JSON body that is generated
-// from the given template and the name value pairs given as arguments. For example, the following
-// code:
+// RespondeWithContent responds with the given status code, content type and body.
+func RespondWithContent(status int, contentType, body string) http.HandlerFunc {
+	return ghttp.RespondWith(
+		status,
+		body,
+		http.Header{
+			"Content-Type": []string{
+				contentType,
+			},
+		},
+	)
+}
+
+// RespondWithJSON responds with the given status code and JSON body.
+func RespondWithJSON(status int, body string) http.HandlerFunc {
+	return RespondWithContent(status, "application/json", body)
+}
+
+// RespondWithJSONTemplate responds with the given status code and with a JSON body that is
+// generated from the given template and the name value pairs given as arguments. For example, the
+// following code:
 //
 //	RespondWithJSONTemplate(
 //		http.StatusOK,
@@ -66,7 +84,7 @@ var _ = BeforeSuite(func() {
 //		"access_token": "myaccesstoken"
 //		"access_token": "myrefreshtoken"
 //	}
-func RespondWithJSONTemplate(statusCode int, source string, args ...interface{}) http.HandlerFunc {
+func RespondWithJSONTemplate(status int, source string, args ...interface{}) http.HandlerFunc {
 	// Check that there is an even number of args, and that the first of each pair is a string:
 	count := len(args)
 	Expect(count%2).To(
@@ -111,13 +129,7 @@ func RespondWithJSONTemplate(statusCode int, source string, args ...interface{})
 		source, err,
 	)
 
-	return ghttp.RespondWith(
-		statusCode,
-		buffer.Bytes(),
-		http.Header{
-			"Content-Type": []string{"application/json"},
-		},
-	)
+	return RespondWithJSON(status, buffer.String())
 }
 
 // RespondWithCookie responds to the request adding a cookie with the given name and value.

--- a/methods_test.go
+++ b/methods_test.go
@@ -41,8 +41,6 @@ var _ = Describe("Methods", func() {
 	// Connection used during the tests:
 	var connection *Connection
 
-	jsonHeader := http.Header{"Content-Type": []string{"application/json"}}
-
 	BeforeEach(func() {
 		var err error
 
@@ -100,7 +98,7 @@ var _ = Describe("Methods", func() {
 			apiServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest(http.MethodGet, "/mypath"),
-					ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+					RespondWithJSON(http.StatusOK, ""),
 				),
 			)
 
@@ -116,7 +114,7 @@ var _ = Describe("Methods", func() {
 			apiServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyHeaderKV("Accept", "application/json"),
-					ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+					RespondWithJSON(http.StatusOK, ""),
 				),
 			)
 
@@ -132,7 +130,7 @@ var _ = Describe("Methods", func() {
 			apiServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyFormKV("myparameter", "myvalue"),
-					ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+					RespondWithJSON(http.StatusOK, ""),
 				),
 			)
 
@@ -150,7 +148,7 @@ var _ = Describe("Methods", func() {
 				ghttp.CombineHandlers(
 					ghttp.VerifyFormKV("myparameter", "myvalue"),
 					ghttp.VerifyFormKV("yourparameter", "yourvalue"),
-					ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+					RespondWithJSON(http.StatusOK, ""),
 				),
 			)
 
@@ -168,7 +166,7 @@ var _ = Describe("Methods", func() {
 			apiServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyHeaderKV("myheader", "myvalue"),
-					ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+					RespondWithJSON(http.StatusOK, ""),
 				),
 			)
 
@@ -186,7 +184,7 @@ var _ = Describe("Methods", func() {
 				ghttp.CombineHandlers(
 					ghttp.VerifyHeaderKV("myheader", "myvalue"),
 					ghttp.VerifyHeaderKV("yourheader", "yourvalue"),
-					ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+					RespondWithJSON(http.StatusOK, ""),
 				),
 			)
 
@@ -202,7 +200,7 @@ var _ = Describe("Methods", func() {
 		It("Receives body", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusOK, `{"test":"mybody"}`, jsonHeader),
+				RespondWithJSON(http.StatusOK, `{"test":"mybody"}`),
 			)
 
 			// Send the request:
@@ -219,7 +217,7 @@ var _ = Describe("Methods", func() {
 		It("Receives status code 200", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+				RespondWithJSON(http.StatusOK, ""),
 			)
 
 			// Send the request:
@@ -234,7 +232,7 @@ var _ = Describe("Methods", func() {
 		It("Receives status code 400", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusBadRequest, nil, jsonHeader),
+				RespondWithJSON(http.StatusBadRequest, ""),
 			)
 
 			// Send the request:
@@ -249,7 +247,7 @@ var _ = Describe("Methods", func() {
 		It("Receives status code 500", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusInternalServerError, nil, jsonHeader),
+				RespondWithJSON(http.StatusInternalServerError, ""),
 			)
 
 			// Send the request:
@@ -302,7 +300,7 @@ var _ = Describe("Methods", func() {
 		It("Accepts empty body", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+				RespondWithJSON(http.StatusOK, ""),
 			)
 
 			// Send the request:
@@ -317,7 +315,7 @@ var _ = Describe("Methods", func() {
 		It("Increments outbound prometheus counter", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusTeapot, nil, jsonHeader),
+				RespondWithJSON(http.StatusTeapot, ""),
 			)
 
 			// Send the request:
@@ -343,7 +341,7 @@ var _ = Describe("Methods", func() {
 		It("Accepts empty body", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+				RespondWithJSON(http.StatusOK, ""),
 			)
 
 			// Send the request:
@@ -360,7 +358,7 @@ var _ = Describe("Methods", func() {
 		It("Accepts empty body", func() {
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(http.StatusOK, nil, jsonHeader),
+				RespondWithJSON(http.StatusOK, ""),
 			)
 
 			// Send the request:
@@ -425,15 +423,7 @@ var _ = Describe("Methods", func() {
 
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(
-					http.StatusBadGateway,
-					content,
-					http.Header{
-						"Content-Type": []string{
-							"text/html",
-						},
-					},
-				),
+				RespondWithContent(http.StatusBadGateway, "text/html", content),
 			)
 
 			// Try to get the access token:
@@ -452,15 +442,7 @@ var _ = Describe("Methods", func() {
 
 			// Configure the server:
 			apiServer.AppendHandlers(
-				ghttp.RespondWith(
-					http.StatusBadGateway,
-					content,
-					http.Header{
-						"Content-Type": []string{
-							"text/html",
-						},
-					},
-				),
+				RespondWithContent(http.StatusBadGateway, "text/html", content),
 			)
 
 			// Try to get the access token:

--- a/token_test.go
+++ b/token_test.go
@@ -984,30 +984,22 @@ var _ = Describe("Tokens", func() {
 		})
 	})
 
-	Describe("Test retry for getting access token", func() {
+	Describe("Retry for getting access token", func() {
 		It("Return access token after a few retries", func() {
 			// Generate tokens:
 			refreshToken := DefaultToken("Refresh", 10*time.Hour)
 			accessToken := DefaultToken("Bearer", 5*time.Minute)
 
 			oidServer.AppendHandlers(
-				ghttp.RespondWith(
+				RespondWithContent(
 					http.StatusInternalServerError,
-					`Internal Server Error`,
-					http.Header{
-						"Content-Type": []string{
-							"text/plain",
-						},
-					},
+					"text/plain",
+					"Internal Server Error",
 				),
-				ghttp.RespondWith(
+				RespondWithContent(
 					http.StatusBadGateway,
-					`Bad Gateway`,
-					http.Header{
-						"Content-Type": []string{
-							"text/plain",
-						},
-					},
+					"text/plain",
+					"Bad Gateway",
 				),
 				ghttp.CombineHandlers(
 					VerifyRefreshGrant(refreshToken),
@@ -1039,29 +1031,21 @@ var _ = Describe("Tokens", func() {
 			counter := connection.tokenCountMetric.With(expectedLabels)
 			Expect(testutil.ToFloat64(counter)).To(Equal(1.0))
 		})
+
 		It("Test no retry when status is not http 5xx", func() {
 			// Generate tokens:
 			refreshToken := DefaultToken("Refresh", 10*time.Hour)
 			accessToken := DefaultToken("Bearer", 5*time.Minute)
 
 			oidServer.AppendHandlers(
-				ghttp.RespondWith(
+				RespondWithContent(
 					http.StatusInternalServerError,
-					`Internal Server Error`,
-					http.Header{
-						"Content-Type": []string{
-							"text/plain",
-						},
-					},
+					"text/plain",
+					"Internal Server Error",
 				),
-				ghttp.RespondWith(
+				RespondWithJSON(
 					http.StatusForbidden,
-					`{}`,
-					http.Header{
-						"Content-Type": []string{
-							"application/json",
-						},
-					},
+					"{}",
 				),
 				ghttp.CombineHandlers(
 					VerifyRefreshGrant(refreshToken),


### PR DESCRIPTION
This patch adds the `RespondWithContent` and `RespondWithJSON` methods that
simplify the tests that need to receive responses with custom or JSON conten
types.