### PR TITLE
Remove logger from metrics transport wrapper

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -806,7 +806,6 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 	if b.metricsSubsystem != "" {
 		var wrapper *metrics.TransportWrapper
 		wrapper, err = metrics.NewTransportWrapper().
-			Logger(b.logger).
 			Path(tokenURL.Path).
 			Subsystem(b.metricsSubsystem).
 			Registerer(b.metricsRegisterer).

--- a/metrics/main_test.go
+++ b/metrics/main_test.go
@@ -29,17 +29,3 @@ func TestMetrics(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Metrics")
 }
-
-// Logger used during the tests:
-var logger logging.Logger
-
-var _ = BeforeSuite(func() {
-	var err error
-
-	// Create thelogger:
-	logger, err = logging.NewStdLoggerBuilder().
-		Streams(GinkgoWriter, GinkgoWriter).
-		Debug(true).
-		Build()
-	Expect(err).ToNot(HaveOccurred())
-})

--- a/metrics/transport_wrapper.go
+++ b/metrics/transport_wrapper.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/openshift-online/ocm-sdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -71,7 +70,6 @@ import (
 //
 // Don't create objects of this type directly; use the NewTransportWrapper function instead.
 type TransportWrapperBuilder struct {
-	logger     logging.Logger
 	paths      []string
 	subsystem  string
 	registerer prometheus.Registerer
@@ -80,7 +78,6 @@ type TransportWrapperBuilder struct {
 // TransportWrapper contains the data and logic needed to wrap an HTTP round tripper with another
 // one that generates Prometheus metrics.
 type TransportWrapper struct {
-	logger          logging.Logger
 	paths           pathTree
 	requestCount    *prometheus.CounterVec
 	requestDuration *prometheus.HistogramVec
@@ -109,12 +106,6 @@ func NewTransportWrapper() *TransportWrapperBuilder {
 // accumulated in the `/-` path.
 func (b *TransportWrapperBuilder) Path(value string) *TransportWrapperBuilder {
 	b.paths = append(b.paths, value)
-	return b
-}
-
-// Logger sets the logger that will be used by the round tripper. This is mandatory.
-func (b *TransportWrapperBuilder) Logger(value logging.Logger) *TransportWrapperBuilder {
-	b.logger = value
 	return b
 }
 
@@ -148,10 +139,6 @@ func (b *TransportWrapperBuilder) Registerer(value prometheus.Registerer) *Trans
 // Build uses the information stored in the builder to create a new transport wrapper.
 func (b *TransportWrapperBuilder) Build() (result *TransportWrapper, err error) {
 	// Check parameters:
-	if b.logger == nil {
-		err = fmt.Errorf("logger is mandatory")
-		return
-	}
 	if b.subsystem == "" {
 		err = fmt.Errorf("subsystem is mandatory")
 		return
@@ -211,7 +198,6 @@ func (b *TransportWrapperBuilder) Build() (result *TransportWrapper, err error) 
 
 	// Create and populate the object:
 	result = &TransportWrapper{
-		logger:          b.logger,
 		paths:           paths,
 		requestCount:    requestCount,
 		requestDuration: requestDuration,

--- a/metrics/transport_wrapper_test.go
+++ b/metrics/transport_wrapper_test.go
@@ -32,20 +32,8 @@ import (
 )
 
 var _ = Describe("Create", func() {
-	It("Can't be created without a logger", func() {
-		wrapper, err := NewTransportWrapper().
-			Subsystem("my").
-			Build()
-		Expect(err).To(HaveOccurred())
-		Expect(wrapper).To(BeNil())
-		message := err.Error()
-		Expect(message).To(ContainSubstring("logger"))
-		Expect(message).To(ContainSubstring("mandatory"))
-	})
-
 	It("Can't be created without a subsystem", func() {
 		wrapper, err := NewTransportWrapper().
-			Logger(logger).
 			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(wrapper).To(BeNil())
@@ -69,7 +57,6 @@ var _ = Describe("Metrics", func() {
 
 		// Create the API client:
 		apiWrapper, err := NewTransportWrapper().
-			Logger(logger).
 			Path("/my/path").
 			Subsystem("my").
 			Registerer(metricsServer.Registry()).


### PR DESCRIPTION
This patch removes the logger parameter from the metrics transport
wrapper, as it isn't used.