### PR TITLE
Accept Empty Reader as non-nil req body

### DIFF
--- a/send.go
+++ b/send.go
@@ -114,8 +114,8 @@ func (c *Connection) send(ctx context.Context, request *http.Request) (response 
 	switch request.Method {
 	case http.MethodGet, http.MethodDelete:
 		if request.Body != nil {
-			err = fmt.Errorf(
-				"request body is not allowed for the '%s' method",
+			c.logger.Warn(ctx,
+				"Request body is not allowed for the '%s' method",
 				request.Method,
 			)
 			return


### PR DESCRIPTION
Passing a req such as `http.NewRequest('GET', '/api/clusters_mgmt/v1/.., bytes.NewReader(nil))` treated the reader with nil buffer as a non-empty req-body. Should we verify first the length of the body before determining if its non-empty.
cc: @jhernand @igoihman  