### PR TITLE
Fix retry wait

### DIFF
--- a/retry/transport_wrapper.go
+++ b/retry/transport_wrapper.go
@@ -298,7 +298,7 @@ func (t *roundTripper) sleep(ctx context.Context, attempt int) {
 	interval := t.interval
 
 	// Double the interval for each attempt:
-	interval *= 1 << attempt
+	interval *= 1 << (attempt - 1)
 
 	// Adjust the interval adding or subtracting a random amount. For example, if the jitter
 	// factor given in the configuration is 0.1 will add or sustract up to a 10%.


### PR DESCRIPTION
Currently the retry interval isn't correctly calculated for the first
retry: it is double what it should be. This isn't detected by tests
because they check only that the retry wait is larger than the minimum
expected value. This patch fixes the issue and improves the tests so
that they use a lower and upper limit.