### PR TITLE
Write failed request details to the debug log

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -775,9 +775,9 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 		Scopes(b.scopes...).
 		TrustedCAs(b.trustedCAs...).
 		Insecure(b.insecure).
-		TransportWrappers(b.transportWrappers...).
-		TransportWrapper(loggingWrapper).
 		TransportWrapper(metricsWrapper).
+		TransportWrapper(loggingWrapper).
+		TransportWrappers(b.transportWrappers...).
 		MetricsSubsystem(b.metricsSubsystem).
 		MetricsRegisterer(b.metricsRegisterer).
 		Build(ctx)
@@ -802,9 +802,9 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 		TrustedCAs(b.trustedCAs...).
 		Insecure(b.insecure).
 		TransportWrapper(authnWrapper.Wrap).
-		TransportWrapper(loggingWrapper).
 		TransportWrapper(metricsWrapper).
 		TransportWrapper(retryWrapper.Wrap).
+		TransportWrapper(loggingWrapper).
 		TransportWrappers(b.transportWrappers...).
 		Build(ctx)
 	if err != nil {


### PR DESCRIPTION
Currently the details of requests that fail and are then retried aren't
written to the log. This happens because the order of the transport
wrappers isn't correct. This patch changes the orders of the wrappers so
that the logging wrapper is called after the retry wrapper.