### PR TITLE
Use `golang-jwt/jwt` instead of `dgrijalva/jwt-go`

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,32 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.199 TBD
+
+- Use `golang-jwt/jwt` instead of `dgrijalva/jwt-go`.
++
+The `dgrijalva/jwt-go` library is no longer maintained and `golang-jwt/jwt` is
+a community maintained fork. See https://github.com/dgrijalva/jwt-go/issues/462
+for detailts.
++
+Parts of the public interface of the SDK use this library, so this is a
+backwards compatibility breaking change. Projects using the SDK will need to
+switch to the new library, specially if they are using the
+`context.ContextWithToken` or `context.TokenFromContext` functions. The change
+should only require changing the import paths, as the fork is fully compatible
+with the original library.
++
+A simple way to do the required changes is the following command:
++
+....
+$ find . -name '*.go' | xargs sed -i 's|dgrijalva/jwt-go|golang-jwt/jwt|'
+....
++
+This also addresses
+https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26160[CVE-2020-26160],
+but that vulnerability doesn't currently affect the SDK because the
+authentication handler doesn't use the `aud` claim.
+
 == 0.1.198 Aug 03 2021
 
 - Update model to v0.0.139:

--- a/authentication/context.go
+++ b/authentication/context.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 // ContextWithToken creates a new context containing the given token.

--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -35,8 +35,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/ghodss/yaml"
+	"github.com/golang-jwt/jwt"
 
 	"github.com/openshift-online/ocm-sdk-go/errors"
 	"github.com/openshift-online/ocm-sdk-go/logging"

--- a/authentication/handler_test.go
+++ b/authentication/handler_test.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"                         // nolint

--- a/authentication/helpers.go
+++ b/authentication/helpers.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 // tokenRemaining determines if the given token will eventually expire (offile access tokens, for

--- a/authentication/transport_wrapper.go
+++ b/authentication/transport_wrapper.go
@@ -35,7 +35,7 @@ import (
 
 	//
 	"github.com/cenkalti/backoff/v4"
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 	"github.com/openshift-online/ocm-sdk-go/internal"
 	"github.com/openshift-online/ocm-sdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/cenkalti/backoff/v4 v4.0.0
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/ghodss/yaml v1.0.0
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/uuid v1.2.0
 	github.com/jackc/pgconn v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/testing/tokens.go
+++ b/testing/tokens.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	. "github.com/onsi/gomega" // nolint
 )


### PR DESCRIPTION
The `dgrijalva/jwt-go` library is no longer maintained and `golang-jwt/jwt` is a
community maintained fork. See https://github.com/dgrijalva/jwt-go/issues/462
for detailts.

Parts of the public interface of the SDK use this library, so this is a
backwards compatibility breaking change. Projects using the SDK will need to
switch to the new library, specially if they are using the
`context.ContextWithToken` or `context.TokenFromContext` functions. The change
should only require changing the import paths, as the fork is fully compatible
with the original library.

A simple way to do the required changes is the following command:

```
$ find . -name '*.go' | xargs sed -i 's|dgrijalva/jwt-go|golang-jwt/jwt|'
```

This also addresses CVE-2020-26160, but that vulnerability doesn't
currently affect the SDK because the authentication handler doesn't use
the `aud` claim.

Related: https://github.com/openshift-online/ocm-sdk-go/issues/421
Related: https://github.com/dgrijalva/jwt-go/issues/462
Related: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26160