### PR TITLE
Enable tests that need a database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,8 @@ examples:
 
 .PHONY: test tests
 test tests:
-	# Currently we need to skip the tests of the `leadership` package
-	# because the Jenkins environment isn't prepared to run `podman`.
 	ginkgo -p -r --skipPackage=leadership
+	ginkgo leadership
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
The tests that need a database are currently disabled because they
needed to start a container with the `podman` tool, and that wasn't
available when running in the old Jenkins environment. In the new GitHub
actions environment it isn't available either, but `docker` can be used
instead.