### PR TITLE
Release 0.1.165

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.165 Mar 22 2021
+
+- Fix wrong TLS server name (issue
+  https://github.com/openshift-online/ocm-sdk-go/issues/356[356]).
+
 == 0.1.164 Mar 17 2021
 
 - Change default user agent to `OCM-SDK`.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.164"
+const Version = "0.1.165"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fix wrong TLS server name.

Related: https://github.com/openshift-online/ocm-sdk-go/issues/356