### PR TITLE
Fix minor JSON debug issue

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -283,7 +283,7 @@ func (d *dumpRoundTripper) dumpJSON(ctx context.Context, data []byte) {
 		if err != nil {
 			d.logger.Debug(ctx, "%s", data)
 		} else {
-			d.logger.Debug(ctx, "%s", buf)
+			d.logger.Debug(ctx, "%s", buf.String())
 		}
 	}
 }


### PR DESCRIPTION
We need to convert the buffer to string before printing, otherwise the
output looks like this:

```
2021/08/10 13:33:53 {{
  "kind": "ClusterList",
  "page": 1,
  "size": 2,
  "total": 2,
  "items": [
    ...
  ]
} %!s(int=0) %!s(bytes.readOp=0)}

```