### PR TITLE
Fix standard streams logger

### DIFF
--- a/std_logger.go
+++ b/std_logger.go
@@ -103,6 +103,7 @@ func (b *StdLoggerBuilder) Build() (logger *StdLogger, err error) {
 	logger.warnEnabled = b.warnEnabled
 	logger.errorEnabled = b.errorEnabled
 	logger.outStream = b.outStream
+	logger.errStream = b.errStream
 	if logger.outStream == nil {
 		logger.outStream = os.Stdout
 	}


### PR DESCRIPTION
Currently the builder of the `StdLogger` type doesn't use correctly the passed
error stream: it ignores it. This is bad in itself, but it also has a negative
side effect in the output of the tests: the log messages are mixed with the
_Ginkgo_ output. This patch fixes that.