### PR TITLE
Add `!include` configuration tag

### DIFF
--- a/configuration/doc.go
+++ b/configuration/doc.go
@@ -49,9 +49,10 @@ limitations under the License.
 //
 // The following tags are supported:
 //
-//	!variable MYVARIABLE - Is replaced by the content of the environment variable `MYVARIABLE`.
 //	!file /my/file.txt - Is replaced by the content of the file `/my/file.txt`.
+//	!include /my/file.yaml - Is replaced by the result of parsing the `/my/file.yaml` file.
 //	!shell myscript - Is replaced by the result of executing the `myscript` shell script.
+//	!variable MYVARIABLE - Is replaced by the content of the environment variable `MYVARIABLE`.
 //
 // Tag names can be abbreviated. For example these are all valid tags:
 //
@@ -59,6 +60,7 @@ limitations under the License.
 //	!v MYVARIABLE - Replaced by the content of the environment variablel `MYVARIABLE`.
 //	!f /my/file.txt - Replaced by the content of the `/my.file.txt` file.
 //	!sh myscript - Replaced by the result of execution the `myscript` shell script.
+//	!inc /my/file.yaml - Replaced by the result of parsing the `/my/file.yaml` file.
 //
 // The `file` tag trims all leading and traling white space from the content of the file.
 //

--- a/configuration/object_test.go
+++ b/configuration/object_test.go
@@ -724,6 +724,120 @@ var _ = Describe("Object", func() {
 					User: "myuser",
 				},
 			),
+			Entry(
+				"Include string",
+				`
+				user: !include myuser.yaml
+				`,
+				nil,
+				map[string]string{
+					"myuser.yaml": "myuser",
+				},
+				Config{
+					User: "myuser",
+				},
+			),
+			Entry(
+				"Include bool",
+				`
+				enabled: !include myenabled.yaml
+				`,
+				nil,
+				map[string]string{
+					"myenabled.yaml": "true",
+				},
+				Config{
+					Enabled: true,
+				},
+			),
+			Entry(
+				"Include int",
+				`
+				id: !include myid.yaml
+				`,
+				nil,
+				map[string]string{
+					"myid.yaml": "123",
+				},
+				Config{
+					ID: 123,
+				},
+			),
+			Entry(
+				"Include map",
+				`
+				!include mymap.yaml
+				`,
+				nil,
+				map[string]string{
+					"mymap.yaml": "{ user: myuser, id: 123 }",
+				},
+				Config{
+					User: "myuser",
+					ID: 123,
+				},
+			),
+			Entry(
+				"Include chain",
+				`
+				user: !include first.yaml
+				`,
+				nil,
+				map[string]string{
+					"first.yaml": "!include second.yaml",
+					"second.yaml": "myuser",
+				},
+				Config{
+					User: "myuser",
+				},
+			),
+			Entry(
+				"Include chain and variable",
+				`
+				user: !include first.yaml
+				`,
+				map[string]string{
+					"MYUSER": "myuser",
+				},
+				map[string]string{
+					"first.yaml": "!include second.yaml",
+					"second.yaml": "!variable MYUSER",
+				},
+				Config{
+					User: "myuser",
+				},
+			),
+			Entry(
+				"Include chain and file",
+				`
+				user: !include first.yaml
+				`,
+				nil,
+				map[string]string{
+					"first.yaml": "!include second.yaml",
+					"second.yaml": "!file myuser.txt",
+					"myuser.txt": "myuser",
+				},
+				Config{
+					User: "myuser",
+				},
+			),
+			Entry(
+				"Include chain and shell",
+				`
+				user: !include first.yaml
+				`,
+				map[string]string{
+					"MYUSER": "myuser",
+				},
+				map[string]string{
+					"first.yaml": "!include second.yaml",
+					"second.yaml": "!shell echo -n ${MYUSER}",
+				},
+				Config{
+					User: "myuser",
+				},
+			),
 		)
 
 		It("Fails if environment variable doesn't exist", func() {


### PR DESCRIPTION
The `!include` configuration tag takes the name of a file as value and replaces
it with the result of parsing that file. For example, the following two files:

    # Main configuration file:
    alternative_urls: !include alternative_urls.yaml

    # Secondary configuration file:
    - /api/clusters_mtmt: https://my.server.com
    - /api/accounts_mgmt: https://your.server.com

Will result in the following configuration:

    alternative_urls:
    - /api/clusters_mtmt: https://my.server.com
    - /api/accounts_mgmt: https://your.server.com