### PR TITLE
Release 0.1.149

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.149 Nov 24 2020
+
+- Fix issue in the method that returns the URL of a connection: it was returning
+  an empty string when no alternative URLs were configured.
+
 == 0.1.148 Nov 23 2020
 
 - Rename `!shell` configuration tag to `!script`.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.148"
+const Version = "0.1.149"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fix issue in the method that returns the URL of a connection: it was returning
  an empty string when no alternative URLs were configured.