### PR TITLE
Prepare to upgrade golangci-lint to 1.42.0

### DIFF
--- a/authentication/transport_wrapper.go
+++ b/authentication/transport_wrapper.go
@@ -946,12 +946,6 @@ func (w *TransportWrapper) sendFormTimed(ctx context.Context, form url.Values) (
 	return
 }
 
-// haveCredentials returns true if the connection has credentials that can be used to request new
-// tokens.
-func (w *TransportWrapper) haveCredentials() bool {
-	return w.havePassword() || w.haveSecret()
-}
-
 func (w *TransportWrapper) havePassword() bool {
 	return w.user != "" && w.password != ""
 }

--- a/authentication/transport_wrapper_test.go
+++ b/authentication/transport_wrapper_test.go
@@ -333,7 +333,8 @@ var _ = Describe("Tokens", func() {
 				}()
 
 				// Try to get the access token:
-				ctx, _ = context.WithTimeout(ctx, 100*time.Millisecond)
+				ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+				defer cancel()
 				_, _, err = wrapper.Tokens(ctx)
 				Expect(err).To(HaveOccurred())
 				message := err.Error()
@@ -1096,7 +1097,8 @@ var _ = Describe("Tokens", func() {
 
 			// Request the token with a timeout smaller than the artificial
 			// delay introduced by the server:
-			ctx, _ = context.WithTimeout(ctx, 5*time.Millisecond)
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+			defer cancel()
 			_, _, err = wrapper.Tokens(ctx)
 
 			// The request should fail with a context deadline exceeded error:

--- a/configuration/object_test.go
+++ b/configuration/object_test.go
@@ -401,14 +401,18 @@ var _ = Describe("Object", func() {
 				var err error
 
 				// Set the environment variables:
+				var names []string
 				for name, value := range variables {
 					err = os.Setenv(name, value)
 					Expect(err).ToNot(HaveOccurred())
-					defer func() {
+					names = append(names, name)
+				}
+				defer func() {
+					for _, name := range names {
 						err = os.Unsetenv(name)
 						Expect(err).ToNot(HaveOccurred())
-					}()
-				}
+					}
+				}()
 
 				// Create a temporary directory to contain the temporary files:
 				var tmp string

--- a/connection_test.go
+++ b/connection_test.go
@@ -204,7 +204,8 @@ var _ = Describe("Connection", func() {
 		// Try to get the tokens using a explicit and short timeout to make the test run
 		// faster (by default it takes up to 15 seconds) but give it enough time to retry
 		// a few times:
-		ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
 		_, _, err = connection.TokensContext(ctx)
 
 		// Check that the transport was called at least three times:

--- a/h2c_test.go
+++ b/h2c_test.go
@@ -86,10 +86,8 @@ var _ = Describe("H2C", func() {
 		})
 
 		AfterEach(func() {
-			var err error
-
 			// Close the connection:
-			err = connection.Close()
+			err := connection.Close()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Stop the API server:

--- a/internal/client_selector.go
+++ b/internal/client_selector.go
@@ -349,7 +349,7 @@ func (s *ClientSelector) createTransport(ctx context.Context,
 				dialer := net.Dialer{}
 				return dialer.DialContext(ctx, UnixNetwork, address.Socket)
 			}
-			transport.DialTLS = func(_, _ string) (net.Conn, error) {
+			transport.DialTLS = func(_, _ string) (net.Conn, error) { // nolint
 				// TODO: This ignores the passed context because it isn't currently
 				// supported. Once we migrate to Go 1.15 it should be done like
 				// this:

--- a/logging/go_logger.go
+++ b/logging/go_logger.go
@@ -120,7 +120,7 @@ func (l *GoLogger) Debug(ctx context.Context, format string, args ...interface{}
 	if l.debugEnabled {
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
-		log.Output(1, msg)
+		_ = log.Output(1, msg)
 	}
 }
 
@@ -130,7 +130,7 @@ func (l *GoLogger) Info(ctx context.Context, format string, args ...interface{})
 	if l.infoEnabled {
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
-		log.Output(1, msg)
+		_ = log.Output(1, msg)
 	}
 }
 
@@ -140,7 +140,7 @@ func (l *GoLogger) Warn(ctx context.Context, format string, args ...interface{})
 	if l.warnEnabled {
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
-		log.Output(1, msg)
+		_ = log.Output(1, msg)
 	}
 }
 
@@ -150,7 +150,7 @@ func (l *GoLogger) Error(ctx context.Context, format string, args ...interface{}
 	if l.errorEnabled {
 		msg := fmt.Sprintf(format, args...)
 		// #nosec G104
-		log.Output(1, msg)
+		_ = log.Output(1, msg)
 	}
 }
 
@@ -160,6 +160,6 @@ func (l *GoLogger) Error(ctx context.Context, format string, args ...interface{}
 func (l *GoLogger) Fatal(ctx context.Context, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	// #nosec G104
-	log.Output(1, msg)
+	_ = log.Output(1, msg)
 	os.Exit(1)
 }

--- a/methods_test.go
+++ b/methods_test.go
@@ -308,7 +308,8 @@ var _ = Describe("Methods", func() {
 			// Send the request with a timeout smaller than the artificial delay
 			// introduced by the server so that a deadline exceeded error will be
 			// created and returned:
-			ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
 			_, err := connection.Get().
 				Path("/mypath").
 				SendContext(ctx)

--- a/metrics/handler_wrapper.go
+++ b/metrics/handler_wrapper.go
@@ -250,8 +250,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	h.owner.requestCount.With(labels).Inc()
 	h.owner.requestDuration.With(labels).Observe(elapsed.Seconds())
-
-	return
 }
 
 // Header is part of the implementation of the http.ResponseWriter interface.

--- a/metrics/handler_wrapper_test.go
+++ b/metrics/handler_wrapper_test.go
@@ -81,7 +81,6 @@ var _ = Describe("Metrics", func() {
 		called := false
 		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			called = true
-			return
 		}))
 
 		// Send the request:

--- a/metrics/path_tree.go
+++ b/metrics/path_tree.go
@@ -57,43 +57,6 @@ import (
 // Path variables are represented with a dash.
 type pathTree map[string]pathTree
 
-// redact removes from the given URL path all the segments that correspond to path variable, as
-// defined in this tree. Each path variable will be replaced with a dash. For example:
-//
-//	/api/clusters_mgmt/v1/clusters/123 -> /api/clusters_mgmt/v1/clusters/-
-//	/api/clusters_mgmt/v1/clusters/123/users -> /api/clusters_mgmt/v1/clusters/-/users
-//	/api/clusters_mgmt/v1/clusters/123/users/456 -> /api/clusters_mgmt/v1/clusters/-/users/456
-//
-// Paths with segments that don't match this tree will be replaced with `/-`.
-func (t pathTree) redact(path string) string {
-	// Remove leading and trailing slashes:
-	path = t.clean(path)
-	if len(path) == 0 {
-		return path
-	}
-
-	// Clear segments that correspond to path variables:
-	segments := strings.Split(path, "/")
-	current := t
-	for i, segment := range segments {
-		next, ok := current[segment]
-		if ok {
-			current = next
-			continue
-		}
-		next, ok = current["-"]
-		if ok {
-			segments[i] = "-"
-			current = next
-			continue
-		}
-		return "/-"
-	}
-
-	// Reconstruct the path joining the modified segments:
-	return "/" + strings.Join(segments, "/")
-}
-
 // copy creates a deep copy of this tree.
 func (t pathTree) copy() pathTree {
 	if t == nil {

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -195,6 +195,5 @@ func RespondWithRedirect(code int, target string) http.HandlerFunc {
 		location.Host = parsed.Host
 		w.Header().Set("Location", location.String())
 		w.WriteHeader(code)
-		return
 	}
 }


### PR DESCRIPTION
This changes the code so that it will be prepared for the upgrade to
`golangci-lint` 1.42.0 that will happen in a latter change.