### PR TITLE
Add caching package

### DIFF
--- a/caching/cache.go
+++ b/caching/cache.go
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the cache interface.
+
+package caching
+
+import (
+	"context"
+)
+
+// Cache is an object that knows how to store key/value pairs.
+type Cache interface {
+	// Get returns the value that is associated with the given key and a boolean indicating if
+	// there is such an object.
+	Get(ctx context.Context, key interface{}) (value interface{}, ok bool)
+
+	// Put puts in the cache the given given value associated to the given key.
+	Put(ctx context.Context, key, value interface{})
+}
+
+// CacheFactory is a function that knows how to create caches.
+type CacheFactory func(ctx context.Context) (cache Cache, err error)

--- a/caching/context.go
+++ b/caching/context.go
@@ -1,0 +1,48 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functions to get from the context and add to the context a cache.
+
+package caching
+
+import (
+	"context"
+)
+
+// contextKeyType is the type of the keys used to store things in the context.
+type contextKeyType int
+
+// contextCacheKey is the key used to store the cache in the context.
+const contextCacheKey contextKeyType = iota
+
+// CacheFromContext returns the cache associated to the given context, or nil if no cache is
+// associated to the context.
+func CacheFromContext(ctx context.Context) Cache {
+	value := ctx.Value(contextCacheKey)
+	if value != nil {
+		return value.(Cache)
+	}
+	return nil
+}
+
+// CacheIntoContext adds the given cache to the context. If the given context is nil a new one will
+// be created using the context.Background function.
+func CacheIntoContext(ctx context.Context, cache Cache) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, contextCacheKey, cache)
+}

--- a/caching/context_test.go
+++ b/caching/context_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package caching
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+var _ = Describe("Context", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("Adds cache to existing context", func() {
+		// Create a cache:
+		cache, err := NewMemoryCache().Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Add the cache to the context:
+		ctx = CacheIntoContext(ctx, cache)
+		Expect(ctx).ToNot(BeNil())
+
+		// Check the result:
+		result := CacheFromContext(ctx)
+		Expect(result).To(Equal(cache))
+	})
+
+	It("Creates new context if needed", func() {
+		// Create a cache:
+		cache, err := NewMemoryCache().Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Add the cache to the context:
+		ctx = CacheIntoContext(nil, cache) // nolint
+		Expect(ctx).ToNot(BeNil())
+
+		// Check the result:
+		result := CacheFromContext(ctx)
+		Expect(result).To(Equal(cache))
+	})
+
+	It("Returns nil if there is no cache in the context", func() {
+		result := CacheFromContext(ctx)
+		Expect(result).To(BeNil())
+	})
+})

--- a/caching/handler_wrapper.go
+++ b/caching/handler_wrapper.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the implementations of a wrapper that wraps HTTP handlers that attatch an
+// empty cache to the request context. This cache can then be used to store object that will be
+// frequently used for the duration of the request.
+
+package caching
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+// HandlerWrapperBuilder contains the data and logic needed to build a new chacing handler wrapper.
+// Don't create objects of this type directly; use the NewHandlerWrapper function instead.
+type HandlerWrapperBuilder struct {
+	logger       logging.Logger
+	cacheFactory CacheFactory
+}
+
+// HandlerWrapper contains the data and logic needed to wrap an HTTP handler.
+type HandlerWrapper struct {
+	logger       logging.Logger
+	cacheFactory CacheFactory
+}
+
+// handler is an HTTP handler that adds a new cache to the request context.
+type handler struct {
+	logger       logging.Logger
+	cacheFactory CacheFactory
+	handler      http.Handler
+}
+
+// Make sure that we implement the interface:
+var _ http.Handler = (*handler)(nil)
+
+// NewHandlerWrapper creates a new builder that can then be used to configure and create a new
+// caching handler wrapper.
+func NewHandlerWrapper() *HandlerWrapperBuilder {
+	return &HandlerWrapperBuilder{
+		cacheFactory: defaultHandlerWrapperCacheFactory,
+	}
+}
+
+// Logger sets the logger that the handlers will use to write messages to the log.
+func (b *HandlerWrapperBuilder) Logger(value logging.Logger) *HandlerWrapperBuilder {
+	b.logger = value
+	return b
+}
+
+// CacheFactory sets a function that the handlers will use to create the cache. For example, to
+// configure the handlers so that they create memory caches:
+//
+//	wrapper, err := caching.NewHandlerWrapper().
+//		CacheFactory(func (ctx context.Context) (cache Cache, err error) {
+//			cache, err = caching.NewMemoryCache().Build(ctx)
+//			return
+//		}).
+//		Build(ctx)
+//	if err != nil {
+//		...
+//	}
+//
+// Note that this is just an example, and is not required as the handlers will create memory caches
+// by default.
+func (b *HandlerWrapperBuilder) CacheFactory(value CacheFactory) *HandlerWrapperBuilder {
+	b.cacheFactory = value
+	return b
+}
+
+// Build uses the information stored in the builder to create a new handler wrapper.
+func (b *HandlerWrapperBuilder) Build(ctx context.Context) (result *HandlerWrapper, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+	if b.cacheFactory == nil {
+		err = fmt.Errorf("cache factory is mandatory")
+		return
+	}
+
+	// Create and populate the object:
+	result = &HandlerWrapper{
+		logger:       b.logger,
+		cacheFactory: b.cacheFactory,
+	}
+
+	return
+}
+
+// Wrap creates a new caching handler that wraps the given one.
+func (w *HandlerWrapper) Wrap(h http.Handler) http.Handler {
+	return &handler{
+		logger:       w.logger,
+		cacheFactory: w.cacheFactory,
+		handler:      h,
+	}
+}
+
+// ServeHTTP is the implementation of the HTTP handler interface.
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	cache := CacheFromContext(ctx)
+	if cache == nil {
+		var err error
+		cache, err = h.cacheFactory(ctx)
+		if err != nil {
+			h.logger.Error(ctx, "Can't create cache: %v", err)
+			errors.SendInternalServerError(w, r)
+			return
+		}
+		ctx = CacheIntoContext(ctx, cache)
+		r = r.WithContext(ctx)
+	}
+	h.handler.ServeHTTP(w, r)
+}
+
+// defaultHandlerWrapperCacheFactory is the default function used to create caches.
+func defaultHandlerWrapperCacheFactory(ctx context.Context) (cache Cache, err error) {
+	cache, err = NewMemoryCache().Build(ctx)
+	return
+}

--- a/caching/handler_wrapper_test.go
+++ b/caching/handler_wrapper_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package caching
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+var _ = Describe("Handler wrapper", func() {
+	var ctx context.Context
+	var handler http.Handler
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("Can't be created without a logger", func() {
+		wrapper, err := NewHandlerWrapper().Build(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(wrapper).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("logger"))
+		Expect(message).To(ContainSubstring("mandatory"))
+	})
+
+	It("Can't be created without a cache factory", func() {
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			CacheFactory(nil).
+			Build(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(wrapper).To(BeNil())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("factory"))
+		Expect(message).To(ContainSubstring("mandatory"))
+	})
+
+	It("Calls wrapped handler", func() {
+		// Create the wrapper:
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Prepare the handler:
+		called := false
+		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Send the request:
+		request := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		// Check that the wrapped handler was called:
+		Expect(called).To(BeTrue())
+	})
+
+	It("Returns output of wrapped handler", func() {
+		// Create the wrapper:
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Prepare the handler:
+		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{}`))
+			Expect(err).ToNot(HaveOccurred())
+		}))
+
+		// Send the request:
+		request := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		// Check the output:
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		Expect(recorder.Body).To(MatchJSON(`{}`))
+	})
+
+	It("Creates a memory cache by default", func() {
+		// Create the wrapper:
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Prepare the handler:
+		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			cache := CacheFromContext(ctx)
+			Expect(cache).ToNot(BeNil())
+			var memory *MemoryCache
+			Expect(cache).To(BeAssignableToTypeOf(memory))
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Send the request:
+		request := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+	})
+
+	It("Uses the provided cache factory", func() {
+		// Create the wrapper:
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			CacheFactory(func(ctx context.Context) (cache Cache, err error) {
+				cache, err = NewNopCache().Build(ctx)
+				return
+			}).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Prepare the handler:
+		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			cache := CacheFromContext(ctx)
+			Expect(cache).ToNot(BeNil())
+			var nop *NopCache
+			Expect(cache).To(BeAssignableToTypeOf(nop))
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Send the request:
+		request := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+	})
+
+	It("Doesn't create a cache if there is already one in the context", func() {
+		// Create the wrapper:
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Prepare the handler:
+		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			cache := CacheFromContext(ctx)
+			Expect(cache).ToNot(BeNil())
+			var nop *NopCache
+			Expect(cache).To(BeAssignableToTypeOf(nop))
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Create a nop cache and put it in the context:
+		cache, err := NewNopCache().Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		ctx = CacheIntoContext(ctx, cache)
+
+		// Send the request:
+		request := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		request = request.WithContext(ctx)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+	})
+
+	It("Doesn't call the wrapped handler if the cache can't be created", func() {
+		// Create the wrapper:
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			CacheFactory(func(ctx context.Context) (cache Cache, err error) {
+				err = fmt.Errorf("myerror")
+				return
+			}).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Prepare the handler:
+		called := false
+		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+
+		// Send the request:
+		request := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		// Check that the wrapped handler wasn't called:
+		Expect(called).To(BeFalse())
+	})
+
+	It("Returns a 500 error if the cache can't be created", func() {
+		// Create the wrapper:
+		wrapper, err := NewHandlerWrapper().
+			Logger(logger).
+			CacheFactory(func(ctx context.Context) (cache Cache, err error) {
+				err = fmt.Errorf("myerror")
+				return
+			}).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Prepare the handler:
+		handler = wrapper.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Send the request:
+		request := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		// Check the response:
+		Expect(recorder.Code).To(Equal(http.StatusInternalServerError))
+		Expect(recorder.Body).To(MatchJSON(`{
+			"kind": "Error",
+			"id": "500",
+			"reason": "Can't process 'GET' request for path '' due to an internalserver error"
+		}`))
+	})
+})

--- a/caching/main_test.go
+++ b/caching/main_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package caching
+
+import (
+	"testing"
+
+	"github.com/openshift-online/ocm-sdk-go/logging"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+func TestCaching(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Caching")
+}
+
+// Logger used for tests:
+var logger logging.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create the logger that will be used by all the tests:
+	logger, err = logging.NewStdLoggerBuilder().
+		Streams(GinkgoWriter, GinkgoWriter).
+		Debug(true).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/caching/memory_cache.go
+++ b/caching/memory_cache.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains a cache implementation that stores key/value pairs in memory.
+
+package caching
+
+import (
+	"context"
+	"sync"
+)
+
+// MemoryCacheBuilder contains the data and logic needed to create a memory cache. Don't create
+// instances of this type directly, use the NewMemoryCache function instead.
+type MemoryCacheBuilder struct {
+}
+
+// MemoryCache is an implementation of the cache iterface that stores the keys and values in memory.
+type MemoryCache struct {
+	values *sync.Map
+}
+
+// NewMemoryCache creates a builder that can then be used to configure and create a memory cache.
+func NewMemoryCache() *MemoryCacheBuilder {
+	return &MemoryCacheBuilder{}
+}
+
+// Build uses the data stored in the builder to create a new memory cache.
+func (b *MemoryCacheBuilder) Build(ctx context.Context) (result *MemoryCache, err error) {
+	// Create and populate the object:
+	result = &MemoryCache{
+		values: &sync.Map{},
+	}
+
+	return
+}
+
+// Get is part of the implementation of the Cache interface.
+func (c *MemoryCache) Get(ctx context.Context, key interface{}) (value interface{}, ok bool) {
+	value, ok = c.values.Load(key)
+	return
+}
+
+// Put is part of the implementation of the Cache interface.
+func (c *MemoryCache) Put(ctx context.Context, key interface{}, value interface{}) {
+	c.values.Store(key, value)
+}

--- a/caching/memory_cache_test.go
+++ b/caching/memory_cache_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package caching
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+var _ = Describe("Memory cache", func() {
+	var ctx context.Context
+	var cache Cache
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Create a cache:
+		cache, err = NewMemoryCache().Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Get after put", func() {
+		cache.Put(ctx, "mykey", "myvalue")
+		value, ok := cache.Get(ctx, "mykey")
+		Expect(ok).To(BeTrue())
+		Expect(value).To(Equal("myvalue"))
+	})
+
+	It("Get without put", func() {
+		value, ok := cache.Get(ctx, "mykey")
+		Expect(ok).To(BeFalse())
+		Expect(value).To(BeNil())
+	})
+})

--- a/caching/nop_cache.go
+++ b/caching/nop_cache.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains a cache implementation that doesn't store key/value pairs. This is intended
+// for tests only.
+
+package caching
+
+import (
+	"context"
+)
+
+// NopCacheBuilder contains the data and logic needed to create a cache that doesn't store key/value
+// pairs. Don't create instances of this type directly, use the NewNopCache function instead.
+type NopCacheBuilder struct {
+}
+
+// NopCache is an implementation of the cache interface that doesn't store key/value pairs.
+type NopCache struct {
+}
+
+// NewNopCache creates a builder that can then be used to configure and create a nop cache.
+func NewNopCache() *NopCacheBuilder {
+	return &NopCacheBuilder{}
+}
+
+// Build uses the data stored in the builder to create a new nop cache.
+func (b *NopCacheBuilder) Build(ctx context.Context) (result *NopCache, err error) {
+	// Create and populate the object:
+	result = &NopCache{}
+
+	return
+}
+
+// Get is part of the implementation of the Cache interface.
+func (c *NopCache) Get(ctx context.Context, key interface{}) (value interface{}, ok bool) {
+	// This does nothing on purpose.
+	return
+}
+
+// Put is part of the implementation of the Cache interface.
+func (c *NopCache) Put(ctx context.Context, key interface{}, value interface{}) {
+	// This does nothing on purpose.
+}


### PR DESCRIPTION
This patch adds a new `catching` package that currently contains an HTTP
handler wrapper that creates handlers that add to the context a short
term cache for use in the current request.