### PR TITLE
Enable building with Go 1.13

### DIFF
--- a/internal/client_selector.go
+++ b/internal/client_selector.go
@@ -323,16 +323,18 @@ func (s *ClientSelector) createTransport(ctx context.Context,
 				dialer := net.Dialer{}
 				return dialer.DialContext(ctx, UnixNetwork, address.Socket)
 			}
-			transport.DialTLSContext = func(ctx context.Context,
-				_, _ string) (net.Conn, error) {
+			transport.DialTLS = func(_, _ string) (net.Conn, error) {
 				// TODO: This ignores the passed context because it isn't currently
 				// supported. Once we migrate to Go 1.15 it should be done like
 				// this:
 				//
-				//	dialer := tls.Dialer{
-				//		Config: config,
+				//	transport.DialTLSContext = func(ctx context.Context,
+				//		_, _ string) (net.Conn, error) {
+				//		dialer := tls.Dialer{
+				//			Config: config,
+				//		}
+				//		return dialer.DialContext(ctx, network, address.Socket)
 				//	}
-				//	return dialer.DialContext(ctx, network, address.Socket)
 				//
 				// This will only have a negative impact in applications that
 				// specify a deadline or timeout in the passed context, as it


### PR DESCRIPTION
This patch changes the SDK so that it can be built with Go 1.13. Tests
will still require at least 1.14.