### PR TITLE
Add GitHub action to lint Go code

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -24,6 +24,7 @@ on:
 jobs:
 
   test:
+    name: Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,3 +45,15 @@ jobs:
 
     - name: Run the tests
       run: make tests
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+
+    - name: Run the linter
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.42.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,19 +28,3 @@ run:
   - server.go
   deadline: 15m
   issues-exit-code: 1
-linters:
-  disable-all: true
-  enable:
-  - deadcode
-  - gas
-  - goconst
-  - gofmt
-  - golint
-  - ineffassign
-  - interfacer
-  - lll
-  - megacheck
-  - misspell
-  - structcheck
-  - unconvert
-  - varcheck


### PR DESCRIPTION
This patch adds a GitHub action that runs the `golangci-lint` tool to
lint the code.