### PR TITLE
Accept lower case token type

### DIFF
--- a/authentication/transport_wrapper.go
+++ b/authentication/transport_wrapper.go
@@ -901,8 +901,8 @@ func (w *TransportWrapper) sendFormTimed(ctx context.Context, form url.Values) (
 		err = fmt.Errorf("token response status code is '%d'", response.StatusCode)
 		return
 	}
-	if result.TokenType != nil && *result.TokenType != "bearer" {
-		err = fmt.Errorf("expected 'bearer' token type but got '%s", *result.TokenType)
+	if result.TokenType != nil && !strings.EqualFold(*result.TokenType, "bearer") {
+		err = fmt.Errorf("expected 'bearer' token type but got '%s'", *result.TokenType)
 		return
 	}
 
@@ -918,10 +918,11 @@ func (w *TransportWrapper) sendFormTimed(ctx context.Context, form url.Values) (
 		return
 	}
 
-	// The refresh token isn't mandatory for the client credentials grant:
+	// The refresh token isn't mandatory for the password and client credentials grants:
 	var refreshToken *jwt.Token
 	if result.RefreshToken == nil {
-		if form.Get(grantTypeField) != clientCredentialsGrant {
+		grantType := form.Get(grantTypeField)
+		if grantType != passwordGrant && grantType != clientCredentialsGrant {
 			err = fmt.Errorf("no refresh token was received")
 			return
 		}

--- a/authentication/transport_wrapper_test.go
+++ b/authentication/transport_wrapper_test.go
@@ -685,6 +685,68 @@ var _ = Describe("Tokens", func() {
 			_, _, err = wrapper.Tokens(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("Works if no refresh token is returned", func() {
+			// Generate the tokens:
+			accessToken := MakeTokenString("Bearer", 5*time.Minute)
+
+			// Configure the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyPasswordGrant("myuser", "mypassword"),
+					RespondWithAccessToken(accessToken),
+				),
+			)
+
+			// Create the wrapper:
+			wrapper, err := NewTransportWrapper().
+				Logger(logger).
+				TokenURL(server.URL()).
+				TrustedCA(ca).
+				User("myuser", "mypassword").
+				Build(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err = wrapper.Close()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			// Get the tokens:
+			returnedAccess, _, err := wrapper.Tokens(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedAccess).To(Equal(accessToken))
+		})
+
+		It("Accepts lower case token type", func() {
+			// Generate the tokens:
+			accessToken := MakeTokenString("bearer", 5*time.Minute)
+
+			// Configure the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyPasswordGrant("myuser", "mypassword"),
+					RespondWithAccessToken(accessToken),
+				),
+			)
+
+			// Create the wrapper:
+			wrapper, err := NewTransportWrapper().
+				Logger(logger).
+				TokenURL(server.URL()).
+				TrustedCA(ca).
+				User("myuser", "mypassword").
+				Build(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err = wrapper.Close()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			// Get the tokens:
+			returnedAccess, _, err := wrapper.Tokens(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedAccess).To(Equal(accessToken))
+		})
 	})
 
 	When("Only the access token is provided", func() {


### PR DESCRIPTION
Currently the SDK expects responses from the SSO server to contain the
token type exactly as `Bearer`. But some servers, in particular the
_Okta_ identity provider, return it in lower case. This patch changes
the SDK so that it will accept that.