### PR TITLE
Run tests serially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,7 @@ examples:
 
 .PHONY: test tests
 test tests:
-	ginkgo -p -r --skipPackage=leadership
-	ginkgo leadership
+	ginkgo -r
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
We are currently running tests in parallel, using the `-p` option of
_Ginkgo_, but this is causing random failures in the _GitHub_ workflows,
apparently due to communication failures between the multiple processes
that _Ginkgo_ creates, something like this:

```
• Failure [0.000 seconds]
Get bearer from context [It] Succeeds if there is no token
/home/runner/work/ocm-sdk-go/ocm-sdk-go/authentication/context_test.go:66

  Unexpected error:
      <http.http2StreamError>: {StreamID: 1, Code: 8, Cause: nil}
      stream error: stream ID 1; CANCEL
  occurred

  /home/runner/go/pkg/mod/github.com/onsi/gomega@v1.16.0/ghttp/handlers.go:163
```

That is for a test that doesn't use HTTP at all, so looks like it is an
internal _Ginkgo_ failure.

To try to make the tests more reliable this patch changes the Makefile
so that they run serially. This also means that we don't need to run the
tests that require a database server separately.