### PR TITLE
Downgrade to Go 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-online/ocm-sdk-go
 
-go 1.15
+go 1.14
 
 require (
 	github.com/cenkalti/backoff/v4 v4.0.0

--- a/send.go
+++ b/send.go
@@ -336,10 +336,17 @@ func (c *Connection) createTransport(ctx context.Context, base *urlInfo) (
 			return dialer.DialContext(ctx, base.network, base.socket)
 		}
 		transport.DialTLSContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
-			dialer := tls.Dialer{
-				Config: config,
-			}
-			return dialer.DialContext(ctx, base.network, base.socket)
+			// TODO: This ignores the passed context because it isn't currently
+			// supported. Once we migrate to Go 1.15 it should be done like this:
+			//
+			//	dialer := tls.Dialer{
+			//		Config: config,
+			//	}
+			//	return dialer.DialContext(ctx, base.network, base.socket)
+			//
+			// This will only have a negative impact in applications that specify a
+			// deadline or timeout in the passed context, as it will be ignored.
+			return tls.Dial(base.network, base.socket, config)
 		}
 	}
 


### PR DESCRIPTION
This patch downgrades the version of the Go required by the SDK from
1.15 to 1.14. The reason to do that is that many users of the SDK are
finding difficulties to migrate to 1.15 due to the lack of that
version in RHEL and to the issues with X.509 certificates and the
obsolete `CN` field that it introduces.

The price to pay is that connections to servers that use TLS over Unix
sockets will be marginally less robust because there is no support Go
1.15 doesn't support passing contexts to the `tls.Dial` function.