### PR TITLE
Release 0.1.213

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.213 Oct 26 2021
+
+- Update to model 0.0.42
+** Accept iterator as parameter in `helpers.NewIterator`
+- Retry when `REFUSED_STREAM`
+
 == 0.1.212 Oct 12 2021
 
 - Fix typo in HTTP internal server error message

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.212"
+const Version = "0.1.213"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.0.42
  - Accept iterator as parameter in `helpers.NewIterator`
- Retry when `REFUSED_STREAM`