### PR TITLE
Release 0.1.179

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.179 May 20 2021
+
+- Allow building with Go 1.13.
+
 == 0.1.178 May 18 2021
 
 - Update model to v0.0.125

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.178"
+const Version = "0.1.179"


### PR DESCRIPTION
The only change in this release is that it is now possible to build the
SDK with Go 1.13.