### PR TITLE
Add support for HTTP/2 with TLS

### DIFF
--- a/authentication/main_test.go
+++ b/authentication/main_test.go
@@ -104,6 +104,7 @@ func MakeTLSServer() *ghttp.Server {
 	server := ghttp.NewTLSServer()
 	server.Writer = GinkgoWriter
 	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	server.HTTPTestServer.EnableHTTP2 = true
 	return server
 }
 

--- a/dump.go
+++ b/dump.go
@@ -165,6 +165,7 @@ func (d *dumpRoundTripper) dumpRequest(ctx context.Context, request *http.Reques
 
 // dumpResponse dumps to the log, in debug level, the details of the given HTTP response.
 func (d *dumpRoundTripper) dumpResponse(ctx context.Context, response *http.Response, body []byte) {
+	d.logger.Debug(ctx, "Response protocol is '%s'", response.Proto)
 	d.logger.Debug(ctx, "Response status is '%s'", response.Status)
 	header := response.Header
 	names := make([]string, len(header))

--- a/main_test.go
+++ b/main_test.go
@@ -74,6 +74,7 @@ func MakeTCPServer() *ghttp.Server {
 	server := ghttp.NewUnstartedServer()
 	server.Writer = GinkgoWriter
 	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	server.HTTPTestServer.EnableHTTP2 = true
 	server.HTTPTestServer.Start()
 	return server
 }
@@ -96,6 +97,7 @@ func MakeUnixServer() (server *ghttp.Server, socket string) {
 	server = ghttp.NewUnstartedServer()
 	server.Writer = GinkgoWriter
 	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	server.HTTPTestServer.EnableHTTP2 = true
 	server.HTTPTestServer.Listener = listener
 	server.HTTPTestServer.Start()
 
@@ -111,6 +113,7 @@ func MakeTCPTLSServer() (server *ghttp.Server, ca string) {
 	server = ghttp.NewUnstartedServer()
 	server.Writer = GinkgoWriter
 	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	server.HTTPTestServer.EnableHTTP2 = true
 	server.HTTPTestServer.StartTLS()
 
 	// Fetch the CA certificate:
@@ -141,6 +144,7 @@ func MakeUnixTLSServer() (server *ghttp.Server, ca, socket string) {
 	server = ghttp.NewUnstartedServer()
 	server.Writer = GinkgoWriter
 	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	server.HTTPTestServer.EnableHTTP2 = true
 	server.HTTPTestServer.Listener = listener
 	server.HTTPTestServer.StartTLS()
 
@@ -160,6 +164,7 @@ func MakeTCPH2CServer() *ghttp.Server {
 	server := ghttp.NewUnstartedServer()
 	server.Writer = GinkgoWriter
 	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	server.HTTPTestServer.EnableHTTP2 = true
 
 	// Wrap the handler of the regular server with the handler that detects HTTP/2 requests
 	// without TLS and delegates them to the HTTP/2 server that supports that:
@@ -192,6 +197,7 @@ func MakeUnixH2CServer() (server *ghttp.Server, socket string) {
 	server = ghttp.NewUnstartedServer()
 	server.Writer = GinkgoWriter
 	server.HTTPTestServer.Config.ErrorLog = log.New(GinkgoWriter, "", log.LstdFlags)
+	server.HTTPTestServer.EnableHTTP2 = true
 	server.HTTPTestServer.Listener = listener
 
 	// Wrap the handler of the regular server with the handler that detects HTTP/2 requests

--- a/methods_test.go
+++ b/methods_test.go
@@ -319,6 +319,24 @@ var _ = Describe("Methods", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
 		})
+
+		It("Uses HTTP/2", func() {
+			// Configure the server:
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						Expect(r.Proto).To(Equal("HTTP/2.0"))
+					}),
+					RespondWithJSON(http.StatusOK, ""),
+				),
+			)
+
+			// Send the request:
+			_, err := connection.Get().
+				Path("/mypath").
+				Send()
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Describe("Post", func() {

--- a/send.go
+++ b/send.go
@@ -287,6 +287,7 @@ func (c *Connection) createTransport(ctx context.Context, base *urlInfo) (
 			Proxy:              http.ProxyFromEnvironment,
 			DisableKeepAlives:  c.disableKeepAlives,
 			DisableCompression: false,
+			ForceAttemptHTTP2:  true,
 		}
 
 		// In order to use Unix sockets we need to explicitly set dialers that use `unix` as


### PR DESCRIPTION
Currently the SDK doesn't use HTTP/2 even with servers that support it,
because the Go HTTP library automatically disables it when using custom
TLS settings. This patch uses the `ForceAttemptHTTP2` transport
parameter to enable it.