### PR TITLE
Change level of token retry messages

### DIFF
--- a/authentication/transport_wrapper.go
+++ b/authentication/transport_wrapper.go
@@ -612,14 +612,14 @@ func (w *TransportWrapper) Tokens(ctx context.Context, expiresIn ...time.Duratio
 		code, access, refresh, err = w.tokens(ctx, attempt, expiresDuration)
 		if err != nil {
 			if code >= http.StatusInternalServerError {
-				w.logger.Error(
+				w.logger.Debug(
 					ctx,
 					"Can't get tokens, got HTTP code %d, will retry: %v",
 					code, err,
 				)
 				return err
 			}
-			w.logger.Error(
+			w.logger.Debug(
 				ctx,
 				"Can't get tokens, got HTTP code %d, will not retry: %v",
 				code, err,
@@ -628,7 +628,7 @@ func (w *TransportWrapper) Tokens(ctx context.Context, expiresIn ...time.Duratio
 		}
 
 		if attempt > 1 {
-			w.logger.Info(ctx, "Got tokens on attempt %d", attempt)
+			w.logger.Debug(ctx, "Got tokens on attempt %d", attempt)
 		} else {
 			w.logger.Debug(ctx, "Got tokens on first attempt")
 		}


### PR DESCRIPTION
Currently the mechanism used to retry token requests generates error
messages in the log. This interferes with output of applications, in
particular with the output of the `ocm` command. To avoid tha this patch
changes the level of those messages to `DEBUG`.

Related: https://issues.redhat.com/browse/SDA-4686