### PR TITLE
Fix token close to expire test

### DIFF
--- a/authentication/transport_wrapper_test.go
+++ b/authentication/transport_wrapper_test.go
@@ -257,7 +257,7 @@ var _ = Describe("Tokens", func() {
 
 		It("Succeeds if access token expires soon and there is no refresh token", func() {
 			// Generate the tokens:
-			accessToken := MakeTokenString("Bearer", 1*time.Second)
+			accessToken := MakeTokenString("Bearer", 10*time.Second)
 
 			// Create the wrapper:
 			wrapper, err := NewTransportWrapper().


### PR DESCRIPTION
This patch checks the test that checks that access tokens are used even
if they are close to expire when there is no other way to get new
tokens. Currently it fails some times because it generates a token that
expires too soon: in one second. It is now changed to 10 seconds.