### PR TITLE
Move logging code to `logging` package

### DIFF
--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -38,14 +38,14 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/ghodss/yaml"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 // HandlerBuilder contains the data and logic needed to create a new authentication handler. Don't
 // create objects of this type directly, use the NewHandler function instead.
 type HandlerBuilder struct {
-	logger       sdk.Logger
+	logger       logging.Logger
 	publicPaths  []string
 	keysFiles    []string
 	keysURLs     []string
@@ -58,7 +58,7 @@ type HandlerBuilder struct {
 // Handler is an HTTP handler that checks authentication using the JWT tokens from the authorization
 // header.
 type Handler struct {
-	logger        sdk.Logger
+	logger        logging.Logger
 	publicPaths   []*regexp.Regexp
 	tokenParser   *jwt.Parser
 	keysFiles     []string
@@ -78,7 +78,7 @@ func NewHandler() *HandlerBuilder {
 
 // Logger sets the logger that the middleware will use to send messages to the log. This is
 // mandatory.
-func (b *HandlerBuilder) Logger(value sdk.Logger) *HandlerBuilder {
+func (b *HandlerBuilder) Logger(value logging.Logger) *HandlerBuilder {
 	b.logger = value
 	return b
 }

--- a/authentication/main_test.go
+++ b/authentication/main_test.go
@@ -27,13 +27,13 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/ghttp"
-
 	"github.com/dgrijalva/jwt-go"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+	"github.com/onsi/gomega/ghttp"
 )
 
 func TestAuthentication(t *testing.T) {
@@ -46,7 +46,7 @@ var publicKey *rsa.PublicKey
 var privateKey *rsa.PrivateKey
 
 // Logger used for tests:
-var logger sdk.Logger
+var logger logging.Logger
 
 // JSON web key set used for tests:
 var keysBytes []byte
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func() {
 	keysFile = keysFD.Name()
 
 	// Create the logger that will be used by all the tests:
-	logger, err = sdk.NewStdLoggerBuilder().
+	logger, err = logging.NewStdLoggerBuilder().
 		Streams(GinkgoWriter, GinkgoWriter).
 		Debug(true).
 		Build()

--- a/connection.go
+++ b/connection.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift-online/ocm-sdk-go/authorizations"
 	"github.com/openshift-online/ocm-sdk-go/clustersmgmt"
 	"github.com/openshift-online/ocm-sdk-go/configuration"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 	"github.com/openshift-online/ocm-sdk-go/servicelogs"
 )
 
@@ -62,7 +63,7 @@ var DefaultScopes = []string{
 // function instead.
 type ConnectionBuilder struct {
 	// Basic attributes:
-	logger            Logger
+	logger            logging.Logger
 	trustedCASources  []interface{}
 	trustedCAPool     *x509.CertPool
 	insecure          bool
@@ -97,7 +98,7 @@ type TransportWrapper func(http.RoundTripper) http.RoundTripper
 type Connection struct {
 	// Basic attributes:
 	closed            bool
-	logger            Logger
+	logger            logging.Logger
 	trustedCAs        *x509.CertPool
 	insecure          bool
 	disableKeepAlives bool
@@ -163,7 +164,7 @@ func NewConnectionBuilder() *ConnectionBuilder {
 // can create a logger and pass it to this method. For example:
 //
 //	// Create a logger with the debug level enabled:
-//	logger, err := client.NewGoLoggerBuilder().
+//	logger, err := logging.NewGoLoggerBuilder().
 //		Debug(true).
 //		Build()
 //	if err != nil {
@@ -179,7 +180,7 @@ func NewConnectionBuilder() *ConnectionBuilder {
 //	}
 //
 // You can also build your own logger, implementing the Logger interface.
-func (b *ConnectionBuilder) Logger(logger Logger) *ConnectionBuilder {
+func (b *ConnectionBuilder) Logger(logger logging.Logger) *ConnectionBuilder {
 	if b.err != nil {
 		return b
 	}
@@ -668,7 +669,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 
 	// Create the default logger, if needed:
 	if b.logger == nil {
-		b.logger, err = NewGoLoggerBuilder().
+		b.logger, err = logging.NewGoLoggerBuilder().
 			Debug(false).
 			Info(true).
 			Warn(true).
@@ -944,7 +945,7 @@ func (b *ConnectionBuilder) createTransport() (
 }
 
 // Logger returns the logger that is used by the connection.
-func (c *Connection) Logger() Logger {
+func (c *Connection) Logger() logging.Logger {
 	return c.logger
 }
 

--- a/deprecated_logger.go
+++ b/deprecated_logger.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains aliases for the types and functions that have been moved to the logging
+// package.
+
+package sdk
+
+import (
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+// Logger has been moved to the logging package.
+type Logger = logging.Logger
+
+// GlogLoggerBuilder has been moved to the logging package.
+type GlogLoggerBuilder = logging.GlogLoggerBuilder
+
+// GlogLogger has been moved to the logging package.
+type GlogLogger = logging.GlogLogger
+
+// NewGlogLoggerBuilder has been moved to the logging package.
+func NewGlogLoggerBuilder() *GlogLoggerBuilder {
+	return logging.NewGlogLoggerBuilder()
+}
+
+// GoLoggerBuilder has been moved to the logging package.
+type GoLoggerBuilder = logging.GoLoggerBuilder
+
+// GoLogger has been moved to the logging package.
+type GoLogger = logging.GoLogger
+
+// NewGoLoggerBuilder has been moved to the logging package.
+func NewGoLoggerBuilder() *GoLoggerBuilder {
+	return logging.NewGoLoggerBuilder()
+}
+
+// StdLoggerBuilder has been moved to the logging package.
+type StdLoggerBuilder = logging.StdLoggerBuilder
+
+// StdLogger has been moved to the logging package.
+type StdLogger = logging.StdLogger
+
+// NewStdLoggerBuilder has been moved to the logging package.
+func NewStdLoggerBuilder() *StdLoggerBuilder {
+	return logging.NewStdLoggerBuilder()
+}

--- a/deprecated_logger_test.go
+++ b/deprecated_logger_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains tests for the aliases of the types and functoins that have been
+// moved to the logging package.
+
+package sdk
+
+import (
+	"time"
+
+	// Never import the logging package here, as that will defeat the purpuse of
+	// these tests.
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+var _ = Describe("Deprecated logging", func() {
+	Describe("Interface", func() {
+		It("Can be declared", func() {
+			var logger Logger
+			Expect(logger).To(BeNil())
+		})
+	})
+
+	Describe("Go implementation", func() {
+		It("Can be created", func() {
+			var logger Logger
+			logger, err := NewGoLoggerBuilder().Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logger).ToNot(BeNil())
+		})
+	})
+
+	Describe("Std implementation", func() {
+		It("Can be created", func() {
+			var logger Logger
+			logger, err := NewStdLoggerBuilder().Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logger).ToNot(BeNil())
+		})
+	})
+
+	Describe("Glog implementation", func() {
+		It("Can be created", func() {
+			var logger Logger
+			logger, err := NewGlogLoggerBuilder().Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logger).ToNot(BeNil())
+		})
+	})
+
+	Describe("Connection", func() {
+		It("Can be created with deprecated logger", func() {
+			// Create the logger:
+			var logger Logger
+			logger, err := NewGoLoggerBuilder().Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logger).ToNot(BeNil())
+
+			// Create the connection:
+			token := DefaultToken("Bearer", 5*time.Minute)
+			connection, err := NewConnectionBuilder().
+				Logger(logger).
+				Tokens(token).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err = connection.Close()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+			Expect(connection).ToNot(BeNil())
+		})
+	})
+})

--- a/dump.go
+++ b/dump.go
@@ -31,12 +31,14 @@ import (
 	"strings"
 
 	"gitlab.com/c0b/go-ordered-json"
+
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 // dumpRoundTripper is a round tripper that dumps the details of the requests and the responses to
 // the log.
 type dumpRoundTripper struct {
-	logger Logger
+	logger logging.Logger
 	next   http.RoundTripper
 }
 

--- a/examples/client_credentials_grant.go
+++ b/examples/client_credentials_grant.go
@@ -26,6 +26,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -33,7 +34,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/create_cluster.go
+++ b/examples/create_cluster.go
@@ -23,6 +23,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -30,7 +31,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/create_syncset.go
+++ b/examples/create_syncset.go
@@ -26,6 +26,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,7 +36,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/delete_cluster.go
+++ b/examples/delete_cluster.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/delete_subscription.go
+++ b/examples/delete_subscription.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/existing_token.go
+++ b/examples/existing_token.go
@@ -27,6 +27,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -34,7 +35,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/export_control_review.go
+++ b/examples/export_control_review.go
@@ -25,6 +25,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	azv1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/get_cluster.go
+++ b/examples/get_cluster.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/get_cluster_credentials.go
+++ b/examples/get_cluster_credentials.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/get_cluster_logs.go
+++ b/examples/get_cluster_logs.go
@@ -26,6 +26,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -33,7 +34,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/get_cluster_metrics.go
+++ b/examples/get_cluster_metrics.go
@@ -25,6 +25,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/get_metadata.go
+++ b/examples/get_metadata.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/list_cloud_providers.go
+++ b/examples/list_cloud_providers.go
@@ -25,6 +25,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/list_cluster_creators.go
+++ b/examples/list_cluster_creators.go
@@ -26,6 +26,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -33,7 +34,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(false).
 		Build()
 	if err != nil {

--- a/examples/list_clusters.go
+++ b/examples/list_clusters.go
@@ -25,6 +25,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/list_quota_summary.go
+++ b/examples/list_quota_summary.go
@@ -26,6 +26,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -33,7 +34,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/list_versions.go
+++ b/examples/list_versions.go
@@ -25,6 +25,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/load_config.go
+++ b/examples/load_config.go
@@ -26,6 +26,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -33,7 +34,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -29,6 +29,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -40,7 +41,7 @@ func main() {
 	go http.ListenAndServe(":8000", promhttp.Handler())
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/resource_review.go
+++ b/examples/resource_review.go
@@ -25,6 +25,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	azv1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/run_cluster_operator_metrics.go
+++ b/examples/run_cluster_operator_metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This example shows how to use run of the metric queries provided for clusters management service.
+// This example shows how to use the metric queries provided for clusters management service.
 
 package main
 
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/run_metric_query.go
+++ b/examples/run_metric_query.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This example shows how to use run of the metric queries provided for clusters management service.
+// This example shows how to run one of the metric queries provided for clusters management service.
 
 package main
 
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/sync_addons.go
+++ b/examples/sync_addons.go
@@ -29,6 +29,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/examples/transport_wrapper.go
+++ b/examples/transport_wrapper.go
@@ -25,16 +25,17 @@ import (
 	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 type LoggingTransport struct {
-	logger  sdk.Logger
+	logger  logging.Logger
 	wrapped http.RoundTripper
 }
 
 // NewLoggingTransport creates a transport that sends basic details of requests to the
 // given logger. The wrapped transport will be used actually send the requests.
-func NewLoggingTransport(logger sdk.Logger, wrapped http.RoundTripper) http.RoundTripper {
+func NewLoggingTransport(logger logging.Logger, wrapped http.RoundTripper) http.RoundTripper {
 	return &LoggingTransport{
 		logger:  logger,
 		wrapped: wrapped,
@@ -57,7 +58,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(false).
 		Build()
 	if err != nil {

--- a/examples/update_cluster.go
+++ b/examples/update_cluster.go
@@ -25,6 +25,7 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a logger that has the debug level enabled:
-	logger, err := sdk.NewGoLoggerBuilder().
+	logger, err := logging.NewGoLoggerBuilder().
 		Debug(true).
 		Build()
 	if err != nil {

--- a/logging/glog_logger.go
+++ b/logging/glog_logger.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // This file contains a logger that uses the `glog` package.
 
-package sdk
+package logging
 
 import (
 	"context"

--- a/logging/go_logger.go
+++ b/logging/go_logger.go
@@ -14,44 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This file contains a logger that uses the standard output and error streams, or custom writers.
+// This file contains a logger that uses the Go `log` package.
 
-package sdk
+package logging
 
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
+	"log"
 )
 
-// StdLoggerBuilder contains the configuration and logic needed to build a logger that uses the
-// standard output and error streams, or custom writers.
-type StdLoggerBuilder struct {
+// GoLoggerBuilder contains the configuration and logic needed to build a logger that uses the Go
+// `log` package. Don't create instances of this type directly, use the NewGoLoggerBuilder function
+// instead.
+type GoLoggerBuilder struct {
 	debugEnabled bool
 	infoEnabled  bool
 	warnEnabled  bool
 	errorEnabled bool
-	outStream    io.Writer
-	errStream    io.Writer
 }
 
-// StdLogger is a logger that uses the standard output and error streams, or custom writers.
-type StdLogger struct {
+// GoLogger is a logger that uses the Go `log` package.
+type GoLogger struct {
 	debugEnabled bool
 	infoEnabled  bool
 	warnEnabled  bool
 	errorEnabled bool
-	outStream    io.Writer
-	errStream    io.Writer
 }
 
-// NewStdLoggerBuilder creates a builder that knows how to build a logger that uses the standard
-// output and error streams, or custom writers. By default these loggers will have enabled the
-// information, warning and error levels
-func NewStdLoggerBuilder() *StdLoggerBuilder {
+// NewGoLoggerBuilder creates a builder that knows how to build a logger that uses the Go `log`
+// package. By default these loggers will have enabled the information, warning and error levels
+func NewGoLoggerBuilder() *GoLoggerBuilder {
 	// Allocate the object:
-	builder := new(StdLoggerBuilder)
+	builder := new(GoLoggerBuilder)
 
 	// Set default values:
 	builder.debugEnabled = false
@@ -62,106 +57,98 @@ func NewStdLoggerBuilder() *StdLoggerBuilder {
 	return builder
 }
 
-// Streams sets the standard output and error streams to use. If not used then the logger will use
-// os.Stdout and os.Stderr.
-func (b *StdLoggerBuilder) Streams(out io.Writer, err io.Writer) *StdLoggerBuilder {
-	b.outStream = out
-	b.errStream = err
-	return b
-}
-
 // Debug enables or disables the debug level.
-func (b *StdLoggerBuilder) Debug(flag bool) *StdLoggerBuilder {
+func (b *GoLoggerBuilder) Debug(flag bool) *GoLoggerBuilder {
 	b.debugEnabled = flag
 	return b
 }
 
 // Info enables or disables the information level.
-func (b *StdLoggerBuilder) Info(flag bool) *StdLoggerBuilder {
+func (b *GoLoggerBuilder) Info(flag bool) *GoLoggerBuilder {
 	b.infoEnabled = flag
 	return b
 }
 
 // Warn enables or disables the warning level.
-func (b *StdLoggerBuilder) Warn(flag bool) *StdLoggerBuilder {
+func (b *GoLoggerBuilder) Warn(flag bool) *GoLoggerBuilder {
 	b.warnEnabled = flag
 	return b
 }
 
 // Error enables or disables the error level.
-func (b *StdLoggerBuilder) Error(flag bool) *StdLoggerBuilder {
+func (b *GoLoggerBuilder) Error(flag bool) *GoLoggerBuilder {
 	b.errorEnabled = flag
 	return b
 }
 
 // Build creates a new logger using the configuration stored in the builder.
-func (b *StdLoggerBuilder) Build() (logger *StdLogger, err error) {
+func (b *GoLoggerBuilder) Build() (logger *GoLogger, err error) {
 	// Allocate and populate the object:
-	logger = new(StdLogger)
+	logger = new(GoLogger)
 	logger.debugEnabled = b.debugEnabled
 	logger.infoEnabled = b.infoEnabled
 	logger.warnEnabled = b.warnEnabled
 	logger.errorEnabled = b.errorEnabled
-	logger.outStream = b.outStream
-	logger.errStream = b.errStream
-	if logger.outStream == nil {
-		logger.outStream = os.Stdout
-	}
-	if logger.errStream == nil {
-		logger.errStream = os.Stderr
-	}
 
 	return
 }
 
 // DebugEnabled returns true iff the debug level is enabled.
-func (l *StdLogger) DebugEnabled() bool {
+func (l *GoLogger) DebugEnabled() bool {
 	return l.debugEnabled
 }
 
 // InfoEnabled returns true iff the information level is enabled.
-func (l *StdLogger) InfoEnabled() bool {
+func (l *GoLogger) InfoEnabled() bool {
 	return l.infoEnabled
 }
 
 // WarnEnabled returns true iff the warning level is enabled.
-func (l *StdLogger) WarnEnabled() bool {
+func (l *GoLogger) WarnEnabled() bool {
 	return l.warnEnabled
 }
 
 // ErrorEnabled returns true iff the error level is enabled.
-func (l *StdLogger) ErrorEnabled() bool {
+func (l *GoLogger) ErrorEnabled() bool {
 	return l.errorEnabled
 }
 
 // Debug sends to the log a debug message formatted using the fmt.Sprintf function and the given
 // format and arguments.
-func (l *StdLogger) Debug(ctx context.Context, format string, args ...interface{}) {
+func (l *GoLogger) Debug(ctx context.Context, format string, args ...interface{}) {
 	if l.debugEnabled {
-		fmt.Fprintf(l.outStream, format+"\n", args...)
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
 	}
 }
 
 // Info sends to the log an information message formatted using the fmt.Sprintf function and the
 // given format and arguments.
-func (l *StdLogger) Info(ctx context.Context, format string, args ...interface{}) {
+func (l *GoLogger) Info(ctx context.Context, format string, args ...interface{}) {
 	if l.infoEnabled {
-		fmt.Fprintf(l.outStream, format+"\n", args...)
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
 	}
 }
 
 // Warn sends to the log a warning message formatted using the fmt.Sprintf function and the given
 // format and arguments.
-func (l *StdLogger) Warn(ctx context.Context, format string, args ...interface{}) {
+func (l *GoLogger) Warn(ctx context.Context, format string, args ...interface{}) {
 	if l.infoEnabled {
-		fmt.Fprintf(l.outStream, format+"\n", args...)
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
 	}
 }
 
 // Error sends to the log an error message formatted using the fmt.Sprintf function and the given
 // format and arguments.
-func (l *StdLogger) Error(ctx context.Context, format string, args ...interface{}) {
-	if l.infoEnabled {
-		fmt.Fprintf(l.errStream, format+"\n", args...)
+func (l *GoLogger) Error(ctx context.Context, format string, args ...interface{}) {
+	if l.errorEnabled {
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
 	}
 }

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // This file contains the definition of the logger interface that is used by the client.
 
-package sdk
+package logging
 
 import (
 	"context"

--- a/main_test.go
+++ b/main_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/onsi/gomega/ghttp"
 
+	"github.com/openshift-online/ocm-sdk-go/logging"
+
 	. "github.com/onsi/ginkgo" // nolint
 	. "github.com/onsi/gomega" // nolint
 )
@@ -43,7 +45,7 @@ func TestClient(t *testing.T) {
 }
 
 // Logger used during the tests:
-var logger Logger
+var logger logging.Logger
 
 var _ = BeforeSuite(func() {
 	var err error
@@ -55,7 +57,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create the logger:
-	logger, err = NewStdLoggerBuilder().
+	logger, err = logging.NewStdLoggerBuilder().
 		Streams(GinkgoWriter, GinkgoWriter).
 		Debug(true).
 		Build()

--- a/methods_test.go
+++ b/methods_test.go
@@ -42,9 +42,6 @@ var _ = Describe("Methods", func() {
 	var oidCA string
 	var apiCA string
 
-	// Logger used during the testss:
-	var logger Logger
-
 	// Connection used during the tests:
 	var connection *Connection
 


### PR DESCRIPTION
This is intended to allow use of the logging package from other sub-packages
that currently can't use it because it would introduce import loops.

Applications don't need to be changed inmediately because there are aliases in
the main package for the relevant types and functions.