### PR TITLE
Update to metamodel 0.0.38

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ model_version:=v0.0.135
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.37
+metamodel_version:=v0.0.38
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples

--- a/accountsmgmt/v1/access_token_server.go
+++ b/accountsmgmt/v1/access_token_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/account_server.go
+++ b/accountsmgmt/v1/account_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/accounts_server.go
+++ b/accountsmgmt/v1/accounts_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/cluster_authorizations_server.go
+++ b/accountsmgmt/v1/cluster_authorizations_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/cluster_registrations_server.go
+++ b/accountsmgmt/v1/cluster_registrations_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/current_access_server.go
+++ b/accountsmgmt/v1/current_access_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/current_account_server.go
+++ b/accountsmgmt/v1/current_account_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/feature_toggle_query_server.go
+++ b/accountsmgmt/v1/feature_toggle_query_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/generic_label_server.go
+++ b/accountsmgmt/v1/generic_label_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/generic_labels_server.go
+++ b/accountsmgmt/v1/generic_labels_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/labels_server.go
+++ b/accountsmgmt/v1/labels_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/notify_server.go
+++ b/accountsmgmt/v1/notify_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/organization_server.go
+++ b/accountsmgmt/v1/organization_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/organizations_server.go
+++ b/accountsmgmt/v1/organizations_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/permission_server.go
+++ b/accountsmgmt/v1/permission_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/permissions_server.go
+++ b/accountsmgmt/v1/permissions_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/pull_secret_server.go
+++ b/accountsmgmt/v1/pull_secret_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/pull_secrets_server.go
+++ b/accountsmgmt/v1/pull_secrets_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/quota_cost_server.go
+++ b/accountsmgmt/v1/quota_cost_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/quota_summary_server.go
+++ b/accountsmgmt/v1/quota_summary_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/registries_server.go
+++ b/accountsmgmt/v1/registries_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/registry_credential_server.go
+++ b/accountsmgmt/v1/registry_credential_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/registry_credentials_server.go
+++ b/accountsmgmt/v1/registry_credentials_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/registry_server.go
+++ b/accountsmgmt/v1/registry_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/resource_quota_server.go
+++ b/accountsmgmt/v1/resource_quota_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/resource_quotas_server.go
+++ b/accountsmgmt/v1/resource_quotas_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/role_binding_server.go
+++ b/accountsmgmt/v1/role_binding_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/role_bindings_server.go
+++ b/accountsmgmt/v1/role_bindings_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/role_server.go
+++ b/accountsmgmt/v1/role_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/roles_server.go
+++ b/accountsmgmt/v1/roles_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/sku_rule_server.go
+++ b/accountsmgmt/v1/sku_rule_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/sku_rules_server.go
+++ b/accountsmgmt/v1/sku_rules_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/sku_server.go
+++ b/accountsmgmt/v1/sku_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/skus_server.go
+++ b/accountsmgmt/v1/skus_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/subscription_notify_server.go
+++ b/accountsmgmt/v1/subscription_notify_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/subscription_reserved_resource_server.go
+++ b/accountsmgmt/v1/subscription_reserved_resource_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/subscription_reserved_resources_server.go
+++ b/accountsmgmt/v1/subscription_reserved_resources_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/subscription_server.go
+++ b/accountsmgmt/v1/subscription_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/subscriptions_server.go
+++ b/accountsmgmt/v1/subscriptions_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/summary_dashboard_server.go
+++ b/accountsmgmt/v1/summary_dashboard_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/support_case_server.go
+++ b/accountsmgmt/v1/support_case_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/support_cases_server.go
+++ b/accountsmgmt/v1/support_cases_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/accountsmgmt/v1/token_authorization_server.go
+++ b/accountsmgmt/v1/token_authorization_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/access_review_server.go
+++ b/authorizations/v1/access_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/capability_review_server.go
+++ b/authorizations/v1/capability_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/export_control_review_server.go
+++ b/authorizations/v1/export_control_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/feature_review_server.go
+++ b/authorizations/v1/feature_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/resource_review_server.go
+++ b/authorizations/v1/resource_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/self_access_review_server.go
+++ b/authorizations/v1/self_access_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/self_capability_review_server.go
+++ b/authorizations/v1/self_capability_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/self_feature_review_server.go
+++ b/authorizations/v1/self_feature_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/self_terms_review_server.go
+++ b/authorizations/v1/self_terms_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/authorizations/v1/terms_review_server.go
+++ b/authorizations/v1/terms_review_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/add_on_installation_server.go
+++ b/clustersmgmt/v1/add_on_installation_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/add_on_installations_server.go
+++ b/clustersmgmt/v1/add_on_installations_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/add_on_server.go
+++ b/clustersmgmt/v1/add_on_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/add_ons_server.go
+++ b/clustersmgmt/v1/add_ons_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/alerts_metric_query_server.go
+++ b/clustersmgmt/v1/alerts_metric_query_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/available_regions_inquiry_server.go
+++ b/clustersmgmt/v1/available_regions_inquiry_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/available_regions_server.go
+++ b/clustersmgmt/v1/available_regions_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grant_server.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grant_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grants_server.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grants_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/aws_infrastructure_access_role_server.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/aws_infrastructure_access_roles_server.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_roles_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cloud_provider_server.go
+++ b/clustersmgmt/v1/cloud_provider_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cloud_providers_server.go
+++ b/clustersmgmt/v1/cloud_providers_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cloud_region_server.go
+++ b/clustersmgmt/v1/cloud_region_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cloud_regions_server.go
+++ b/clustersmgmt/v1/cloud_regions_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cluster_operators_metric_query_server.go
+++ b/clustersmgmt/v1/cluster_operators_metric_query_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cluster_server.go
+++ b/clustersmgmt/v1/cluster_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cluster_status_server.go
+++ b/clustersmgmt/v1/cluster_status_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/clusterdeployment_server.go
+++ b/clustersmgmt/v1/clusterdeployment_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/clusters_server.go
+++ b/clustersmgmt/v1/clusters_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_server.go
+++ b/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/credentials_server.go
+++ b/clustersmgmt/v1/credentials_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/encryption_keys_inquiry_server.go
+++ b/clustersmgmt/v1/encryption_keys_inquiry_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/events_server.go
+++ b/clustersmgmt/v1/events_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/external_configuration_server.go
+++ b/clustersmgmt/v1/external_configuration_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/flavour_server.go
+++ b/clustersmgmt/v1/flavour_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/flavours_server.go
+++ b/clustersmgmt/v1/flavours_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/group_server.go
+++ b/clustersmgmt/v1/group_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/groups_server.go
+++ b/clustersmgmt/v1/groups_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/identity_provider_server.go
+++ b/clustersmgmt/v1/identity_provider_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/identity_providers_server.go
+++ b/clustersmgmt/v1/identity_providers_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/ingress_server.go
+++ b/clustersmgmt/v1/ingress_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/ingresses_server.go
+++ b/clustersmgmt/v1/ingresses_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/key_rings_inquiry_server.go
+++ b/clustersmgmt/v1/key_rings_inquiry_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/label_server.go
+++ b/clustersmgmt/v1/label_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/labels_server.go
+++ b/clustersmgmt/v1/labels_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/log_server.go
+++ b/clustersmgmt/v1/log_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/logs_server.go
+++ b/clustersmgmt/v1/logs_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/machine_pool_server.go
+++ b/clustersmgmt/v1/machine_pool_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/machine_pools_server.go
+++ b/clustersmgmt/v1/machine_pools_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/machine_type_server.go
+++ b/clustersmgmt/v1/machine_type_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/machine_types_server.go
+++ b/clustersmgmt/v1/machine_types_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/nodes_metric_query_server.go
+++ b/clustersmgmt/v1/nodes_metric_query_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/product_server.go
+++ b/clustersmgmt/v1/product_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/products_server.go
+++ b/clustersmgmt/v1/products_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/provision_shard_server.go
+++ b/clustersmgmt/v1/provision_shard_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/provision_shards_server.go
+++ b/clustersmgmt/v1/provision_shards_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_server.go
+++ b/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/syncset_server.go
+++ b/clustersmgmt/v1/syncset_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/syncsets_server.go
+++ b/clustersmgmt/v1/syncsets_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/upgrade_policies_server.go
+++ b/clustersmgmt/v1/upgrade_policies_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/upgrade_policy_server.go
+++ b/clustersmgmt/v1/upgrade_policy_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/upgrade_policy_state_server.go
+++ b/clustersmgmt/v1/upgrade_policy_state_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/user_server.go
+++ b/clustersmgmt/v1/user_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/users_server.go
+++ b/clustersmgmt/v1/users_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/version_server.go
+++ b/clustersmgmt/v1/version_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/versions_server.go
+++ b/clustersmgmt/v1/versions_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/clustersmgmt/v1/vpcs_inquiry_server.go
+++ b/clustersmgmt/v1/vpcs_inquiry_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/jobqueue/v1/job_server.go
+++ b/jobqueue/v1/job_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/jobqueue/v1/queue_server.go
+++ b/jobqueue/v1/queue_server.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	time "time"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/jobqueue/v1/queues_server.go
+++ b/jobqueue/v1/queues_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/servicelogs/v1/cluster_logs_server.go
+++ b/servicelogs/v1/cluster_logs_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 

--- a/servicelogs/v1/log_entry_server.go
+++ b/servicelogs/v1/log_entry_server.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/istio/glog"
+	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-sdk-go/errors"
 )
 


### PR DESCRIPTION
The only change in the new version of the metamodel is that the
generated code explicitly imports `github.com/golang/glog` in order to
avoid conflicts with `github.com/istio/glog`.