### PR TITLE
Update `Logger` interface to include `Fatal` level

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,16 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+
+== 0.1.175 May 6 2021
+
+- Update `Logger` interface to include a `Fatal` log level.
+** Fatal level will call `os.Exit(1)` after writing the message.
+** Fatal level is always active.
+
+IMPORTANT: This version breaks backwards compatibility in the `Logger`
+interface, as all implementations now require a `Fatal` method to be implemented.
+
 == 0.1.174 Apr 14 2021
 
 - Miscellaneous fixes to JobQueue service.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.174"
+const Version = "0.1.175"


### PR DESCRIPTION
Update `Logger` interface to include `Fatal` level
 ** Fatal level will call `os.Exit(1)` after writing the message.
 ** Fatal level is always active.

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>