### PR TITLE
Release 0.1.164

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,14 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.164 Mar 17 2021
+
+- Change default user agent to `OCM-SDK`.
+- Update to model 0.0.111:
+** Add subscription metrics.
+** Add `deprovision` and `force` parameters to delete cluster method.
+** Ensure all subscription fields are available.
+
 == 0.1.163 Mar 5 2021
 
 - Enable compression.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.163"
+const Version = "0.1.164"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Change default user agent to `OCM-SDK`.
- Update to model 0.0.111:
  - Add subscription metrics.
  - Add `deprovision` and `force` parameters to delete cluster method.
  - Ensure all subscription fields are available.