### PR TITLE
Add support for Unix sockets

### DIFF
--- a/alternative_url_test.go
+++ b/alternative_url_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Alternative URLs", func() {
 		refreshToken = DefaultToken("Refresh", 10*time.Hour)
 
 		// Create the OpenID server:
-		oidServer, oidCA = MakeServer()
+		oidServer, oidCA = MakeTCPTLSServer()
 		oidServer.AppendHandlers(
 			ghttp.CombineHandlers(
 				RespondWithTokens(accessToken, refreshToken),
@@ -64,9 +64,9 @@ var _ = Describe("Alternative URLs", func() {
 		oidURL = oidServer.URL()
 
 		// Create the API servers:
-		defaultServer, defaultCA = MakeServer()
+		defaultServer, defaultCA = MakeTCPTLSServer()
 		defaultURL = defaultServer.URL()
-		alternativeServer, alternativeCA = MakeServer()
+		alternativeServer, alternativeCA = MakeTCPTLSServer()
 		alternativeURL = alternativeServer.URL()
 	})
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -893,6 +893,74 @@ var _ = Describe("Connection", func() {
 		Expect(message).To(ContainSubstring("http:///yourpath"))
 		Expect(message).To(ContainSubstring("host name"))
 	})
+
+	It("Can be created with Unix network and host", func() {
+		token := DefaultToken("Bearer", 5*time.Minute)
+		connection, err := NewConnectionBuilder().
+			Logger(logger).
+			URL("unix://my.server.com/tmp/api.socket").
+			Tokens(token).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(connection).ToNot(BeNil())
+	})
+
+	It("Can be created with Unix network and HTTPS", func() {
+		token := DefaultToken("Bearer", 5*time.Minute)
+		connection, err := NewConnectionBuilder().
+			Logger(logger).
+			URL("unix+https://my.server.com/tmp/api.socket").
+			Tokens(token).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(connection).ToNot(BeNil())
+	})
+
+	It("Can't be created with Unix network and no host", func() {
+		token := DefaultToken("Bearer", 5*time.Minute)
+		connection, err := NewConnectionBuilder().
+			Logger(logger).
+			URL("unix:/tmp/api.socket").
+			Tokens(token).
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(connection).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("unix:/tmp/api.socket"))
+		Expect(message).To(ContainSubstring("host"))
+		Expect(message).To(ContainSubstring("mandatory"))
+	})
+
+	It("Can't be created with incorrect network", func() {
+		token := DefaultToken("Bearer", 5*time.Minute)
+		connection, err := NewConnectionBuilder().
+			Logger(logger).
+			URL("junk+https://my.server.com").
+			Tokens(token).
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(connection).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("junk"))
+		Expect(message).To(ContainSubstring("network"))
+		Expect(message).To(ContainSubstring("tcp"))
+		Expect(message).To(ContainSubstring("unix"))
+	})
+
+	It("Can't be created with Unix network and no socket", func() {
+		token := DefaultToken("Bearer", 5*time.Minute)
+		connection, err := NewConnectionBuilder().
+			Logger(logger).
+			URL("unix://my.server.com").
+			Tokens(token).
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(connection).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("unix"))
+		Expect(message).To(ContainSubstring("socket"))
+		Expect(message).To(ContainSubstring("path"))
+	})
 })
 
 type TestTransport struct {

--- a/dump.go
+++ b/dump.go
@@ -121,6 +121,9 @@ var redactFields = map[string]bool{
 func (d *dumpRoundTripper) dumpRequest(ctx context.Context, request *http.Request, body []byte) {
 	d.logger.Debug(ctx, "Request method is %s", request.Method)
 	d.logger.Debug(ctx, "Request URL is '%s'", request.URL)
+	if request.Host != "" {
+		d.logger.Debug(ctx, "Request header 'Host' is '%s'", request.Host)
+	}
 	header := request.Header
 	names := make([]string, len(header))
 	i := 0

--- a/methods_test.go
+++ b/methods_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Methods", func() {
 		refreshToken := DefaultToken("Refresh", 10*time.Hour)
 
 		// Create the OpenID server:
-		oidServer, oidCA = MakeServer()
+		oidServer, oidCA = MakeTCPTLSServer()
 		oidServer.AppendHandlers(
 			ghttp.CombineHandlers(
 				RespondWithTokens(accessToken, refreshToken),
@@ -61,7 +61,7 @@ var _ = Describe("Methods", func() {
 		)
 
 		// Create the API server:
-		apiServer, apiCA = MakeServer()
+		apiServer, apiCA = MakeTCPTLSServer()
 
 		// Metrics subsystem - value doesn't matter but configuring it enables
 		// prometheus exporting, exercising the counter increment functionality

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Redirect", func() {
 		refreshToken = DefaultToken("Refresh", 10*time.Hour)
 
 		// Create the OpenID server:
-		oidServer, oidCA = MakeServer()
+		oidServer, oidCA = MakeTCPTLSServer()
 		oidServer.AppendHandlers(
 			ghttp.CombineHandlers(
 				RespondWithTokens(accessToken, refreshToken),
@@ -70,9 +70,9 @@ var _ = Describe("Redirect", func() {
 		oidURL = oidServer.URL()
 
 		// Create the API servers:
-		redirectServer, redirectCA = MakeServer()
+		redirectServer, redirectCA = MakeTCPTLSServer()
 		redirectURL = redirectServer.URL()
-		realServer, realCA = MakeServer()
+		realServer, realCA = MakeTCPTLSServer()
 		realURL = realServer.URL()
 
 		// Configure the real server so that it verifies that the request is

--- a/token.go
+++ b/token.go
@@ -349,8 +349,14 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 		request = request.WithContext(ctx)
 	}
 
+	// Select the HTTP client:
+	client, err := c.selectClient(ctx, c.tokenURL)
+	if err != nil {
+		return
+	}
+
 	// Send the HTTP request:
-	response, err := c.client.Do(request)
+	response, err := client.Do(request)
 	if err != nil {
 		err = fmt.Errorf("can't send request: %w", err)
 		return

--- a/token_test.go
+++ b/token_test.go
@@ -51,8 +51,8 @@ var _ = Describe("Tokens", func() {
 
 	BeforeEach(func() {
 		// Create the servers:
-		oidServer, oidCA = MakeServer()
-		apiServer, apiCA = MakeServer()
+		oidServer, oidCA = MakeTCPTLSServer()
+		apiServer, apiCA = MakeTCPTLSServer()
 	})
 
 	AfterEach(func() {
@@ -999,7 +999,7 @@ var _ = Describe("Tokens", func() {
 			Expect(returnedRefresh).To(Equal(newRefresh))
 		})
 
-		It("Honors cookies", func() {
+		It("Honours cookies", func() {
 			// Generate the tokens:
 			expiredAccess := DefaultToken("Bearer", -5*time.Minute)
 			validAccess := DefaultToken("Bearer", 5*time.Minute)

--- a/unix_sockets_test.go
+++ b/unix_sockets_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains tests for the support for Unix sockets.
+
+package sdk
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Unix sockets", func() {
+	var accessToken string
+	var refreshToken string
+	var oidServer *ghttp.Server
+	var oidSocket string
+	var oidURL string
+
+	BeforeEach(func() {
+		// Create the tokens:
+		accessToken = DefaultToken("Bearer", 5*time.Minute)
+		refreshToken = DefaultToken("Refresh", 10*time.Hour)
+
+		// Create the OpenID server:
+		oidServer, oidSocket = MakeUnixServer()
+		oidServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				RespondWithTokens(accessToken, refreshToken),
+			),
+		)
+		oidURL = "unix://127.0.0.1" + oidSocket
+	})
+
+	AfterEach(func() {
+		// Stop the OpenID server:
+		oidServer.Close()
+	})
+
+	Describe("With HTTP", func() {
+		var apiServer *ghttp.Server
+		var apiURL string
+		var apiSocket string
+		var connection *Connection
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the server:
+			apiServer, apiSocket = MakeUnixServer()
+			apiURL = "unix://127.0.0.1" + apiSocket
+
+			// Create the connection:
+			connection, err = NewConnectionBuilder().
+				Logger(logger).
+				TokenURL(oidURL).
+				URL(apiURL).
+				Tokens(accessToken, refreshToken).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			var err error
+
+			// Close the connection:
+			err = connection.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Close the server:
+			apiServer.Close()
+
+			// Remore the temporary files and directories:
+			err = os.RemoveAll(filepath.Dir(apiSocket))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Get", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					RespondWithJSON(http.StatusOK, `{
+						"href": "/api/clusters_mgmt"
+					}`),
+				),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.String()).To(MatchJSON(`{
+				"href": "/api/clusters_mgmt"
+			}`))
+		})
+	})
+
+	Describe("With HTTPS", func() {
+		var apiServer *ghttp.Server
+		var apiURL string
+		var apiCA string
+		var apiSocket string
+		var connection *Connection
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the server:
+			apiServer, apiCA, apiSocket = MakeUnixTLSServer()
+			apiURL = "unix+https://127.0.0.1" + apiSocket
+
+			// Create the connection:
+			connection, err = NewConnectionBuilder().
+				Logger(logger).
+				TokenURL(oidURL).
+				URL(apiURL).
+				Tokens(accessToken, refreshToken).
+				TrustedCAFile(apiCA).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			var err error
+
+			// Close the connection:
+			err = connection.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Close the server:
+			apiServer.Close()
+
+			// Remore the temporary files and directories:
+			err = os.RemoveAll(apiCA)
+			Expect(err).ToNot(HaveOccurred())
+			err = os.RemoveAll(filepath.Dir(apiSocket))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Get", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					RespondWithJSON(http.StatusOK, `{
+						"href": "/api/clusters_mgmt"
+					}`),
+				),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.String()).To(MatchJSON(`{
+				"href": "/api/clusters_mgmt"
+			}`))
+		})
+	})
+
+	Describe("With Unix and TCP simultaneously", func() {
+		var unixServer *ghttp.Server
+		var unixURL string
+		var unixSocket string
+		var tcpServer *ghttp.Server
+		var tcpURL string
+		var connection *Connection
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the the main server, using Unix sockets:
+			unixServer, unixSocket = MakeUnixServer()
+			unixURL = "unix://127.0.0.1" + unixSocket
+
+			// Make the alternative, using TCP:
+			tcpServer = MakeTCPServer()
+			tcpURL = tcpServer.URL()
+
+			// Create the connection:
+			connection, err = NewConnectionBuilder().
+				Logger(logger).
+				TokenURL(oidURL).
+				AlternativeURL("/api/clusters_mgmt", unixURL).
+				AlternativeURL("/api/accounts_mgmt", tcpURL).
+				Tokens(accessToken, refreshToken).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			var err error
+
+			// Close the connection:
+			err = connection.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Close the servers:
+			unixServer.Close()
+			tcpServer.Close()
+
+			// Remore the temporary files and directories:
+			err = os.RemoveAll(filepath.Dir(unixSocket))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Get", func() {
+			// Configure the servers:
+			unixServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					RespondWithJSON(http.StatusOK, `{
+						"href": "/api/clusters_mgmt"
+					}`),
+				),
+			)
+			tcpServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					RespondWithJSON(http.StatusOK, `{
+						"href": "/api/accounts_mgmt"
+					}`),
+				),
+			)
+
+			// Send a request to the Unix server:
+			unixResponse, err := connection.Get().
+				Path("/api/clusters_mgmt").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unixResponse.String()).To(MatchJSON(`{
+				"href": "/api/clusters_mgmt"
+			}`))
+
+			// Send a request to the TCP server:
+			tcpResponse, err := connection.Get().
+				Path("/api/accounts_mgmt").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tcpResponse.String()).To(MatchJSON(`{
+				"href": "/api/accounts_mgmt"
+			}`))
+		})
+	})
+})


### PR DESCRIPTION
This patch adds support for connecting to the server using Unix sockets:

```go
connection, err := NewConnectionBuilder().
        Logger(logger).
        Tokens(token).
        URL("unix://my.host.com/tmp/api.socket").
        Build()
if err != nil {
        ...
}
```