### PR TITLE
Implement the `http.Flusher` interface

### DIFF
--- a/metrics/handler_wrapper.go
+++ b/metrics/handler_wrapper.go
@@ -268,3 +268,11 @@ func (w *responseWriter) WriteHeader(code int) {
 	w.code = code
 	w.writer.WriteHeader(code)
 }
+
+// Flush is the implementation of the http.Flusher interface.
+func (w *responseWriter) Flush() {
+	flusher, ok := w.writer.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}


### PR DESCRIPTION
This patch changes the metrics handler so that the response writers that
it create implement the `http.Flusher` interface.