### PR TITLE
Add context to log messages

### DIFF
--- a/logging/go_logger.go
+++ b/logging/go_logger.go
@@ -118,6 +118,7 @@ func (l *GoLogger) ErrorEnabled() bool {
 // format and arguments.
 func (l *GoLogger) Debug(ctx context.Context, format string, args ...interface{}) {
 	if l.debugEnabled {
+		format = appendHeader(Debug, format)
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
 		log.Output(1, msg)
@@ -128,6 +129,7 @@ func (l *GoLogger) Debug(ctx context.Context, format string, args ...interface{}
 // given format and arguments.
 func (l *GoLogger) Info(ctx context.Context, format string, args ...interface{}) {
 	if l.infoEnabled {
+		format = appendHeader(Info, format)
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
 		log.Output(1, msg)
@@ -138,6 +140,7 @@ func (l *GoLogger) Info(ctx context.Context, format string, args ...interface{})
 // format and arguments.
 func (l *GoLogger) Warn(ctx context.Context, format string, args ...interface{}) {
 	if l.warnEnabled {
+		format = appendHeader(Warning, format)
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
 		log.Output(1, msg)
@@ -148,6 +151,7 @@ func (l *GoLogger) Warn(ctx context.Context, format string, args ...interface{})
 // format and arguments.
 func (l *GoLogger) Error(ctx context.Context, format string, args ...interface{}) {
 	if l.errorEnabled {
+		format = appendHeader(Error, format)
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
 		log.Output(1, msg)
@@ -158,6 +162,7 @@ func (l *GoLogger) Error(ctx context.Context, format string, args ...interface{}
 // format and arguments. After that it will os.Exit(1)
 // This level is always enabled
 func (l *GoLogger) Fatal(ctx context.Context, format string, args ...interface{}) {
+	format = appendHeader(Fatal, format)
 	msg := fmt.Sprintf(format, args...)
 	// #nosec G104
 	log.Output(1, msg)

--- a/logging/header.go
+++ b/logging/header.go
@@ -1,0 +1,32 @@
+package logging
+
+import "fmt"
+
+type Level int
+
+const (
+	Fatal Level = iota // 0
+	Error
+	Warning
+	Info
+	Debug
+)
+
+func appendHeader(l Level, msg string) string {
+	prepend := ""
+	switch l {
+	case Fatal:
+		prepend = "Fatal"
+	case Error:
+		prepend = "Error"
+	case Warning:
+		prepend = "Warning"
+	case Info:
+		prepend = "Info"
+	case Debug:
+		prepend = "Debug"
+
+	}
+	return fmt.Sprintf("%s - %s", prepend, msg)
+
+}

--- a/logging/header_test.go
+++ b/logging/header_test.go
@@ -1,0 +1,29 @@
+package logging
+
+import "testing"
+
+func Test_appendHeader(t *testing.T) {
+	type args struct {
+		l   Level
+		msg string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"1", args{Debug, "test %v"}, "Debug - test %v"},
+		{"2", args{Info, "test %v"}, "Info - test %v"},
+		{"3", args{Warning, "test %v"}, "Warning - test %v"},
+		{"4", args{Error, "test %v"}, "Error - test %v"},
+		{"5", args{Fatal, "test %v"}, "Fatal - test %v"},
+		{"6", args{Info, "test %v - %s - %d"}, "Info - test %v - %s - %d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendHeader(tt.args.l, tt.args.msg); got != tt.want {
+				t.Errorf("appendHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/logging/std_logger.go
+++ b/logging/std_logger.go
@@ -138,6 +138,7 @@ func (l *StdLogger) ErrorEnabled() bool {
 // format and arguments.
 func (l *StdLogger) Debug(ctx context.Context, format string, args ...interface{}) {
 	if l.debugEnabled {
+		format = appendHeader(Debug, format)
 		fmt.Fprintf(l.outStream, format+"\n", args...)
 	}
 }
@@ -146,6 +147,7 @@ func (l *StdLogger) Debug(ctx context.Context, format string, args ...interface{
 // given format and arguments.
 func (l *StdLogger) Info(ctx context.Context, format string, args ...interface{}) {
 	if l.infoEnabled {
+		format = appendHeader(Info, format)
 		fmt.Fprintf(l.outStream, format+"\n", args...)
 	}
 }
@@ -154,6 +156,7 @@ func (l *StdLogger) Info(ctx context.Context, format string, args ...interface{}
 // format and arguments.
 func (l *StdLogger) Warn(ctx context.Context, format string, args ...interface{}) {
 	if l.warnEnabled {
+		format = appendHeader(Warning, format)
 		fmt.Fprintf(l.outStream, format+"\n", args...)
 	}
 }
@@ -162,6 +165,7 @@ func (l *StdLogger) Warn(ctx context.Context, format string, args ...interface{}
 // format and arguments.
 func (l *StdLogger) Error(ctx context.Context, format string, args ...interface{}) {
 	if l.errorEnabled {
+		format = appendHeader(Error, format)
 		fmt.Fprintf(l.errStream, format+"\n", args...)
 	}
 }
@@ -170,6 +174,7 @@ func (l *StdLogger) Error(ctx context.Context, format string, args ...interface{
 // format and arguments. After that it will os.Exit(1)
 // This level is always enabled
 func (l *StdLogger) Fatal(ctx context.Context, format string, args ...interface{}) {
+	format = appendHeader(Fatal, format)
 	fmt.Fprintf(l.errStream, format+"\n", args...)
 	os.Exit(1)
 }


### PR DESCRIPTION
# Why

When using `go_logger` or `std_logger` log messages don't give a context of what type of message is printed

e.g.:
```
ocm-load-test --rate 5/s --duration 1 --test-names self-access-token
2021/05/06 09:55:32 Creating './results' directory
2021/05/06 09:55:32 Using output directory: ./results
2021/05/06 09:55:32 error parsing rate for test self-access-token. Using default
2021/05/06 09:55:32 Executing Test: self-access-token
2021/05/06 09:55:32 Rate: Constant{5 hits/1s}
2021/05/06 09:55:32 Duration: 1m0s
2021/05/06 09:55:32 Endpoint: /api/accounts_mgmt/v1/access_token
2021/05/06 09:56:32 Results written to: 170d1a4b-f9bf-4aaa-853c-f66d67515b1c_self-access-token.json
```

In this case I would expect to see something like this:

e.g.:
```
ocm-load-test --rate 5/s --duration 1 --test-names self-access-token
2021/05/06 09:55:32 Info - Creating './results' directory
2021/05/06 09:55:32 Info - Using output directory: ./results                                                                                                                                                                                         
2021/05/06 09:55:32 Error - error parsing rate for test self-access-token. Using default
2021/05/06 09:55:32 Info - Executing Test: self-access-token
2021/05/06 09:55:32 Debug - Rate: Constant{5 hits/1s}
2021/05/06 09:55:32 Debug - Duration: 1m0s
2021/05/06 09:55:32 Debug - Endpoint: /api/accounts_mgmt/v1/access_token
2021/05/06 09:56:32 Info -Results written to: 170d1a4b-f9bf-4aaa-853c-f66d67515b1c_self-access-token.json
```

If we use `glog_logger` we get by default in their formatting a Prepended character that tells us the type of message we are seeing:

`Lmmdd hh:mm:ss.uuuuuu threadid file:line] msg...` the `L` stands for the log level.

# Changes

So what I tried to do was a general solution that would work with both affected loggers. A new function that will prepend the format for the log message including the Log Level, and it is generic enough that could be extended to make a more complex log format.

Let me know what do you think on this? @nimrodshn @jhernand 

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>