### PR TITLE
Wrap errors

### DIFF
--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -183,7 +183,7 @@ func (b *HandlerBuilder) Build() (handler *Handler, err error) {
 		var info os.FileInfo
 		info, err = os.Stat(file)
 		if err != nil {
-			err = fmt.Errorf("keys file '%s' doesn't exist: %v", file, err)
+			err = fmt.Errorf("keys file '%s' doesn't exist: %w", file, err)
 			return
 		}
 		if !info.Mode().IsRegular() {
@@ -197,12 +197,12 @@ func (b *HandlerBuilder) Build() (handler *Handler, err error) {
 		var parsed *url.URL
 		parsed, err = url.Parse(addr)
 		if err != nil {
-			err = fmt.Errorf("keys URL '%s' isn't a valid URL: %v", addr, err)
+			err = fmt.Errorf("keys URL '%s' isn't a valid URL: %w", addr, err)
 			return
 		}
 		if !strings.EqualFold(parsed.Scheme, "https") {
 			err = fmt.Errorf(
-				"keys URL '%s' doesn't use the HTTPS protocol: %v",
+				"keys URL '%s' doesn't use the HTTPS protocol: %w",
 				addr, err,
 			)
 		}

--- a/connection.go
+++ b/connection.go
@@ -366,7 +366,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 		var token *jwt.Token
 		token, _, err = tokenParser.ParseUnverified(text, jwt.MapClaims{})
 		if err != nil {
-			err = fmt.Errorf("can't parse token %d: %v", i, err)
+			err = fmt.Errorf("can't parse token %d: %w", i, err)
 			return
 		}
 		claims, ok := token.Claims.(jwt.MapClaims)
@@ -406,7 +406,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 			Error(true).
 			Build()
 		if err != nil {
-			err = fmt.Errorf("can't create default logger: %v", err)
+			err = fmt.Errorf("can't create default logger: %w", err)
 			return
 		}
 		b.logger.Debug(ctx, "Logger wasn't provided, will use Go log")
@@ -424,7 +424,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 	}
 	tokenURL, err := url.Parse(rawTokenURL)
 	if err != nil {
-		err = fmt.Errorf("can't parse token URL '%s': %v", rawTokenURL, err)
+		err = fmt.Errorf("can't parse token URL '%s': %w", rawTokenURL, err)
 		return
 	}
 	clientID := b.clientID
@@ -465,7 +465,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 	}
 	apiURL, err := url.Parse(rawAPIURL)
 	if err != nil {
-		err = fmt.Errorf("can't parse API URL '%s': %v", rawAPIURL, err)
+		err = fmt.Errorf("can't parse API URL '%s': %w", rawAPIURL, err)
 		return
 	}
 
@@ -520,7 +520,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 	if b.subsystem != "" {
 		err = connection.registerMetrics(b.subsystem)
 		if err != nil {
-			err = fmt.Errorf("can't register metrics: %v", err)
+			err = fmt.Errorf("can't register metrics: %w", err)
 			return
 		}
 	}

--- a/send.go
+++ b/send.go
@@ -125,7 +125,7 @@ func (c *Connection) send(ctx context.Context, request *http.Request) (response 
 	// Get the access token:
 	token, _, err := c.TokensContext(ctx)
 	if err != nil {
-		err = fmt.Errorf("can't get access token: %v", err)
+		err = fmt.Errorf("can't get access token: %w", err)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (c *Connection) send(ctx context.Context, request *http.Request) (response 
 	// Send the request and get the response:
 	response, err = c.client.Do(request)
 	if err != nil {
-		err = fmt.Errorf("can't send request: %v", err)
+		err = fmt.Errorf("can't send request: %w", err)
 		return
 	}
 
@@ -182,7 +182,7 @@ func (c *Connection) checkContentType(response *http.Response) error {
 		if err != nil {
 			return fmt.Errorf(
 				"expected response content type 'application/json' but received "+
-					"'%s' and couldn't obtain content summary: %v",
+					"'%s' and couldn't obtain content summary: %w",
 				mediaType, err,
 			)
 		}

--- a/token.go
+++ b/token.go
@@ -79,13 +79,13 @@ func (c *Connection) TokensContext(
 			if code >= http.StatusInternalServerError {
 				c.logger.Error(ctx,
 					"OCM auth: failed to get tokens, got http code %d, "+
-						"will attempt to retry. err: %v",
+						"will attempt to retry. err: %w",
 					code, err)
 				return err
 			}
 			c.logger.Error(ctx,
 				"OCM auth: failed to get tokens, got http code %d, "+
-					"will not attempt to retry. err: %v",
+					"will not attempt to retry. err: %w",
 				code, err)
 			return backoff.Permanent(err)
 		}
@@ -330,7 +330,7 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	header.Set("Content-Type", "application/x-www-form-urlencoded")
 	header.Set("Accept", "application/json")
 	if err != nil {
-		err = fmt.Errorf("can't create request: %v", err)
+		err = fmt.Errorf("can't create request: %w", err)
 		return
 	}
 
@@ -342,7 +342,7 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	// Send the HTTP request:
 	response, err := c.client.Do(request)
 	if err != nil {
-		err = fmt.Errorf("can't send request: %v", err)
+		err = fmt.Errorf("can't send request: %w", err)
 		return
 	}
 	defer response.Body.Close()
@@ -358,7 +358,7 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	// Read the response body:
 	body, err = ioutil.ReadAll(response.Body)
 	if err != nil {
-		err = fmt.Errorf("can't read response: %v", err)
+		err = fmt.Errorf("can't read response: %w", err)
 		return
 	}
 
@@ -366,7 +366,7 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	result = &internal.TokenResponse{}
 	err = json.Unmarshal(body, result)
 	if err != nil {
-		err = fmt.Errorf("can't parse JSON response: %v", err)
+		err = fmt.Errorf("can't parse JSON response: %w", err)
 		return
 	}
 	if result.Error != nil {


### PR DESCRIPTION
This patch changes the SDK so that it wraps errors using the `%w` format verb.
This way it will then be possible for the user to check the types of the errors.
For example, a user interested in checkinf if an error was caused by a timeout
it can check it like this:

    response, err := connection.ClusersMgmg().V1().Clusters().Get().Send()
    if errors.Is(err, context.DeadlineExceeded) {
           ...
    }