### PR TITLE
Rename `Metrics` to `MetricsSubsystem`

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -117,6 +117,7 @@ type Connection struct {
 	scopes            []string
 
 	// Metrics:
+	metricsSubsystem    string
 	tokenCountMetric    *prometheus.CounterVec
 	tokenDurationMetric *prometheus.HistogramVec
 	callCountMetric     *prometheus.CounterVec
@@ -789,6 +790,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 		accessToken:       accessToken,
 		refreshToken:      refreshToken,
 		scopes:            scopes,
+		metricsSubsystem:  b.metricsSubsystem,
 	}
 
 	// Create the mutex that protects token manipulations:
@@ -1012,6 +1014,12 @@ func (c *Connection) Insecure() bool {
 
 func (c *Connection) DisableKeepAlives() bool {
 	return c.disableKeepAlives
+}
+
+// MetricsSubsystem returns the name of the subsystem that is used by the connection to register
+// metrics with Prometheus. An empty string means that no metrics are registered.
+func (c *Connection) MetricsSubsystem() string {
+	return c.metricsSubsystem
 }
 
 // AlternativeURLs returns the alternative URLs in use by the connection. Note that the map returned

--- a/connection.go
+++ b/connection.go
@@ -518,18 +518,19 @@ func (b *ConnectionBuilder) Load(source interface{}) *ConnectionBuilder {
 		return b
 	}
 	var view struct {
-		URL             *string           `yaml:"url"`
-		AlternativeURLs map[string]string `yaml:"alternative_urls"`
-		TokenURL        *string           `yaml:"token_url"`
-		User            *string           `yaml:"user"`
-		Password        *string           `yaml:"password"`
-		ClientID        *string           `yaml:"client_id"`
-		ClientSecret    *string           `yaml:"client_secret"`
-		Tokens          []string          `yaml:"tokens"`
-		Insecure        *bool             `yaml:"insecure"`
-		TrustedCAs      []string          `yaml:"trusted_cas"`
-		Scopes          []string          `yaml:"scopes"`
-		Agent           *string           `yaml:"agent"`
+		URL              *string           `yaml:"url"`
+		AlternativeURLs  map[string]string `yaml:"alternative_urls"`
+		TokenURL         *string           `yaml:"token_url"`
+		User             *string           `yaml:"user"`
+		Password         *string           `yaml:"password"`
+		ClientID         *string           `yaml:"client_id"`
+		ClientSecret     *string           `yaml:"client_secret"`
+		Tokens           []string          `yaml:"tokens"`
+		Insecure         *bool             `yaml:"insecure"`
+		TrustedCAs       []string          `yaml:"trusted_cas"`
+		Scopes           []string          `yaml:"scopes"`
+		Agent            *string           `yaml:"agent"`
+		MetricsSubsystem *string           `yaml:"metrics_subsystem"`
 	}
 	b.err = config.Populate(&view)
 	if b.err != nil {
@@ -600,6 +601,11 @@ func (b *ConnectionBuilder) Load(source interface{}) *ConnectionBuilder {
 	// Agent:
 	if view.Agent != nil {
 		b.Agent(*view.Agent)
+	}
+
+	// Metrics subsystem:
+	if view.MetricsSubsystem != nil {
+		b.MetricsSubsystem(*view.MetricsSubsystem)
 	}
 
 	return b

--- a/connection_test.go
+++ b/connection_test.go
@@ -375,6 +375,7 @@ var _ = Describe("Connection", func() {
 			- {{ .Tmp }}/myca.pem
 			- {{ .Tmp }}/yourca.pem
 			agent: myagent
+			metrics_subsystem: mysubsystem
 			`,
 			"Tmp", tmp,
 			"AccessToken", generatedAccess,
@@ -426,6 +427,7 @@ var _ = Describe("Connection", func() {
 		Expect(connection.Scopes()).To(ConsistOf("openid", "myscope"))
 		Expect(connection.Insecure()).To(BeTrue())
 		Expect(connection.Agent()).To(Equal("myagent"))
+		Expect(connection.MetricsSubsystem()).To(Equal("mysubsystem"))
 	})
 
 	It("Method calls after load override configuration file", func() {
@@ -466,6 +468,7 @@ var _ = Describe("Connection", func() {
 			- {{ .Tmp }}/myca.pem
 			- {{ .Tmp }}/yourca.pem
 			agent: myagent
+			metrics_subsystem: mysubsystem
 			`,
 			"Tmp", tmp,
 			"AccessToken", generatedAccess,
@@ -500,6 +503,7 @@ var _ = Describe("Connection", func() {
 			Scopes("openid", "overriden.myscope").
 			Insecure(false).
 			Agent("overriden.myagent").
+			MetricsSubsystem("overriden_mysubsystem").
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -531,6 +535,7 @@ var _ = Describe("Connection", func() {
 		Expect(connection.Scopes()).To(ConsistOf("openid", "overriden.myscope"))
 		Expect(connection.Insecure()).To(BeFalse())
 		Expect(connection.Agent()).To(Equal("overriden.myagent"))
+		Expect(connection.MetricsSubsystem()).To(Equal("overriden_mysubsystem"))
 	})
 
 	It("Method calls before load don't override configuration file", func() {
@@ -571,6 +576,7 @@ var _ = Describe("Connection", func() {
 			- {{ .Tmp }}/myca.pem
 			- {{ .Tmp }}/yourca.pem
 			agent: myagent
+			metrics_subsystem: mysubsystem
 			`,
 			"Tmp", tmp,
 			"AccessToken", generatedAccess,
@@ -603,6 +609,7 @@ var _ = Describe("Connection", func() {
 			Scopes("openid", "overriden.myscope").
 			Insecure(false).
 			Agent("overriden.myagent").
+			MetricsSubsystem("overriden_mysubsystem").
 			Load(path).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -635,6 +642,7 @@ var _ = Describe("Connection", func() {
 		Expect(connection.Scopes()).To(ConsistOf("openid", "myscope"))
 		Expect(connection.Insecure()).To(BeTrue())
 		Expect(connection.Agent()).To(Equal("myagent"))
+		Expect(connection.MetricsSubsystem()).To(Equal("mysubsystem"))
 	})
 
 	It("Returns configured URL when there are no alternative URLs", func() {

--- a/connection_test.go
+++ b/connection_test.go
@@ -110,6 +110,22 @@ var _ = Describe("Connection", func() {
 		Expect(connection).ToNot(BeNil())
 	})
 
+	It("Can be created with metrics subsystem", func() {
+		accessToken := DefaultToken("Bearer", 5*time.Minute)
+		connection, err := NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			MetricsSubsystem("my_subsystem").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(connection).ToNot(BeNil())
+		defer func() {
+			err = connection.Close()
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		Expect(connection.MetricsSubsystem()).To(Equal("my_subsystem"))
+	})
+
 	It("Selects default OpenID server with default access token", func() {
 		accessToken := DefaultToken("Bearer", 5*time.Minute)
 		connection, err := NewConnectionBuilder().

--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -55,7 +55,7 @@ func main() {
 	connection, err := sdk.NewConnectionBuilder().
 		Logger(logger).
 		Tokens(token).
-		Metrics("api_outbound").
+		MetricsSubsystem("api_outbound").
 		BuildContext(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)

--- a/methods_test.go
+++ b/methods_test.go
@@ -66,12 +66,12 @@ var _ = Describe("Methods", func() {
 		// Metrics subsystem - value doesn't matter but configuring it enables
 		// prometheus exporting, exercising the counter increment functionality
 		// (e.g. will catch inconsistent labels).
-		metrics := "test_subsystem"
+		metricsSubsystem := "test_subsystem"
 
 		// Create the connection:
 		connection, err = NewConnectionBuilder().
 			Logger(logger).
-			Metrics(metrics).
+			MetricsSubsystem(metricsSubsystem).
 			TokenURL(oidServer.URL()).
 			URL(apiServer.URL()).
 			Tokens(refreshToken).

--- a/token_test.go
+++ b/token_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Tokens", func() {
 	// Metrics subsystem - value doesn't matter but configuring it enables
 	// prometheus exporting, exercising the counter increment functionality
 	// (e.g. will catch inconsistent labels).
-	metrics := "test_subsystem"
+	metricsSubsystem := "test_subsystem"
 
 	BeforeEach(func() {
 		// Create the servers:
@@ -84,7 +84,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -117,7 +117,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -155,7 +155,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -188,7 +188,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -224,7 +224,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -247,7 +247,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -269,7 +269,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -291,7 +291,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -329,7 +329,7 @@ var _ = Describe("Tokens", func() {
 				// Create the connection:
 				connection, err := NewConnectionBuilder().
 					Logger(logger).
-					Metrics(metrics).
+					MetricsSubsystem(metricsSubsystem).
 					TokenURL(oidServer.URL()).
 					URL(apiServer.URL()).
 					TrustedCAFile(oidCA).
@@ -371,7 +371,7 @@ var _ = Describe("Tokens", func() {
 				// Create the connection:
 				connection, err := NewConnectionBuilder().
 					Logger(logger).
-					Metrics(metrics).
+					MetricsSubsystem(metricsSubsystem).
 					TokenURL(oidServer.URL()).
 					URL(apiServer.URL()).
 					TrustedCAFile(oidCA).
@@ -412,7 +412,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -451,7 +451,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -489,7 +489,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -532,7 +532,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -575,7 +575,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -608,7 +608,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -635,7 +635,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -671,7 +671,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -701,7 +701,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -725,7 +725,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -760,7 +760,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				TrustedCAFile(oidCA).
 				TrustedCAFile(apiCA).
@@ -798,7 +798,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				TrustedCAFile(oidCA).
 				TrustedCAFile(apiCA).
@@ -841,7 +841,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -884,7 +884,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -917,7 +917,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -944,7 +944,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -981,7 +981,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -1020,7 +1020,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -1068,7 +1068,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -1116,7 +1116,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).
@@ -1151,7 +1151,7 @@ var _ = Describe("Tokens", func() {
 			// Create the connection:
 			connection, err := NewConnectionBuilder().
 				Logger(logger).
-				Metrics(metrics).
+				MetricsSubsystem(metricsSubsystem).
 				TokenURL(oidServer.URL()).
 				URL(apiServer.URL()).
 				TrustedCAFile(oidCA).


### PR DESCRIPTION
This set of patches rename the `Metrics` method to `MetricsSubsystem`, as it reflects better what it does. It also adds support for loading the value from the configuration file.

The old `Metrics` method is preserved for backwards compatibility.