### PR TITLE
Add _tolerance_ parameter to authentication handler

### DIFF
--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -55,6 +55,7 @@ type HandlerBuilder struct {
 	service      string
 	error        string
 	operationID  func(*http.Request) string
+	tolerance    time.Duration
 	next         http.Handler
 }
 
@@ -73,6 +74,7 @@ type Handler struct {
 	service       string
 	error         string
 	operationID   func(*http.Request) string
+	tolerance     time.Duration
 	next          http.Handler
 }
 
@@ -240,11 +242,34 @@ func (b *HandlerBuilder) OperationID(value func(r *http.Request) string) *Handle
 	return b
 }
 
+// Tolerance sets the maximum time that a token will be considered valid after it has expired. For
+// example, to accept requests with tokens that have expired up to five minutes ago:
+//
+//	handler, err := authentication.NewHandler().
+//		Logger(logger).
+//		KeysURL("https://...").
+//		Tolerance(5 * time.Minute).
+//		Next(next).
+//		Build()
+//	if err != nil {
+//		...
+//	}
+//
+// The default value is zero tolerance.
+func (b *HandlerBuilder) Tolerance(value time.Duration) *HandlerBuilder {
+	b.tolerance = value
+	return b
+}
+
 // Build uses the data stored in the builder to create a new authentication handler.
 func (b *HandlerBuilder) Build() (handler *Handler, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+	if b.tolerance < 0 {
+		err = fmt.Errorf("toleranze must be zero or positive")
 		return
 	}
 	if b.next == nil {
@@ -342,6 +367,7 @@ func (b *HandlerBuilder) Build() (handler *Handler, err error) {
 		service:     b.service,
 		error:       b.error,
 		operationID: b.operationID,
+		tolerance:   b.tolerance,
 		next:        b.next,
 	}
 
@@ -694,44 +720,75 @@ func (h *Handler) checkToken(w http.ResponseWriter, r *http.Request,
 					w, r,
 					"Bearer token is malformed",
 				)
+				ok = false
 			case typed.Errors&jwt.ValidationErrorUnverifiable != 0:
 				h.sendError(
 					w, r,
 					"Bearer token can't be verified",
 				)
+				ok = false
 			case typed.Errors&jwt.ValidationErrorSignatureInvalid != 0:
 				h.sendError(
 					w, r,
 					"Signature of bearer token isn't valid",
 				)
+				ok = false
 			case typed.Errors&jwt.ValidationErrorExpired != 0:
-				h.sendError(
-					w, r,
-					"Bearer token is expired",
-				)
+				// When the token is expired according to the JWT library we may
+				// still want to accept it if we have a configured tolerance:
+				if h.tolerance > 0 {
+					var remaining time.Duration
+					_, remaining, err = tokenRemaining(token, time.Now())
+					if err != nil {
+						h.logger.Error(
+							ctx,
+							"Can't check token duration: %v",
+							err,
+						)
+						remaining = 0
+					}
+					if -remaining <= h.tolerance {
+						ok = true
+					} else {
+						h.sendError(
+							w, r,
+							"Bearer token is expired",
+						)
+						ok = false
+					}
+				} else {
+					h.sendError(
+						w, r,
+						"Bearer token is expired",
+					)
+					ok = false
+				}
 			case typed.Errors&jwt.ValidationErrorIssuedAt != 0:
 				h.sendError(
 					w, r,
 					"Bearer token was issued in the future",
 				)
+				ok = false
 			case typed.Errors&jwt.ValidationErrorNotValidYet != 0:
 				h.sendError(
 					w, r,
 					"Bearer token isn't valid yet",
 				)
+				ok = false
 			default:
 				h.sendError(
 					w, r,
 					"Bearer token isn't valid",
 				)
+				ok = false
 			}
 		default:
 			h.sendError(
 				w, r,
 				"Bearer token is malformed",
 			)
+			ok = false
 		}
-		ok = false
 		return
 	}
 	ok = true

--- a/authentication/helpers.go
+++ b/authentication/helpers.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains helper functions used in several places in the package.
+
+package authentication
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// tokenRemaining determines if the given token will eventually expire (offile access tokens, for
+// example, never expire) and the time till it expires. That time will be positive if the token
+// isn't expired, and negative if the token has already expired.
+//
+// For tokens that don't have the `exp` claim, or that have it with value zero (typical for offline
+// access tokens) the result will always be `false` and zero.
+func tokenRemaining(token *jwt.Token, now time.Time) (expires bool, duration time.Duration,
+	err error) {
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		err = fmt.Errorf("expected map claims but got %T", claims)
+		return
+	}
+	var exp float64
+	claim, ok := claims["exp"]
+	if !ok {
+		return
+	}
+	exp, ok = claim.(float64)
+	if !ok {
+		err = fmt.Errorf("expected floating point 'exp' but got %T", claim)
+		return
+	}
+	if exp == 0 {
+		return
+	}
+	duration = time.Unix(int64(exp), 0).Sub(now)
+	expires = true
+	return
+}


### PR DESCRIPTION
This patch adds a new tolerance parameter to the authentication
handler. This parameter is the maximum time that tokens can be expired
and anyhow accepted. For example, to accept tokens that have expired up
to ten minutes ago:

```go
handler, err := NewHandler().
       Logger(logger).
       KeysFile(keysFile).
       Tolerance(10 * time.Minute).
       Next(next).
       Build()
if err != nil {
       ...
}
```

The default value for this parameter will be zero tolerance.

Related: https://issues.redhat.com/browse/SDA-4006