### PR TITLE
Retry when EOF or connection reset by peer

### DIFF
--- a/retry/transport_wrapper.go
+++ b/retry/transport_wrapper.go
@@ -211,8 +211,23 @@ func (t *roundTripper) RoundTrip(request *http.Request) (response *http.Response
 		if err != nil {
 			message := err.Error()
 			switch {
+			case strings.Contains(message, "EOF"):
+				t.logger.Warn(
+					ctx,
+					"Request for method %s and URL '%s' failed with EOF, "+
+						"will try again: %v",
+					request.Method, request.URL, err,
+				)
+				continue
+			case strings.Contains(message, "connection reset by peer"):
+				t.logger.Warn(
+					ctx,
+					"Request for method %s and URL '%s' failed with connection "+
+						"reset by peer, will try again: %v",
+					request.Method, request.URL, err,
+				)
+				continue
 			case strings.Contains(message, "PROTOCOL_ERROR"):
-				// If the request failed due to a protocol error then we should retry:
 				t.logger.Warn(
 					ctx,
 					"Request for method %s and URL '%s' failed with protocol error, "+

--- a/retry/transport_wrapper_test.go
+++ b/retry/transport_wrapper_test.go
@@ -331,72 +331,12 @@ var _ = Describe("Protocol error", func() {
 	var address string
 	var transport http.RoundTripper
 
-	// Accept accepts an HTTP/2 connection.
-	var Accept = func(listener net.Listener) net.Conn {
-		// Accept the connection and complete the TLS handshake.
-		conn, err := listener.Accept()
-		Expect(err).ToNot(HaveOccurred())
-		err = conn.(*tls.Conn).Handshake()
-		Expect(err).ToNot(HaveOccurred())
-
-		// Return the connection:
-		return conn
-	}
-
-	// Reject sends an HTTP/2 go away frame to the given connection and then closes it.
-	var Reject = func(conn net.Conn) {
-		// Read the HTTP2 connection preface, otherwise the client won't reach the part of
-		// the code where the protocol error is detected:
-		buffer := make([]byte, len(http2.ClientPreface))
-		count, err := conn.Read(buffer)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(count).To(Equal(len(http2.ClientPreface)))
-		Expect(string(buffer)).To(Equal(http2.ClientPreface))
-
-		// Send the go away frame:
-		framer := http2.NewFramer(conn, conn)
-		err = framer.WriteGoAway(0, http2.ErrCodeStreamClosed, nil)
-		Expect(err).ToNot(HaveOccurred())
-
-		// Close the connection:
-		err = conn.Close()
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Server handles request received from the given connection using a real HTTP/2 server.
-	var Serve = func(conn net.Conn) {
-		handler := func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("{}"))
-			Expect(err).ToNot(HaveOccurred())
-		}
-		server := &http2.Server{}
-		server.ServeConn(conn, &http2.ServeConnOpts{
-			Handler: http.HandlerFunc(handler),
-		})
-	}
-
 	BeforeEach(func() {
-		var err error
-
 		// Create a context:
 		ctx = context.Background()
 
-		// Create a TLS listener that will be used to process incoming requests
-		// simulating an HTTP/2 server:
-		listener, err = tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
-			Certificates: []tls.Certificate{
-				LocalhostKeyPair(),
-			},
-			NextProtos: []string{
-				http2.NextProtoTLS,
-			},
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		// Calculate the listener URL:
-		address = "https://" + listener.Addr().String()
+		// Create a listener:
+		listener, address = Listen()
 
 		// Create the basic transport:
 		transport = &http.Transport{
@@ -422,12 +362,17 @@ var _ = Describe("Protocol error", func() {
 				defer GinkgoRecover()
 
 				// Reject the first connection:
-				firstConn := Accept(listener)
-				Reject(firstConn)
+				first := Accept(listener)
+				Reject(first)
 
 				// Accept the second connection:
-				secondConn := Accept(listener)
-				Serve(secondConn)
+				second := Accept(listener)
+				Serve(second, func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write([]byte("{}"))
+					Expect(err).ToNot(HaveOccurred())
+				})
 			}()
 
 			// Wrap the transport:
@@ -588,3 +533,203 @@ var _ = Describe("Protocol error", func() {
 		})
 	})
 })
+
+var _ = It("Tolerates connection reset by peer", func() {
+	var err error
+
+	// Create a context:
+	ctx := context.Background()
+
+	// Create a listener:
+	listener, address := Listen()
+	defer func() {
+		err = listener.Close()
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	// Run the server:
+	go func() {
+		defer GinkgoRecover()
+
+		// Accept the first connection and close it inmediately. This will trigger
+		// the `connection reset by peer` error in the client.
+		first := Accept(listener)
+		Serve(first, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("{"))
+			Expect(err).ToNot(HaveOccurred())
+			err = first.Close()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// Accept the second connection and handle it correctly.
+		second := Accept(listener)
+		Serve(second, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("{}"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	}()
+
+	// Wrap the transport:
+	wrapper, err := NewTransportWrapper().
+		Logger(logger).
+		Interval(10 * time.Millisecond).
+		Build(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		err = wrapper.Close()
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	client := &http.Client{
+		Transport: wrapper.Wrap(&http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			ForceAttemptHTTP2: true,
+		}),
+		Timeout: 1 * time.Second,
+	}
+
+	// Send the request:
+	response, err := client.Get(address)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(response).ToNot(BeNil())
+	Expect(response.StatusCode).To(Equal(http.StatusOK))
+	body, err := ioutil.ReadAll(response.Body)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(body).To(MatchJSON("{}"))
+})
+
+var _ = It("Tolerates unepected EOF", func() {
+	var err error
+
+	// Create a context:
+	ctx := context.Background()
+
+	// Create a listener:
+	listener, address := Listen()
+	defer func() {
+		err = listener.Close()
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	// Run the server:
+	go func() {
+		defer GinkgoRecover()
+
+		// Accept the first connection and handle it with a server that will close
+		// the it after sending only half of the response body. This will trigger
+		// the `EOF` error in the client.
+		first := Accept(listener)
+		Serve(first, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("{"))
+			Expect(err).ToNot(HaveOccurred())
+			err = first.Close()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// Accept the second connection and handle it correctly.
+		second := Accept(listener)
+		Serve(second, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("{}"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	}()
+
+	// Wrap the transport:
+	wrapper, err := NewTransportWrapper().
+		Logger(logger).
+		Interval(10 * time.Millisecond).
+		Build(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		err = wrapper.Close()
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	client := &http.Client{
+		Transport: wrapper.Wrap(&http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			ForceAttemptHTTP2: true,
+		}),
+		Timeout: 1 * time.Second,
+	}
+
+	// Send the request:
+	response, err := client.Get(address)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(response).ToNot(BeNil())
+	Expect(response.StatusCode).To(Equal(http.StatusOK))
+	body, err := ioutil.ReadAll(response.Body)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(body).To(MatchJSON("{}"))
+})
+
+// Listen creates an HTTP/2 listener.
+func Listen() (listener net.Listener, address string) {
+	// Create a TLS listener that will be used to process incoming requests
+	// simulating an HTTP/2 server:
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{
+			LocalhostKeyPair(),
+		},
+		NextProtos: []string{
+			http2.NextProtoTLS,
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	// Calculate the listener URL:
+	address = "https://" + listener.Addr().String()
+
+	return
+}
+
+// Accept accepts an HTTP/2 connection.
+func Accept(listener net.Listener) net.Conn {
+	// Accept the connection and complete the TLS handshake.
+	conn, err := listener.Accept()
+	Expect(err).ToNot(HaveOccurred())
+	err = conn.(*tls.Conn).Handshake()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Return the connection:
+	return conn
+}
+
+// Reject sends an HTTP/2 go away frame to the given connection and then closes it.
+func Reject(conn net.Conn) {
+	// Read the HTTP2 connection preface, otherwise the client won't reach the part of
+	// the code where the protocol error is detected:
+	buffer := make([]byte, len(http2.ClientPreface))
+	count, err := conn.Read(buffer)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(count).To(Equal(len(http2.ClientPreface)))
+	Expect(string(buffer)).To(Equal(http2.ClientPreface))
+
+	// Send the go away frame:
+	framer := http2.NewFramer(conn, conn)
+	err = framer.WriteGoAway(0, http2.ErrCodeStreamClosed, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Close the connection:
+	err = conn.Close()
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// Serve handles request received from the given connection using a real HTTP/2 server and the given
+// handler function.
+func Serve(conn net.Conn, handler http.HandlerFunc) {
+	server := &http2.Server{}
+	server.ServeConn(conn, &http2.ServeConnOpts{
+		Handler: handler,
+	})
+}


### PR DESCRIPTION
This patch changes the retry handler so that it retry failed requests
when it receives an unexpected EOF or when the connection is
unexpectedly closed by the server.