### PR TITLE
Always use _Ginkgo_ writer from test servers

### DIFF
--- a/authentication/handler_test.go
+++ b/authentication/handler_test.go
@@ -786,7 +786,7 @@ var _ = Describe("Handler", func() {
 
 	It("Doesn't load insecure keys by default", func() {
 		// Prepare the server:
-		server := NewTLSServer()
+		server := MakeTLSServer()
 		server.AppendHandlers(
 			RespondWith(http.StatusOK, keysBytes),
 		)
@@ -821,7 +821,7 @@ var _ = Describe("Handler", func() {
 
 	It("Loads insecure keys in insecure mode", func() {
 		// Prepare the server that will return the keys:
-		server := NewTLSServer()
+		server := MakeTLSServer()
 		server.AppendHandlers(
 			RespondWith(http.StatusOK, keysBytes),
 		)

--- a/authentication/main_test.go
+++ b/authentication/main_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"math/big"
 	"os"
 	"testing"
@@ -28,6 +29,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 
 	"github.com/dgrijalva/jwt-go"
 
@@ -96,6 +98,14 @@ var _ = AfterSuite(func() {
 	err := os.Remove(keysFile)
 	Expect(err).ToNot(HaveOccurred())
 })
+
+// MakeTLSServer creates a test TLS server configured so that it sends log messages to the Ginkgo writer.
+func MakeTLSServer() *ghttp.Server {
+	server := ghttp.NewTLSServer()
+	server.Writer = GinkgoWriter
+	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	return server
+}
 
 // IssueToken generates a token with the claims resulting from merging the default claims and the
 // claims explicitly given.

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,7 @@ package sdk
 import (
 	"bytes"
 	"crypto/rsa"
+	"log"
 	"net/http"
 	"testing"
 	"text/template"
@@ -55,6 +56,14 @@ var _ = BeforeSuite(func() {
 		Build()
 	Expect(err).ToNot(HaveOccurred())
 })
+
+// MakeServer creates a test server configured so that it sends log messages to the Ginkgo writer.
+func MakeServer() *ghttp.Server {
+	server := ghttp.NewServer()
+	server.Writer = GinkgoWriter
+	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	return server
+}
 
 // RespondeWithContent responds with the given status code, content type and body.
 func RespondWithContent(status int, contentType, body string) http.HandlerFunc {

--- a/methods_test.go
+++ b/methods_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Methods", func() {
 		refreshToken := DefaultToken("Refresh", 10*time.Hour)
 
 		// Create the OpenID server:
-		oidServer = ghttp.NewServer()
+		oidServer = MakeServer()
 		oidServer.AppendHandlers(
 			ghttp.CombineHandlers(
 				RespondWithTokens(accessToken, refreshToken),
@@ -57,7 +57,7 @@ var _ = Describe("Methods", func() {
 		)
 
 		// Create the API server:
-		apiServer = ghttp.NewServer()
+		apiServer = MakeServer()
 
 		// Metrics subsystem - value doesn't matter but configuring it enables
 		// prometheus exporting, exercising the counter increment functionality

--- a/token_test.go
+++ b/token_test.go
@@ -44,8 +44,8 @@ var _ = Describe("Tokens", func() {
 
 	BeforeEach(func() {
 		// Create the servers:
-		oidServer = ghttp.NewServer()
-		apiServer = ghttp.NewServer()
+		oidServer = MakeServer()
+		apiServer = MakeServer()
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This patch changes the way that test HTTP servers are constructed so that they
will always write log messages to the Ginkgo writer. That way their output
doesn't interfere with the Ginkgo output.