### PR TITLE
Build examples as part of the `test` job

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -46,6 +46,9 @@ jobs:
     - name: Run the tests
       run: make tests
 
+    - name: Build the examples
+      run: make examples
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
This patch changes the `test` job so that it also builds the examples.