### PR TITLE
Opaque refresh tokens

### DIFF
--- a/authentication/token_info.go
+++ b/authentication/token_info.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authentication
+
+import "github.com/golang-jwt/jwt"
+
+// tokenInfo stores information about a token. We need to store both the original text and the
+// parsed objects because some tokens (refresh tokens in particular) may be opaque strings instead
+// of JSON web tokens.
+type tokenInfo struct {
+	text   string
+	object *jwt.Token
+}


### PR DESCRIPTION
Currently we assume that refresh tokens are JSON web tokens, we try to
parse them and we fail if they aren't. But this is a misconception, it
is true for the refresh tokens issued by `sso.redhat.com`, but not true
in general, and not true for _Okta_ in particular. This patch changes
the authentication package so that it will no longer assume that. We
will still try to parse refresh tokens, but will not fail when that
isn't possible.