### PR TITLE
Add support for digging inside maps

### DIFF
--- a/data/digger.go
+++ b/data/digger.go
@@ -106,6 +106,8 @@ func (d *Digger) digFieldFromValue(value reflect.Value, field string) interface{
 		return d.digFieldFromPtr(value, field)
 	case reflect.Struct:
 		return d.digFieldFromStruct(value, field)
+	case reflect.Map:
+		return d.digFieldFromMap(value, field)
 	default:
 		return nil
 	}
@@ -167,6 +169,15 @@ func (d *Digger) digFieldFromMethod(value reflect.Value, method reflect.Method) 
 	}
 
 	// Return the result:
+	if !result.IsValid() {
+		return nil
+	}
+	return result.Interface()
+}
+
+func (d *Digger) digFieldFromMap(value reflect.Value, name string) interface{} {
+	key := reflect.ValueOf(name)
+	result := value.MapIndex(key)
 	if !result.IsValid() {
 		return nil
 	}

--- a/data/digger_test.go
+++ b/data/digger_test.go
@@ -206,6 +206,24 @@ var _ = Describe("Digger", func() {
 			"does_not_exist",
 			nil,
 		),
+		Entry(
+			"Map field",
+			map[string]interface{}{
+				"id": "123",
+			},
+			"id",
+			"123",
+		),
+		Entry(
+			"Nested map field",
+			map[string]interface{}{
+				"object": map[string]interface{}{
+					"id": "123",
+				},
+			},
+			"object.id",
+			"123",
+		),
 	)
 })
 


### PR DESCRIPTION
This patch adds basic support for digging inside maps to the
`data.Digger` type.