### PR TITLE
Release 0.1.199

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,7 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
-== 0.1.199 TBD
+== 0.1.199 Aug 10 2021
+
+Changes in this release are mainly intended to simplify packaging of the SDK in
+Fedora, see https://github.com/openshift-online/ocm-sdk-go/issues/421[issue
+#421] for details.
 
 - Use `golang-jwt/jwt` instead of `dgrijalva/jwt-go`.
 +
@@ -28,6 +32,14 @@ This also addresses
 https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26160[CVE-2020-26160],
 but that vulnerability doesn't currently affect the SDK because the
 authentication handler doesn't use the `aud` claim.
+
+- Use https://github.com/microcosm-cc/bluemonday[microcosm-cc/bluemonday]
+instead of https://github.com/grokify/html-strip-tags-go[grokify/html-strip-tags-go]
+for HTML sanitizing.
+
+- Use https://github.com/json-iterator/go[json-iterator/go] instead of
+  https://gitlab.com/c0b/go-ordered-json[c0b/go-ordered-json] to ensure ordered
+JSON in debug output.
 
 == 0.1.198 Aug 03 2021
 

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.198"
+const Version = "0.1.199"


### PR DESCRIPTION
Changes in this release are mainly intended to simplify packaging of the SDK in
Fedora, see issue #421 for details.

- Use `golang-jwt/jwt` instead of `dgrijalva/jwt-go`.
- Use `microcosm-cc/bluemonday` instead of `grokify/html-strip-tags-go`.
- Use `json-iterator/go` instead of `c0b/go-ordered-json`.

Related: https://github.com/openshift-online/ocm-sdk-go/issues/421