### PR TITLE
Load `os.Stdin` in dump configuration example

### DIFF
--- a/examples/dump_config.go
+++ b/examples/dump_config.go
@@ -28,8 +28,13 @@ import (
 func main() {
 	// Create the configuration and load all the files given in the command line:
 	builder := configuration.New()
-	for _, arg := range os.Args[1:] {
-		builder.Load(arg)
+	args := os.Args[1:]
+	if len(args) > 0 {
+		for _, arg := range args {
+			builder.Load(arg)
+		}
+	} else {
+		builder.Load(os.Stdin)
 	}
 	object, err := builder.Build()
 	if err != nil {


### PR DESCRIPTION
This patch changes the `dump_config.go` example so that it loads the
configuration from standard input when no command line arguments are provided.