### PR TITLE
Fix incorrect use of `%w`

### DIFF
--- a/token.go
+++ b/token.go
@@ -90,13 +90,13 @@ func (c *Connection) TokensContext(
 			if code >= http.StatusInternalServerError {
 				c.logger.Error(ctx,
 					"OCM auth: failed to get tokens, got http code %d, "+
-						"will attempt to retry. err: %w",
+						"will attempt to retry. err: %v",
 					code, err)
 				return err
 			}
 			c.logger.Error(ctx,
 				"OCM auth: failed to get tokens, got http code %d, "+
-					"will not attempt to retry. err: %w",
+					"will not attempt to retry. err: %v",
 				code, err)
 			return backoff.Permanent(err)
 		}


### PR DESCRIPTION
A previous patch replaced uses of `%v` in calls to `fmt.Errorf` with `%w`, but
it also replaced `%v` with `%w` in some log messages. That results in those log
messages not being generated correctly. This patch fixes that.