### PR TITLE
Add publish release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish release
+
+on:
+  push:
+    tags:
+    - v*
+
+jobs:
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create release
+      run: |
+        # Get the version number:
+        version=$(echo -n ${{ github.ref }} | sed -E 's|^refs/tags/v(.*)$|\1|')
+
+        # Send the request to create the release:
+        cat > request.json <<.
+        {
+          "tag_name": "v${version}",
+          "name": "Release ${version}",
+          "body": "See the [CHANGES](CHANGES.adoc) file for details."
+        }
+        .
+        curl \
+        --silent \
+        --request "POST" \
+        --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+        --header "Content-Type: application/json" \
+        --header "Accept: application/json" \
+        --url "https://api.github.com/repos/${{ github.repository }}/releases" \
+        --data @request.json \
+        --output response.json \
+        --fail


### PR DESCRIPTION
This patch adds a workflow that will be triggered when a new `v*` tag is
pushed. It will create a new GitHub release. This is intended to trigger
notifications to people that is subscribed to release events.