### PR TITLE
Always use _Ginkgo_ writer for logs of tests

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Connection", func() {
 	It("Can be created with access token", func() {
 		accessToken := DefaultToken("Bearer", 5*time.Minute)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(accessToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -42,6 +43,7 @@ var _ = Describe("Connection", func() {
 	It("Can be created with refresh token", func() {
 		refreshToken := DefaultToken("Refresh", 10*time.Hour)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(refreshToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -52,6 +54,7 @@ var _ = Describe("Connection", func() {
 	It("Can be created with offline access token", func() {
 		offlineToken := DefaultToken("Offline", 0)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(offlineToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -63,6 +66,7 @@ var _ = Describe("Connection", func() {
 		accessToken := DefaultToken("Bearer", 5*time.Minute)
 		refreshToken := DefaultToken("Refresh", 10*time.Hour)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(accessToken, refreshToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -74,6 +78,7 @@ var _ = Describe("Connection", func() {
 		accessToken := DefaultToken("Bearer", 5*time.Minute)
 		offlineToken := DefaultToken("Offline", 10*time.Hour)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(accessToken, offlineToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -83,6 +88,7 @@ var _ = Describe("Connection", func() {
 
 	It("Can be created with user name and password", func() {
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			User("myuser", "mypassword").
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -92,6 +98,7 @@ var _ = Describe("Connection", func() {
 
 	It("Can be created with client identifier and secret", func() {
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Client("myclientid", "myclientsecret").
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -102,6 +109,7 @@ var _ = Describe("Connection", func() {
 	It("Selects default OpenID server with default access token", func() {
 		accessToken := DefaultToken("Bearer", 5*time.Minute)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(accessToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -116,6 +124,7 @@ var _ = Describe("Connection", func() {
 	It("Selects default OpenID server with default refresh token", func() {
 		refreshToken := DefaultToken("Refresh", 10*time.Hour)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(refreshToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -130,6 +139,7 @@ var _ = Describe("Connection", func() {
 	It("Selects default OpenID server with default offline access token", func() {
 		offlineToken := DefaultToken("Offline", 0)
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			Tokens(offlineToken).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -143,6 +153,7 @@ var _ = Describe("Connection", func() {
 
 	It("Honours explicitly provided OpenID server with user name and password", func() {
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			User("myuser", "mypassword").
 			TokenURL(DefaultTokenURL).
 			Client(DefaultClientID, DefaultClientSecret).
@@ -159,6 +170,7 @@ var _ = Describe("Connection", func() {
 	It("Use transport wrapper", func() {
 		transport := NewTestTransport()
 		connection, err := NewConnectionBuilder().
+			Logger(logger).
 			User("test", "test").
 			TransportWrapper(func(wrapped http.RoundTripper) http.RoundTripper {
 				return transport

--- a/main_test.go
+++ b/main_test.go
@@ -36,6 +36,9 @@ func TestClient(t *testing.T) {
 	RunSpecs(t, "Client")
 }
 
+// Logger used during the tests:
+var logger Logger
+
 var _ = BeforeSuite(func() {
 	var err error
 
@@ -43,6 +46,13 @@ var _ = BeforeSuite(func() {
 	jwtPublicKey, err = jwt.ParseRSAPublicKeyFromPEM([]byte(jwtPublicKeyPEM))
 	Expect(err).ToNot(HaveOccurred())
 	jwtPrivateKey, err = jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtPrivateKeyPEM))
+	Expect(err).ToNot(HaveOccurred())
+
+	// Create the logger:
+	logger, err = NewStdLoggerBuilder().
+		Streams(GinkgoWriter, GinkgoWriter).
+		Debug(true).
+		Build()
 	Expect(err).ToNot(HaveOccurred())
 })
 

--- a/methods_test.go
+++ b/methods_test.go
@@ -59,13 +59,6 @@ var _ = Describe("Methods", func() {
 		// Create the API server:
 		apiServer = ghttp.NewServer()
 
-		// Create the logger:
-		logger, err = NewStdLoggerBuilder().
-			Streams(GinkgoWriter, GinkgoWriter).
-			Debug(true).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-
 		// Metrics subsystem - value doesn't matter but configuring it enables
 		// prometheus exporting, exercising the counter increment functionality
 		// (e.g. will catch inconsistent labels).

--- a/token_test.go
+++ b/token_test.go
@@ -37,27 +37,15 @@ var _ = Describe("Tokens", func() {
 	var oidServer *ghttp.Server
 	var apiServer *ghttp.Server
 
-	// Logger used during the tests:
-	var logger Logger
-
 	// Metrics subsystem - value doesn't matter but configuring it enables
 	// prometheus exporting, exercising the counter increment functionality
 	// (e.g. will catch inconsistent labels).
 	metrics := "test_subsystem"
 
 	BeforeEach(func() {
-		var err error
-
 		// Create the servers:
 		oidServer = ghttp.NewServer()
 		apiServer = ghttp.NewServer()
-
-		// Create the logger:
-		logger, err = NewStdLoggerBuilder().
-			Streams(GinkgoWriter, GinkgoWriter).
-			Debug(true).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Currently some of the tests aren't explicitly using the logger that writes to
the Ginkgo writer. As a result the log messages of those tests interfere with
the Gingo output. This patch changes the tests so that all of them use the
right logger.