### PR TITLE
Release 0.1.193

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,9 +3,15 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.193 Jul 6 2021
+
+- Update the version number in the `version.go` file.
+
 == 0.1.192 Jul 6 2021
 
-- Update model to v0.0.135
+- Fix initialization of metrics registerer.
+- Update model to v0.0.135:
+** Add user name to service log `LogEntry`.
 
 == 0.1.191 Jul 5 2021
 

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.191"
+const Version = "0.1.193"


### PR DESCRIPTION
The only change in the new version is the update of the version number
inside the `version.go` file.