### PR TITLE
Remove tests from `pr_check.sh`

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -31,12 +31,6 @@ go get golang.org/x/tools/cmd/goimports@v0.0.0-20200518194103-259583f2d8a9
 # will try to run the tests inside them:
 rm -rf model metamodel
 
-# Run the checks:
-make \
-  test \
-  examples \
-  lint
-
 # Check that running `make generate` doesn't introduce any change in the
 # generated code:
 make generate


### PR DESCRIPTION
This patch removes from the `pr_check.sh` script the tests that have
been moved to GitHub actions.