### PR TITLE
Add Fatal logging level

### DIFF
--- a/logging/glog_logger.go
+++ b/logging/glog_logger.go
@@ -21,6 +21,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/golang/glog"
 )
@@ -161,4 +162,14 @@ func (l *GlogLogger) Error(ctx context.Context, format string, args ...interface
 		msg := fmt.Sprintf(format, args...)
 		glog.ErrorDepth(1, msg)
 	}
+}
+
+// Fatal sends to the log an error message formatted using the fmt.Sprintf function and the given
+// format and arguments. After that it will os.Exit(1)
+// This level is always enabled
+func (l *GlogLogger) Fatal(ctx context.Context, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	// #nosec G104
+	glog.ErrorDepth(1, msg)
+	os.Exit(1)
 }

--- a/logging/go_logger.go
+++ b/logging/go_logger.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 )
 
 // GoLoggerBuilder contains the configuration and logic needed to build a logger that uses the Go
@@ -136,7 +137,7 @@ func (l *GoLogger) Info(ctx context.Context, format string, args ...interface{})
 // Warn sends to the log a warning message formatted using the fmt.Sprintf function and the given
 // format and arguments.
 func (l *GoLogger) Warn(ctx context.Context, format string, args ...interface{}) {
-	if l.infoEnabled {
+	if l.warnEnabled {
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
 		log.Output(1, msg)
@@ -151,4 +152,14 @@ func (l *GoLogger) Error(ctx context.Context, format string, args ...interface{}
 		// #nosec G104
 		log.Output(1, msg)
 	}
+}
+
+// Fatal sends to the log an error message formatted using the fmt.Sprintf function and the given
+// format and arguments. After that it will os.Exit(1)
+// This level is always enabled
+func (l *GoLogger) Fatal(ctx context.Context, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	// #nosec G104
+	log.Output(1, msg)
+	os.Exit(1)
 }

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -30,16 +30,16 @@ import (
 // interface must accept and handle smoothly calls to the Debug, Info, Warn and Error methods where
 // the ctx parameter is nil.
 type Logger interface {
-	// DebugEnabled returns true iff the debug level is enabled.
+	// DebugEnabled returns true if the debug level is enabled.
 	DebugEnabled() bool
 
-	// InfoEnabled returns true iff the information level is enabled.
+	// InfoEnabled returns true if the information level is enabled.
 	InfoEnabled() bool
 
-	// WarnEnabled returns true iff the warning level is enabled.
+	// WarnEnabled returns true if the warning level is enabled.
 	WarnEnabled() bool
 
-	// ErrorEnabled returns true iff the error level is enabled.
+	// ErrorEnabled returns true if the error level is enabled.
 	ErrorEnabled() bool
 
 	// Debug sends to the log a debug message formatted using the fmt.Sprintf function and the
@@ -57,4 +57,9 @@ type Logger interface {
 	// Error sends to the log an error message formatted using the fmt.Sprintf function and the
 	// given format and arguments.
 	Error(ctx context.Context, format string, args ...interface{})
+
+	// Fatal sends to the log an error message formatted using the fmt.Sprintf function and the
+	// given format and arguments; and then executes an os.Exit(1)
+	// Fatal level is always enabled
+	Fatal(ctx context.Context, format string, args ...interface{})
 }

--- a/logging/std_logger.go
+++ b/logging/std_logger.go
@@ -153,7 +153,7 @@ func (l *StdLogger) Info(ctx context.Context, format string, args ...interface{}
 // Warn sends to the log a warning message formatted using the fmt.Sprintf function and the given
 // format and arguments.
 func (l *StdLogger) Warn(ctx context.Context, format string, args ...interface{}) {
-	if l.infoEnabled {
+	if l.warnEnabled {
 		fmt.Fprintf(l.outStream, format+"\n", args...)
 	}
 }
@@ -161,7 +161,15 @@ func (l *StdLogger) Warn(ctx context.Context, format string, args ...interface{}
 // Error sends to the log an error message formatted using the fmt.Sprintf function and the given
 // format and arguments.
 func (l *StdLogger) Error(ctx context.Context, format string, args ...interface{}) {
-	if l.infoEnabled {
+	if l.errorEnabled {
 		fmt.Fprintf(l.errStream, format+"\n", args...)
 	}
+}
+
+// Fatal sends to the log an error message formatted using the fmt.Sprintf function and the given
+// format and arguments. After that it will os.Exit(1)
+// This level is always enabled
+func (l *StdLogger) Fatal(ctx context.Context, format string, args ...interface{}) {
+	fmt.Fprintf(l.errStream, format+"\n", args...)
+	os.Exit(1)
 }


### PR DESCRIPTION
Add Fatal logging level

- This will log an Error and execute os.Exit(1) afterwards.
- It is always enabled
- Fix minor errors in checks on std_logger and go_logger

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>