### PR TITLE
Load string if it doesn't look like a file

### DIFF
--- a/configuration/main_test.go
+++ b/configuration/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package configuration
 
 import (
-	"regexp"
 	"testing"
 
 	. "github.com/onsi/ginkgo" // nolint
@@ -28,12 +27,3 @@ func TestConfiguration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Configuration")
 }
-
-// RemoveLeadingTabs removes the leading tabs from the lines of the given string.
-func RemoveLeadingTabs(s string) string {
-	return leadingTabsRE.ReplaceAllString(s, "")
-}
-
-// leadingTabsRE is the regular expression used to remove leading tabs from strings generated with
-// the EvaluateTemplate function.
-var leadingTabsRE = regexp.MustCompile(`(?m)^\t*`)


### PR DESCRIPTION
This patch changes the `Load` method of the configuration object so that it
will interpret strings that don't end in `.yaml`, `.yml` or `.d` as YAML text.
This is very convenient for embedding the configuration in Go code. For
example:

```go
connection, err := sdk.NewConnectionBuilder().
	Logger(logger).
	Load(`
		url: https://my.server.com
		token_url: https://your.server.com
		tokens:
		- eY...
	`).
	Build()
if err != nil {
	...
}
```

This use case is very common in tests.