### PR TITLE
Add `!yaml` configuration tag

### DIFF
--- a/configuration/doc.go
+++ b/configuration/doc.go
@@ -41,35 +41,33 @@ limitations under the License.
 //	}
 //
 // The advantage of using this configuration instead of using plain YAML is that configuration
-// sources can use the the `!variable` and `!file` tags to reference environment variables
-// or files. For example:
+// sources can use the tags to reference environment variables, files and scripts. For example:
 //
 //	mykey: !variable MYVARIABLE
 //	yourkey: !file /my/file.txt
 //
 // The following tags are supported:
 //
-//	!variable MYVARIABLE - Is replaced by the content of the environment variable `MYVARIABLE`.
 //	!file /my/file.txt - Is replaced by the content of the file `/my/file.txt`.
-//	!shell myscript - Is replaced by the result of executing the `myscript` shell script.
+//	!script myscript - Is replaced by the result of executing the `myscript` script.
+//	!trim mytext - Is replaced by the result of trimming white space from `mytext`.
+//	!variable MYVARIABLE - Is replaced by the content of the environment variable `MYVARIABLE`.
+//	!yaml mytext - Is replaced by the result of parsing `mytext` as YAML.
 //
 // Tag names can be abbreviated. For example these are all valid tags:
 //
-//	!var MYVARIABLE - Replaced by the content of the environment variablel `MYVARIABLE`.
-//	!v MYVARIABLE - Replaced by the content of the environment variablel `MYVARIABLE`.
 //	!f /my/file.txt - Replaced by the content of the `/my.file.txt` file.
-//	!sh myscript - Replaced by the result of execution the `myscript` shell script.
+//	!s myscript - Replaced by the result of execution the `myscript` script.
+//	!v MYVARIABLE - Replaced by the content of the environment variablel `MYVARIABLE`.
 //
-// The `file` tag trims all leading and traling white space from the content of the file.
+// By default the tags replace the value of node they are applied to with a string. This will not
+// work for fields that are declared of other types in the configuration struct. In those cases it
+// is possible to add a suffix to the tag to indicate the type of the replacmenet. For example:
 //
-// By default the tags replace the node they are applied to with a string. This will not work for
-// fields that are declared of other types in the configuration struct. In those cases it is
-// possible to add a suffix to the tag to indicate the type of the replacmenet.  For example:
-//
-//  # A configuration with an integer loaded from an environment variable
-//  # and a boolean loaded from a file:
-//  myid: !variable/int MYID
-//  myenabled: !file/bool /my/enabled.txt
+//	# A configuration with an integer loaded from an environment variable and a boolean
+//	# loaded from a file:
+//	myid: !variable/integer MYID
+//	myenabled: !file/boolean /my/enabled.txt
 //
 // This can be used with the following Go code:
 //
@@ -82,6 +80,11 @@ limitations under the License.
 //	if err != nil {
 //		...
 //	}
+//
+// Tags can be chained. For example to read a value from a file and trim white space from
+// the content:
+//
+//	mypassword: !file/trim mypassword.txt
 //
 // When multiple sources are configured (calling the Load method multiple times) they will all
 // be merged, and sources loaded later sources will override sources loaded earlier.

--- a/examples/dump_config.go
+++ b/examples/dump_config.go
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This example shows how to load a configuration and then dump the resulting YAML.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/ocm-sdk-go/configuration"
+)
+
+func main() {
+	// Create the configuration and load all the files given in the command line:
+	builder := configuration.New()
+	for _, arg := range os.Args[1:] {
+		builder.Load(arg)
+	}
+	object, err := builder.Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't load configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Dump the resulting YAML file:
+	effective, err := object.Effective()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't generate effective configuration: %v\n", err)
+		os.Exit(1)
+	}
+	_, err = os.Stdout.Write(effective)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't write effective configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Bye:
+	os.Exit(0)
+}


### PR DESCRIPTION
The `!yaml` configuration tag takes the value of a node and replaces it with
the result of parsing it as a YAML document. For example, the following two
files:

    # Main configuration file:
    alternative_urls: !file/yaml alternative_urls.yaml

    # Secondary configuration file:
    - /api/clusters_mtmt: https://my.server.com
    - /api/accounts_mgmt: https://your.server.com

Will result in the following configuration:

    alternative_urls:
    - /api/clusters_mtmt: https://my.server.com
    - /api/accounts_mgmt: https://your.server.com