### PR TITLE
connection: Skip loading SystemCertPool on Windows

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -27,6 +27,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -881,9 +882,16 @@ func (b *ConnectionBuilder) createCookieJar() (jar http.CookieJar, err error) {
 
 func (b *ConnectionBuilder) loadTrustedCAs(ctx context.Context) error {
 	var err error
-	b.trustedCAPool, err = x509.SystemCertPool()
-	if err != nil {
-		return err
+	if runtime.GOOS == "windows" {
+		// crypto/x509: system root pool is not available on Windows
+		// @see https://github.com/golang/go/issues/16736
+		// @see https://github.com/golang/go/issues/18609
+		b.trustedCAPool = x509.NewCertPool()
+	} else {
+		b.trustedCAPool, err = x509.SystemCertPool()
+		if err != nil {
+			return err
+		}
 	}
 	for _, ca := range b.trustedCASources {
 		switch source := ca.(type) {


### PR DESCRIPTION
Since the root system cert pool is not available on Windows we
instantiate an empty cert pool to which we can add the trusted sources.