### PR TITLE
Use defaults from authentication package

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -43,9 +43,9 @@ import (
 // Default values:
 const (
 	// #nosec G101
-	DefaultTokenURL     = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
-	DefaultClientID     = "cloud-services"
-	DefaultClientSecret = ""
+	DefaultTokenURL     = authentication.DefaultTokenURL
+	DefaultClientID     = authentication.DefaultClientID
+	DefaultClientSecret = authentication.DefaultClientSecret
 	DefaultURL          = "https://api.openshift.com"
 	DefaultAgent        = "OCM-SDK/" + Version
 )


### PR DESCRIPTION
This patch changes the constants for the default token URL and client so
that they use the values from the authentication package.