### PR TITLE
Update to metamodel 0.0.42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ model_version:=v0.0.149
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.39
+metamodel_version:=v0.0.42
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples

--- a/helpers/json_helpers.go
+++ b/helpers/json_helpers.go
@@ -30,7 +30,7 @@ import (
 )
 
 // NewIterator creates a new JSON iterator that will read to the given source, which
-// can be a slice of bytes, a string or a reader.
+// can be a slice of bytes, a string, a reader or an existing iterator.
 func NewIterator(source interface{}) (iterator *jsoniter.Iterator, err error) {
 	config := jsoniter.Config{}
 	api := config.Froze()
@@ -41,9 +41,11 @@ func NewIterator(source interface{}) (iterator *jsoniter.Iterator, err error) {
 		iterator = jsoniter.ParseString(api, typed)
 	case io.Reader:
 		iterator = jsoniter.Parse(api, typed, 4096)
+	case *jsoniter.Iterator:
+		iterator = typed
 	default:
 		err = fmt.Errorf(
-			"expected slice of bytes, string or reader but got '%T'",
+			"expected slice of bytes, string, reader or iterator but got '%T'",
 			source,
 		)
 	}


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Accept iterator as parameter in `helpers.NewIterator`.