### PR TITLE
Declare go 1.15 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-online/ocm-sdk-go
 
-go 1.12
+go 1.15
 
 require (
 	github.com/cenkalti/backoff/v4 v4.0.0


### PR DESCRIPTION
This is a soft requirement: older versions of Go shows a message *if* the build fails.

> The go directive in a go.mod file now indicates the version of the language used by the files within that module. It will be set to the current release (go 1.12) if no existing version is present. If the go directive for a module specifies a version newer than the toolchain in use, the go command will attempt to build the packages regardless, and will note the mismatch only if that build fails.
> — https://golang.org/doc/go1.12#modules

In this case with Go 1.14 the build does fail, so this helps:
```diff
 cd examples && \
 for i in *.go; do \
 	go build ${i} || exit 1; \
 done
 # github.com/openshift-online/ocm-sdk-go
 ../send.go:340:14: undefined: tls.Dialer
 ../send.go:343:4: not enough arguments to return
+note: module requires Go 1.15
 make: *** [Makefile:34: examples] Error 1
```

P.S. The directive also controls "[which language features are available](https://golang.org/ref/mod#go-mod-file-go)", don't know what that means in practice.