### PR TITLE
Use 'go install' instead of 'go get' to install tools

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -40,8 +40,16 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Setup Ginkgo
-      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.4
+    - name: Setup Go tools
+      run: |
+        # The support to specify a version in the `go install` command was
+        # added in Go 1.16, so we need to check the version and use `go get`
+        # if not available yet.
+        command="install"
+        if [ "${{ matrix.go }}" = "1.15" ]; then
+          command="get"
+        fi
+        go "${command}" github.com/onsi/ginkgo/ginkgo@v1.16.4
 
     - name: Run the tests
       run: make tests
@@ -74,7 +82,7 @@ jobs:
         go-version: 1.16
 
     - name: Setup Goimports
-      run: go get golang.org/x/tools/cmd/goimports@v0.0.0-20200518194103-259583f2d8a9
+      run: go install golang.org/x/tools/cmd/goimports@v0.0.0-20200518194103-259583f2d8a9
 
     - name: Generate code
       run: make generate


### PR DESCRIPTION
This patch changes the build so that it uses `go install` instead of `go
get` to install tools. That way there are less chances of accidentally
changing the `go.mod` or `go.sum` files and breaking the build.