### PR TITLE
Don't crash in debug mode deserializing an empty response

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -84,8 +84,13 @@ func (d *dumpRoundTripper) RoundTrip(request *http.Request) (response *http.Resp
 		if err != nil {
 			return
 		}
-		d.dumpResponse(ctx, response, body)
-		response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		if len(body) == 0 {
+			d.dumpResponse(ctx, response, nil)
+			response.Body = http.NoBody // checked by Unmarshal* functions.
+		} else {
+			d.dumpResponse(ctx, response, body)
+			response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		}
 	} else {
 		d.dumpResponse(ctx, response, nil)
 	}


### PR DESCRIPTION
Fixes https://github.com/openshift-online/ocm-sdk-go/issues/296 — was crashing with typed interface for cluster creation with &dryRun=true which returns 204 No Content when dry run is successful.

@jhernand @nimrodshn @igoihman please review.