### PR TITLE
Move client selection logic to separate type

### DIFF
--- a/internal/client_selector.go
+++ b/internal/client_selector.go
@@ -1,0 +1,383 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the implementation of the object that selects the HTTP client to use to
+// connect to servers using TCP or Unix sockets.
+
+package internal
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"sync"
+
+	"golang.org/x/net/http2"
+
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+// ClientSelectorBuilder contains the information and logic needed to create an HTTP client
+// selector. Don't create instances of this type directly, use the NewClientSelector function.
+type ClientSelectorBuilder struct {
+	logger            logging.Logger
+	trustedCASources  []interface{}
+	insecure          bool
+	disableKeepAlives bool
+	transportWrappers []func(http.RoundTripper) http.RoundTripper
+}
+
+// ClientSelector contains the information needed to create select the HTTP client to use to connect
+// to servers using TCP or Unix sockets.
+type ClientSelector struct {
+	logger            logging.Logger
+	trustedCAs        *x509.CertPool
+	insecure          bool
+	disableKeepAlives bool
+	transportWrappers []func(http.RoundTripper) http.RoundTripper
+	cookieJar         http.CookieJar
+	clientsMutex      *sync.Mutex
+	clientsTable      map[string]*http.Client
+}
+
+// NewClientSelector creates a builder that can then be used to configure and create an HTTP client
+// selector.
+func NewClientSelector() *ClientSelectorBuilder {
+	return &ClientSelectorBuilder{}
+}
+
+// Logger sets the logger that will be used by the selector and by the created HTTP clients to write
+// messages to the log. This is mandatory.
+func (b *ClientSelectorBuilder) Logger(value logging.Logger) *ClientSelectorBuilder {
+	b.logger = value
+	return b
+}
+
+// TrustedCAs sets the certificate pool that contains the certificate authorities that will be
+// trusted by the HTTP clients. If this isn't explicitly specified then the clients will trust the
+// certificate authorities trusted by default by the system.
+func (b *ClientSelectorBuilder) TrustedCAs(value *x509.CertPool) *ClientSelectorBuilder {
+	b.trustedCASources = append(b.trustedCASources, value)
+	return b
+}
+
+// TrustedCAFile sets the name of a file that contains the certificate authorities that will be
+// trusted by the HTTP clients. If this isn't explicitly specified then the clients will trust the
+// certificate authorities trusted by default by the system.
+func (b *ClientSelectorBuilder) TrustedCAFile(value string) *ClientSelectorBuilder {
+	b.trustedCASources = append(b.trustedCASources, value)
+	return b
+}
+
+// Insecure enables insecure communication with the servers. This disables verification of TLS
+// certificates and host names and it isn't recommended for a production environment.
+func (b *ClientSelectorBuilder) Insecure(flag bool) *ClientSelectorBuilder {
+	b.insecure = flag
+	return b
+}
+
+// DisableKeepAlives disables HTTP keep-alives with the serviers. This is unrelated to similarly
+// named TCP keep-alives.
+func (b *ClientSelectorBuilder) DisableKeepAlives(flag bool) *ClientSelectorBuilder {
+	b.disableKeepAlives = flag
+	return b
+}
+
+// TransportWrapper adds a function that will be used to wrap the transports of the HTTP clients. If
+// used multiple times the transport wrappers will be called in the same order that they are added.
+func (b *ClientSelectorBuilder) TransportWrapper(
+	value func(http.RoundTripper) http.RoundTripper) *ClientSelectorBuilder {
+	b.transportWrappers = append(b.transportWrappers, value)
+	return b
+}
+
+// Build uses the information stored in the builder to create a new HTTP client selector.
+func (b *ClientSelectorBuilder) Build(ctx context.Context) (result *ClientSelector, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+
+	// Create the cookie jar:
+	cookieJar, err := b.createCookieJar()
+	if err != nil {
+		return
+	}
+
+	// Load trusted CAs:
+	trustedCAs, err := b.loadTrustedCAs(ctx)
+	if err != nil {
+		return
+	}
+
+	// Create and populate the object:
+	result = &ClientSelector{
+		logger:            b.logger,
+		trustedCAs:        trustedCAs,
+		insecure:          b.insecure,
+		disableKeepAlives: b.disableKeepAlives,
+		transportWrappers: b.transportWrappers,
+		cookieJar:         cookieJar,
+		clientsMutex:      &sync.Mutex{},
+		clientsTable:      map[string]*http.Client{},
+	}
+
+	return
+}
+
+func (b *ClientSelectorBuilder) loadTrustedCAs(ctx context.Context) (result *x509.CertPool,
+	err error) {
+	result, err = loadSystemCAs()
+	if err != nil {
+		return
+	}
+	for _, ca := range b.trustedCASources {
+		switch source := ca.(type) {
+		case *x509.CertPool:
+			b.logger.Debug(
+				ctx,
+				"Default trusted CA certificates have been explicitly replaced",
+			)
+			result = source
+		case string:
+			b.logger.Debug(
+				ctx,
+				"Loading trusted CA certificates from file '%s'",
+				source,
+			)
+			var buffer []byte
+			buffer, err = ioutil.ReadFile(source) // #nosec G304
+			if err != nil {
+				result = nil
+				err = fmt.Errorf(
+					"can't read trusted CA certificates from file '%s': %w",
+					source, err,
+				)
+				return
+			}
+			if !result.AppendCertsFromPEM(buffer) {
+				result = nil
+				err = fmt.Errorf(
+					"file '%s' doesn't contain any certificate",
+					source,
+				)
+				return
+			}
+		default:
+			result = nil
+			err = fmt.Errorf(
+				"don't know how to load trusted CA from source of type '%T'",
+				source,
+			)
+			return
+		}
+	}
+	return
+}
+
+func (b *ClientSelectorBuilder) createCookieJar() (result http.CookieJar, err error) {
+	result, err = cookiejar.New(nil)
+	return
+}
+
+// Select returns an HTTP client to use to connect to the given server address. If a client has been
+// created previously for the server address it will be reused, otherwise it will be created.
+func (s *ClientSelector) Select(ctx context.Context, address *ServerAddress) (client *http.Client,
+	err error) {
+	// We need to use a different client for each TCP host name and each Unix socket because we
+	// explicitly set the TLS server name to the host name. For example, if the first request is
+	// for the SSO service (it will usually be) then we would set the TLS server name to
+	// `sso.redhat.com`. The next API request would then use the same client and therefore it
+	// will use `sso.redhat.com` as the TLS server name. If the server uses SNI to select the
+	// certificates it will then fail because the API server doesn't have any certificate for
+	// `sso.redhat.com`, it will return the default certificates, and then the validation would
+	// fail with an error message like this:
+	//
+	//      x509: certificate is valid for *.apps.app-sre-prod-04.i5h0.p1.openshiftapps.com,
+	//      api.app-sre-prod-04.i5h0.p1.openshiftapps.com,
+	//      rh-api.app-sre-prod-04.i5h0.p1.openshiftapps.com, not sso.redhat.com
+	//
+	// To avoid this we add the host name or socket path as a suffix to the key.
+	key := address.Network
+	switch address.Network {
+	case UnixNetwork:
+		key = fmt.Sprintf("%s:%s", key, address.Socket)
+	case TCPNetwork:
+		key = fmt.Sprintf("%s:%s", key, address.Host)
+	}
+
+	// We will be modifiying the clients table so we need to acquire the lock before proceeding:
+	s.clientsMutex.Lock()
+	defer s.clientsMutex.Unlock()
+
+	// Get an existing client, or create a new one if it doesn't exist yet:
+	client, ok := s.clientsTable[key]
+	if ok {
+		return
+	}
+	s.logger.Debug(ctx, "Client for key '%s' doesn't exist, will create it", key)
+	client, err = s.create(ctx, address)
+	if err != nil {
+		return
+	}
+	s.clientsTable[key] = client
+
+	return
+}
+
+// create creates a new HTTP client to use to connect to the given address.
+func (s *ClientSelector) create(ctx context.Context, address *ServerAddress) (result *http.Client,
+	err error) {
+	// Create the transport:
+	transport, err := s.createTransport(ctx, address)
+	if err != nil {
+		return
+	}
+
+	// Create the client:
+	result = &http.Client{
+		Jar:       s.cookieJar,
+		Transport: transport,
+	}
+	if s.logger.DebugEnabled() {
+		result.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+			s.logger.Info(
+				request.Context(),
+				"Following redirect from '%s' to '%s'",
+				via[0].URL,
+				request.URL,
+			)
+			return nil
+		}
+	}
+
+	return
+}
+
+// createTransport creates a new HTTP transport to use to connect to the given server address.
+func (s *ClientSelector) createTransport(ctx context.Context,
+	address *ServerAddress) (result http.RoundTripper, err error) {
+	// Prepare the TLS configuration:
+	// #nosec 402
+	config := &tls.Config{
+		ServerName:         address.Host,
+		InsecureSkipVerify: s.insecure,
+		RootCAs:            s.trustedCAs,
+	}
+
+	// Create the transport:
+	if address.Protocol != H2CProtocol {
+		// Create a regular transport. Note that this does support HTTP/2 with TLS, but
+		// not h2c:
+		transport := &http.Transport{
+			TLSClientConfig:    config,
+			Proxy:              http.ProxyFromEnvironment,
+			DisableKeepAlives:  s.disableKeepAlives,
+			DisableCompression: false,
+			ForceAttemptHTTP2:  true,
+		}
+
+		// In order to use Unix sockets we need to explicitly set dialers that use `unix` as
+		// network and the socket file as address, otherwise the HTTP client will always use
+		// `tcp` as the network and the host name from the request as the address:
+		if address.Network == UnixNetwork {
+			transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn,
+				error) {
+				dialer := net.Dialer{}
+				return dialer.DialContext(ctx, UnixNetwork, address.Socket)
+			}
+			transport.DialTLSContext = func(ctx context.Context,
+				_, _ string) (net.Conn, error) {
+				// TODO: This ignores the passed context because it isn't currently
+				// supported. Once we migrate to Go 1.15 it should be done like
+				// this:
+				//
+				//	dialer := tls.Dialer{
+				//		Config: config,
+				//	}
+				//	return dialer.DialContext(ctx, network, address.Socket)
+				//
+				// This will only have a negative impact in applications that
+				// specify a deadline or timeout in the passed context, as it
+				// will be ignored.
+				return tls.Dial(UnixNetwork, address.Socket, config)
+			}
+		}
+
+		// Prepare the result:
+		result = transport
+	} else {
+		// In order to use h2c we need to tell the transport to allow the `http` scheme:
+		transport := &http2.Transport{
+			AllowHTTP:          true,
+			DisableCompression: false,
+		}
+
+		// We also need to ignore TLS configuration when dialing, and explicitly set the
+		// network and socket when using Unix sockets:
+		if address.Network == UnixNetwork {
+			transport.DialTLS = func(_, _ string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(UnixNetwork, address.Socket)
+			}
+		} else {
+			transport.DialTLS = func(network, addr string, cfg *tls.Config) (net.Conn,
+				error) {
+				return net.Dial(network, addr)
+			}
+		}
+
+		// Prepare the result:
+		result = transport
+	}
+
+	// Transport wrappers are stored in the order that the round trippers that they create
+	// should be called. That means that we need to call them in reverse order.
+	for i := len(s.transportWrappers) - 1; i >= 0; i-- {
+		result = s.transportWrappers[i](result)
+	}
+
+	return
+}
+
+// TrustedCAs sets returns the certificate pool that contains the certificate authorities that are
+// trusted by the HTTP clients.
+func (s *ClientSelector) TrustedCAs() *x509.CertPool {
+	return s.trustedCAs
+}
+
+// Insecure returns the flag that indicates if insecure communication with the server is enabled.
+func (s *ClientSelector) Insecure() bool {
+	return s.insecure
+}
+
+// DisableKeepAlives retursnt the flag that indicates if HTTP keep alive is disabled.
+func (s *ClientSelector) DisableKeepAlives() bool {
+	return s.disableKeepAlives
+}
+
+// Close closes all the connections used by all the clients created by the selector.
+func (s *ClientSelector) Close() error {
+	for _, client := range s.clientsTable {
+		client.CloseIdleConnections()
+	}
+	return nil
+}

--- a/internal/client_selector_test.go
+++ b/internal/client_selector_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+var _ = Describe("Create client selector", func() {
+	It("Can't be created without a logger", func() {
+		selector, err := NewClientSelector().Build(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(selector).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("logger"))
+		Expect(message).To(ContainSubstring("mandatory"))
+	})
+})
+
+var _ = Describe("Select client", func() {
+	var (
+		ctx      context.Context
+		selector *ClientSelector
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Create the selector:
+		selector, err = NewClientSelector().
+			Logger(logger).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(selector).ToNot(BeNil())
+	})
+
+	AfterEach(func() {
+		// Close the selector:
+		err := selector.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Reuses client for same TCP address", func() {
+		address, err := ParseServerAddress(ctx, "tcp://my.server.com")
+		Expect(err).ToNot(HaveOccurred())
+		firstClient, err := selector.Select(ctx, address)
+		Expect(err).ToNot(HaveOccurred())
+		secondClient, err := selector.Select(ctx, address)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(secondClient).To(BeIdenticalTo(firstClient))
+	})
+
+	It("Doesn't reuse client for different TCP addresses", func() {
+		firstAddress, err := ParseServerAddress(ctx, "tcp://my.server.com")
+		Expect(err).ToNot(HaveOccurred())
+		secondAddress, err := ParseServerAddress(ctx, "tcp://your.server.com")
+		Expect(err).ToNot(HaveOccurred())
+		firstClient, err := selector.Select(ctx, firstAddress)
+		Expect(err).ToNot(HaveOccurred())
+		secondClient, err := selector.Select(ctx, secondAddress)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(secondClient == firstClient).To(BeFalse())
+	})
+
+	It("Reuses client for different TCP protocols", func() {
+		firstAddress, err := ParseServerAddress(ctx, "http://my.server.com")
+		Expect(err).ToNot(HaveOccurred())
+		secondAddress, err := ParseServerAddress(ctx, "https://my.server.com")
+		Expect(err).ToNot(HaveOccurred())
+		firstClient, err := selector.Select(ctx, firstAddress)
+		Expect(err).ToNot(HaveOccurred())
+		secondClient, err := selector.Select(ctx, secondAddress)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(secondClient == firstClient).To(BeTrue())
+	})
+
+	It("Doesn't resuse client for different Unix sockets", func() {
+		firstAddress, err := ParseServerAddress(ctx, "unix://my.server.com/my.socket")
+		Expect(err).ToNot(HaveOccurred())
+		secondAddress, err := ParseServerAddress(ctx, "unix://my.server.com/your.socket")
+		Expect(err).ToNot(HaveOccurred())
+		firstClient, err := selector.Select(ctx, firstAddress)
+		Expect(err).ToNot(HaveOccurred())
+		secondClient, err := selector.Select(ctx, secondAddress)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(secondClient == firstClient).To(BeFalse())
+	})
+})

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/openshift-online/ocm-sdk-go/logging"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal")
+}
+
+// Logger used during the tests:
+var logger logging.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create the logger:
+	logger, err = logging.NewStdLoggerBuilder().
+		Streams(GinkgoWriter, GinkgoWriter).
+		Debug(true).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/server_address.go
+++ b/internal/server_address.go
@@ -1,0 +1,325 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the implementation of the server address parser.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	neturl "net/url"
+	"strings"
+)
+
+// ServerAddress contains a parsed URL and additional information extracted from int, like the
+// network (tcp or unix) and the socket name (for Unix sockets).
+type ServerAddress struct {
+	// Text is the original text that was passed to the ParseServerAddress function to create
+	// this server address.
+	Text string
+
+	// Network is the network that should be used to connect to the server. Possible values are
+	// `tcp` and `unix`.
+	Network string
+
+	// Protocol is the application protocol used to connect to the server. Possible values are
+	// `http`, `https` and `h2c`.
+	Protocol string
+
+	// Host is the name of the host used to connect to the server. This will be populated only
+	// even when using Unix sockets, because clients will need it in order to populate the
+	// `Host` header.
+	Host string
+
+	// Port is the port number used to connect to the server. This will only be populated when
+	// using TCP. When using Unix sockets it will be zero.
+	Port string
+
+	// Socket is tha nem of the path of the Unix socket used to connect to the server.
+	Socket string
+
+	// URL is the regular URL calculated from this server address. The scheme will be `http` if
+	// the protocol is `http` or `h2c` and will be `https` if the protocol is https.
+	URL *neturl.URL
+}
+
+// ParseServerAddress parses the given text as a server address. Server addresses should be URLs
+// with this format:
+//
+//	network+protocol://host:port/path?network=...&protocol=...&socket=...
+//
+// The `network` and `protocol` parts of the scheme are optional.
+//
+// Valid values for the `network` part of the scheme are `unix` and `tcp`. If not specified the
+// default value is `tcp`.
+//
+// Valid values for the `protocol` part of the scheme are `http`, `https` and `h2c`. If not
+// specified the default value is `http`.
+//
+// The `host` is mandatory even when using Unix sockets, because it is necessary to populate the
+// `Host` header.
+//
+// The `port` part is optional. If not specified it will be 80 for HTTP and H2C and 443 for HTTPS.
+//
+// When using Unix sockets the `path` part will be used as the name of the Unix socket.
+//
+// The network protocol and Unix socket can alternatively be specified using the `network`,
+// `protocol` and `socket` query parameters. This is useful specially for specifying the Unix
+// sockets when the path of the URL has some other meaning. For example, in order to specify
+// the OpenID token URL it is usually necessary to include a path, so to use a Unix socket it
+// is necessary to put it in the `socket` parameter instead:
+//
+//	unix://my.sso.com/my/token/path?socket=/sockets/my.socket
+//
+// When the Unix socket is specified in the `socket` query parameter as in the above example
+// the URL path will be ignored.
+//
+// Some examples of valid server addresses:
+//
+//	- http://my.server.com - HTTP on top of TCP.
+//	- https://my.server.com - HTTPS on top of TCP.
+//	- unix://my.server.com/sockets/my.socket - HTTP on top Unix socket.
+//	- unix+https://my.server.com/sockets/my.socket - HTTPS on top of Unix socket.
+//	- h2c+unix://my.server.com?socket=/sockets/my.socket - H2C on top of Unix.
+func ParseServerAddress(ctx context.Context, text string) (result *ServerAddress, err error) {
+	// Parse the URL:
+	parsed, err := neturl.Parse(text)
+	if err != nil {
+		return
+	}
+	query := parsed.Query()
+
+	// Extract the network and protocol from the scheme:
+	networkFromScheme, protocolFromScheme, err := parseScheme(ctx, parsed.Scheme)
+	if err != nil {
+		return
+	}
+
+	// Check if the network is also specified with a query parameter. If it is it should not be
+	// conflicting with the value specified in the scheme.
+	var network string
+	networkValues, ok := query["network"]
+	if ok {
+		if len(networkValues) != 1 {
+			err = fmt.Errorf(
+				"expected exactly one value for the 'network' query parameter "+
+					"but found %d",
+				len(networkValues),
+			)
+			return
+		}
+		networkFromQuery := strings.TrimSpace(strings.ToLower(networkValues[0]))
+		err = checkNetwork(networkFromQuery)
+		if err != nil {
+			return
+		}
+		if networkFromScheme != "" && networkFromScheme != networkFromQuery {
+			err = fmt.Errorf(
+				"network '%s' from query parameter isn't compatible with "+
+					"network '%s' from scheme",
+				networkFromQuery, networkFromScheme,
+			)
+			return
+		}
+		network = networkFromQuery
+	} else {
+		network = networkFromScheme
+	}
+
+	// Check if the protocol is also specified with a query parameter. If it is it should not be
+	// conflicting with the value specified in the scheme.
+	var protocol string
+	protocolValues, ok := query["protocol"]
+	if ok {
+		if len(protocolValues) != 1 {
+			err = fmt.Errorf(
+				"expected exactly one value for the 'protocol' query parameter "+
+					"but found %d",
+				len(protocolValues),
+			)
+			return
+		}
+		protocolFromQuery := strings.TrimSpace(strings.ToLower(protocolValues[0]))
+		err = checkProtocol(protocolFromQuery)
+		if err != nil {
+			return
+		}
+		if protocolFromScheme != "" && protocolFromScheme != protocolFromQuery {
+			err = fmt.Errorf(
+				"protocol '%s' from query parameter isn't compatible with "+
+					"protocol '%s' from scheme",
+				protocolFromQuery, protocolFromScheme,
+			)
+			return
+		}
+		protocol = protocolFromQuery
+	} else {
+		protocol = protocolFromScheme
+	}
+
+	// Set default values for the network and protocol if needed:
+	if network == "" {
+		network = TCPNetwork
+	}
+	if protocol == "" {
+		protocol = HTTPProtocol
+	}
+
+	// Get the host name. Note that the host name is mandatory even when using Unix sockets,
+	// because it is used to populate the `Host` header.
+	host := parsed.Hostname()
+	if host == "" {
+		err = fmt.Errorf("host name is mandatory, but it is empty")
+		return
+	}
+
+	// Get the port number:
+	port := parsed.Port()
+	if port == "" {
+		switch protocol {
+		case HTTPProtocol, H2CProtocol:
+			port = "80"
+		case HTTPSProtocol:
+			port = "443"
+		}
+	}
+
+	// Get the socket from the `socket` query parameter or from the path:
+	var socket string
+	if network == UnixNetwork {
+		socketValues, ok := query["socket"]
+		if ok {
+			if len(socketValues) != 1 {
+				err = fmt.Errorf(
+					"expected exactly one value for the 'socket' query "+
+						"parameter but found %d",
+					len(socketValues),
+				)
+				return
+			}
+			socket = socketValues[0]
+		} else {
+			socket = parsed.Path
+		}
+		if socket == "" {
+			err = fmt.Errorf(
+				"expected socket name in the 'socket' query parameter or in " +
+					"the path but both are empty",
+			)
+			return
+		}
+	}
+
+	// Calculate the URL:
+	url := &neturl.URL{
+		Host: host,
+	}
+	switch protocol {
+	case HTTPProtocol, H2CProtocol:
+		url.Scheme = "http"
+		if port != "80" {
+			url.Host = fmt.Sprintf("%s:%s", url.Host, port)
+		}
+	case HTTPSProtocol:
+		url.Scheme = "https"
+		if port != "443" {
+			url.Host = fmt.Sprintf("%s:%s", url.Host, port)
+		}
+	}
+
+	// Create and populate the result:
+	result = &ServerAddress{
+		Text:     text,
+		Network:  network,
+		Protocol: protocol,
+		Host:     host,
+		Port:     port,
+		Socket:   socket,
+		URL:      url,
+	}
+
+	return
+}
+
+func parseScheme(ctx context.Context, scheme string) (network, protocol string,
+	err error) {
+	components := strings.Split(strings.ToLower(scheme), "+")
+	if len(components) > 2 {
+		err = fmt.Errorf(
+			"scheme '%s' should have at most two components separated by '+', "+
+				"but it has %d",
+			scheme, len(components),
+		)
+		return
+	}
+	for _, component := range components {
+		switch strings.TrimSpace(component) {
+		case TCPNetwork, UnixNetwork:
+			network = component
+		case HTTPProtocol, HTTPSProtocol, H2CProtocol:
+			protocol = component
+		default:
+			err = fmt.Errorf(
+				"component '%s' of scheme '%s' doesn't correspond to any "+
+					"supported network or protocol, supported networks "+
+					"are 'tcp' and 'unix', supported protocols are 'http', "+
+					"'https' and 'h2c'",
+				component, scheme,
+			)
+			return
+		}
+	}
+	return
+}
+
+func checkNetwork(value string) error {
+	switch value {
+	case UnixNetwork, TCPNetwork:
+		return nil
+	default:
+		return fmt.Errorf(
+			"network '%s' isn't valid, valid values are 'unix' and 'tcp'",
+			value,
+		)
+	}
+}
+
+func checkProtocol(value string) error {
+	switch value {
+	case HTTPProtocol, HTTPSProtocol, H2CProtocol:
+		return nil
+	default:
+		return fmt.Errorf(
+			"protocol '%s' isn't valid, valid values are 'http', 'https' "+
+				"and 'h2c'",
+			value,
+		)
+	}
+}
+
+// Network names:
+const (
+	UnixNetwork = "unix"
+	TCPNetwork  = "tcp"
+)
+
+// Protocol names:
+const (
+	HTTPProtocol  = "http"
+	HTTPSProtocol = "https"
+	H2CProtocol   = "h2c"
+)

--- a/internal/server_address_test.go
+++ b/internal/server_address_test.go
@@ -1,0 +1,435 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"net/url"
+
+	. "github.com/onsi/ginkgo/extensions/table" // nolint
+	. "github.com/onsi/gomega"                  // nolint
+)
+
+var _ = DescribeTable(
+	"Parsing success",
+	func(input string, expected *ServerAddress) {
+		actual, err := ParseServerAddress(context.Background(), input)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual.Text).To(Equal(input))
+		Expect(actual.Network).To(Equal(expected.Network))
+		Expect(actual.Protocol).To(Equal(expected.Protocol))
+		Expect(actual.Host).To(Equal(expected.Host))
+		Expect(actual.Port).To(Equal(expected.Port))
+		Expect(actual.Socket).To(Equal(expected.Socket))
+		Expect(actual.URL.String()).To(Equal(expected.URL.String()))
+	},
+	Entry(
+		"tcp",
+		"tcp://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"tcp+http",
+		"tcp+http://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"tcp+https",
+		"tcp+https://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPSProtocol,
+			Host:     "my.server.com",
+			Port:     "443",
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"tcp+h2c",
+		"tcp+h2c://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: H2CProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"unix",
+		"unix://my.server.com/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+			Socket: "/my.socket",
+		},
+	),
+	Entry(
+		"unix+http",
+		"unix+http://my.server.com/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"unix+https",
+		"unix+https://my.server.com/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: HTTPSProtocol,
+			Host:     "my.server.com",
+			Port:     "443",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"unix+h2c",
+		"unix+h2c://my.server.com/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: H2CProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"http",
+		"http://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"http+tcp",
+		"http+tcp://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"http+unix",
+		"http+unix://my.server.com/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+				Path:   "",
+			},
+		},
+	),
+	Entry(
+		"https",
+		"https://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPSProtocol,
+			Host:     "my.server.com",
+			Port:     "443",
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"https+tcp",
+		"https+tcp://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPSProtocol,
+			Host:     "my.server.com",
+			Port:     "443",
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"https+unix",
+		"https+unix://my.server.com/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: HTTPSProtocol,
+			Host:     "my.server.com",
+			Port:     "443",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"h2c",
+		"h2c://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: H2CProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"h2c+tcp",
+		"h2c+tcp://my.server.com",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: H2CProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"h2c+unix",
+		"h2c+unix://my.server.com/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: H2CProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"Non default HTTP port",
+		"http://my.server.com:1080",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "1080",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com:1080",
+			},
+		},
+	),
+	Entry(
+		"Non default HTTPS port",
+		"http://my.server.com:1443",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "1443",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com:1443",
+			},
+		},
+	),
+	Entry(
+		"Non default H2C port",
+		"h2c://my.server.com:1080",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: H2CProtocol,
+			Host:     "my.server.com",
+			Port:     "1080",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com:1080",
+			},
+		},
+	),
+	Entry(
+		"Unix socket in query parameter",
+		"unix://my.server.com/my/path?socket=/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"TCP network from query parameter",
+		"http://my.server.com?network=tcp",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"Unix network from query parameter",
+		"http://my.server.com/my/path?network=unix&socket=/my.socket",
+		&ServerAddress{
+			Network:  UnixNetwork,
+			Protocol: HTTPProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			Socket:   "/my.socket",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+	Entry(
+		"H2C protocol from query parameter",
+		"tcp://my.server.com?protocol=h2c",
+		&ServerAddress{
+			Network:  TCPNetwork,
+			Protocol: H2CProtocol,
+			Host:     "my.server.com",
+			Port:     "80",
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "my.server.com",
+			},
+		},
+	),
+)
+
+var _ = DescribeTable(
+	"Parsing error",
+	func(input string, expected ...string) {
+		actual, err := ParseServerAddress(context.Background(), input)
+		Expect(err).To(HaveOccurred())
+		Expect(actual).To(BeNil())
+		message := err.Error()
+		for _, substring := range expected {
+			Expect(message).To(ContainSubstring(substring))
+		}
+	},
+	Entry(
+		"Unknonwn network",
+		"mynet+http://my.server.com",
+		"component 'mynet' of scheme 'mynet+http' doesn't correspond to any supported "+
+			"network or protocol",
+		"supported networks are 'tcp' and 'unix'",
+	),
+	Entry(
+		"Unknonwn protocol",
+		"tcp+myprotocol://my.server.com",
+		"component 'myprotocol' of scheme 'tcp+myprotocol' doesn't correspond to any "+
+			"supported network or protocol",
+		"supported protocols are 'http', 'https' and 'h2c'",
+	),
+	Entry(
+		"Missing Unix socket",
+		"unix://my.server.com",
+		"expected socket name in the 'socket' query parameter or in the path but both "+
+			"are empty",
+	),
+	Entry(
+		"Incompatible network from query parameter",
+		"unix://my.server.com/my.socket?network=tcp",
+		"network 'tcp' from query parameter isn't compatible with network 'unix' "+
+			"from scheme",
+	),
+	Entry(
+		"Invalid network from query parameter",
+		"http://my.server.com/my.socket?network=unox",
+		"network 'unox' isn't valid, valid values are 'unix' and 'tcp'",
+	),
+	Entry(
+		"Invalid protocol from query parameter",
+		"tcp://my.server.com/my.socket?protocol=h2d",
+		"protocol 'h2d' isn't valid, valid values are 'http', 'https' and 'h2c'",
+	),
+)

--- a/internal/system_cas_other.go
+++ b/internal/system_cas_other.go
@@ -19,14 +19,14 @@ limitations under the License.
 // This file contains the function that returns the trusted CA certificates for operating systems
 // other than Windows, where Go knows how to load the system trusted CA store.
 
-package sdk
+package internal
 
 import (
 	"crypto/x509"
 )
 
 // loadSystemCAs loads the trusted CA certifites from the system trusted CA store.
-func (b *ConnectionBuilder) loadSystemCAs() (pool *x509.CertPool, err error) {
+func loadSystemCAs() (pool *x509.CertPool, err error) {
 	pool, err = x509.SystemCertPool()
 	return
 }

--- a/internal/system_cas_windows.go
+++ b/internal/system_cas_windows.go
@@ -23,7 +23,7 @@ limitations under the License.
 //	https://github.com/golang/go/issues/16736
 //	https://github.com/golang/go/issues/18609
 
-package sdk
+package internal
 
 import (
 	"crypto/x509"
@@ -32,7 +32,7 @@ import (
 // loadSystemCAs loads the certificates of the CAs that we will trust. Currently this uses a fixed
 // set of CA certificates, which is obviusly going to break in the future, but there is not much we
 // can do (or know to do) till Go learns to read the Windows CA trust store.
-func (b *ConnectionBuilder) loadSystemCAs() (pool *x509.CertPool, err error) {
+func loadSystemCAs() (pool *x509.CertPool, err error) {
 	pool = x509.NewCertPool()
 	pool.AppendCertsFromPEM(ssoCA)
 	pool.AppendCertsFromPEM(apiCA)

--- a/token.go
+++ b/token.go
@@ -330,7 +330,7 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	result *internal.TokenResponse, err error) {
 	// Create the HTTP request:
 	body := []byte(form.Encode())
-	request, err := http.NewRequest(http.MethodPost, c.tokenURL.String(), bytes.NewReader(body))
+	request, err := http.NewRequest(http.MethodPost, c.tokenURL, bytes.NewReader(body))
 	request.Close = true
 	header := request.Header
 	if c.agent != "" {
@@ -349,7 +349,7 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 	}
 
 	// Select the HTTP client:
-	client, err := c.selectClient(ctx, c.tokenURL)
+	client, err := c.clientSelector.Select(ctx, c.tokenAddress)
 	if err != nil {
 		return
 	}
@@ -461,7 +461,7 @@ func GetTokenExpiry(token *jwt.Token, now time.Time) (expires bool,
 	left time.Duration, err error) {
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		err = fmt.Errorf("expected map claims bug got %T", claims)
+		err = fmt.Errorf("expected map claims but got %T", claims)
 		return
 	}
 	var exp float64


### PR DESCRIPTION
This patch introduces a new `ClientSelector` type that contains the
logic to select HTTP clients according to server addresses. This will
allow in the future to separate the code that manages tokens to an
independent round tripper.