### PR TITLE
Add `All` and `Any` functions to the logging package

### DIFF
--- a/logging/list.go
+++ b/logging/list.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functions useful for printing lists in a format that is easy to read for
+// humans in log files.
+
+package logging
+
+import (
+	"fmt"
+	"strings"
+)
+
+// All generates a human readable representation of the given list of strings, for use in a log
+// file. It puts quotes around each item, separates the first items with commas and the last with
+// the word 'and'.
+func All(items []string) string {
+	return list(items, "and")
+}
+
+// any generates a human readable representation of the given list of strings, for use in a log
+// file. It puts quotes around each item, separates the first items with commas and the last with
+// the word 'or'.
+func Any(items []string) string {
+	return list(items, "or")
+}
+
+func list(items []string, conjunction string) string {
+	count := len(items)
+	if count == 0 {
+		return ""
+	}
+	quoted := make([]string, len(items))
+	for i, item := range items {
+		quoted[i] = fmt.Sprintf("'%s'", item)
+	}
+	if count == 1 {
+		return quoted[0]
+	}
+	head := quoted[0 : count-1]
+	tail := quoted[count-1]
+	return fmt.Sprintf("%s %s %s", strings.Join(head, ", "), conjunction, tail)
+}

--- a/logging/list_test.go
+++ b/logging/list_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	. "github.com/onsi/ginkgo"                  // nolint
+	. "github.com/onsi/ginkgo/extensions/table" // nolint
+	. "github.com/onsi/gomega"                  // nolint
+)
+
+var _ = Describe("List", func() {
+	Describe("All", func() {
+		DescribeTable("Examples",
+			func(items []string, list string) {
+				Expect(All(items)).To(Equal(list))
+			},
+			Entry("Nil", nil, ""),
+			Entry("Empty", []string{}, ""),
+			Entry("One", []string{"one"}, "'one'"),
+			Entry("Two", []string{"one", "two"}, "'one' and 'two'"),
+			Entry("Three", []string{"one", "two", "three"}, "'one', 'two' and 'three'"),
+		)
+
+		It("Doesn't modify the input", func() {
+			items := []string{"a", "b", "c"}
+			All(items)
+			Expect(items).To(Equal([]string{"a", "b", "c"}))
+		})
+	})
+
+	Describe("Any", func() {
+		DescribeTable("Examples",
+			func(items []string, list string) {
+				Expect(Any(items)).To(Equal(list))
+			},
+			Entry("Nil", nil, ""),
+			Entry("Empty", []string{}, ""),
+			Entry("One", []string{"one"}, "'one'"),
+			Entry("Two", []string{"one", "two"}, "'one' or 'two'"),
+			Entry("Three", []string{"one", "two", "three"}, "'one', 'two' or 'three'"),
+		)
+
+		It("Doesn't modify the input", func() {
+			items := []string{"a", "b", "c"}
+			Any(items)
+			Expect(items).To(Equal([]string{"a", "b", "c"}))
+		})
+	})
+})

--- a/logging/main_test.go
+++ b/logging/main_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+func TestLogging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logging")
+}


### PR DESCRIPTION
This patch adds two new `All` and `Any` functions to the logging package
that simplify creating list of items in a human readable form.