### PR TITLE
Reorder execution of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ examples:
 		go build $${i} || exit 1; \
 	done
 
-.PHONY: test
-test:
+.PHONY: test tests
+test tests:
 	ginkgo -p -r .
 
 .PHONY: fmt

--- a/metrics/main_test.go
+++ b/metrics/main_test.go
@@ -19,8 +19,6 @@ package metrics
 import (
 	"testing"
 
-	"github.com/openshift-online/ocm-sdk-go/logging"
-
 	. "github.com/onsi/ginkgo" // nolint
 	. "github.com/onsi/gomega" // nolint
 )

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,6 +27,16 @@ export PATH="${GOBIN}:${PATH}"
 go get github.com/onsi/ginkgo/ginkgo@v1.8.0
 go get golang.org/x/tools/cmd/goimports@v0.0.0-20200518194103-259583f2d8a9
 
+# Remove the temporary model and metamodel directories, as otherwise `ginkgo`
+# will try to run the tests inside them:
+rm -rf model metamodel
+
+# Run the checks:
+make \
+  test \
+  examples \
+  lint
+
 # Check that running `make generate` doesn't introduce any change in the
 # generated code:
 make generate
@@ -35,13 +45,3 @@ if [ $? = 1 ]; then
   echo "Generated code isn't in sync with model and metamodel"
   exit 1
 fi
-
-# Remove the temporary model and metamodel directories, as otherwise `ginkgo`
-# will try to run the tests inside them:
-rm -rf model metamodel
-
-# Run the checks:
-make \
-  examples \
-  test \
-  lint


### PR DESCRIPTION
This patch reorders the execution of tests in the Jenkins environment so
that the tests that provide more value (unit tests in this case) are
executed first. This way if those fail the developer will be notified
sooner, and there will be no need to run the other less valuable (and
longer) tests.

The patch also introduces a `tests` Makefile target that does exactly
the same than the existing `test` target. This is because I frequently
type `make tests` and I get upset because it doesn't work.