### PR TITLE
Add `h2c` support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/prometheus/client_golang v1.9.0
 	gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/api v0.18.5

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -398,10 +398,11 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/h2c_test.go
+++ b/h2c_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains tests for the support for Unix sockets.
+
+package sdk
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("H2C", func() {
+	var (
+		accessToken  string
+		refreshToken string
+		oidServer    *ghttp.Server
+	)
+
+	BeforeEach(func() {
+		// Create the tokens:
+		accessToken = DefaultToken("Bearer", 5*time.Minute)
+		refreshToken = DefaultToken("Refresh", 10*time.Hour)
+
+		// Create the OpenID server:
+		oidServer = MakeTCPServer()
+		oidServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				RespondWithTokens(accessToken, refreshToken),
+			),
+		)
+	})
+
+	AfterEach(func() {
+		// Stop the OpenID server:
+		oidServer.Close()
+	})
+
+	Describe("With TCP", func() {
+		var (
+			apiServer  *ghttp.Server
+			connection *Connection
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the API server:
+			apiServer = MakeTCPH2CServer()
+
+			// Alter the URL scheme to force use of HTTP/2 without TLS:
+			apiURL, err := url.Parse(apiServer.URL())
+			Expect(err).ToNot(HaveOccurred())
+			apiURL.Scheme = "h2c"
+
+			// Create the connection:
+			connection, err = NewConnectionBuilder().
+				Logger(logger).
+				TokenURL(oidServer.URL()).
+				URL(apiURL.String()).
+				Tokens(accessToken, refreshToken).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			var err error
+
+			// Close the connection:
+			err = connection.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Stop the API server:
+			apiServer.Close()
+		})
+
+		It("Uses HTTP/2.0", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						Expect(r.Proto).To(Equal("HTTP/2.0"))
+					}),
+					RespondWithJSON(http.StatusOK, `{
+						"href": "/api/clusters_mgmt"
+					}`),
+				),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.String()).To(MatchJSON(`{
+				"href": "/api/clusters_mgmt"
+			}`))
+		})
+	})
+
+	Describe("With Unix socket", func() {
+		var (
+			apiServer  *ghttp.Server
+			apiSocket  string
+			connection *Connection
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the API server:
+			apiServer, apiSocket = MakeUnixH2CServer()
+			apiURL := "unix+h2c://127.0.0.1" + apiSocket
+
+			// Create the connection:
+			connection, err = NewConnectionBuilder().
+				Logger(logger).
+				TokenURL(oidServer.URL()).
+				URL(apiURL).
+				Tokens(accessToken, refreshToken).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			var err error
+
+			// Close the connection:
+			err = connection.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Stop the API server:
+			apiServer.Close()
+
+			// Remore the temporary files and directories:
+			err = os.RemoveAll(filepath.Dir(apiSocket))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Uses HTTP/2.0", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						Expect(r.Proto).To(Equal("HTTP/2.0"))
+					}),
+					RespondWithJSON(http.StatusOK, `{
+						"href": "/api/clusters_mgmt"
+					}`),
+				),
+			)
+
+			// Send the request:
+			response, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.String()).To(MatchJSON(`{
+				"href": "/api/clusters_mgmt"
+			}`))
+		})
+	})
+})


### PR DESCRIPTION
This patch adds support for using HTTP/2 without TLS. This will be
enabled when using URLs like `h2c://...` or `unix+h2c://...`.