### PR TITLE
Release 0.1.216

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.216 Nov 15 2021
+
+- Update to metamodel 0.0.43:
+** Add `status` attribute to errors.
+
 == 0.1.215 Nov 7 2021
 - Update to model 0.0.151:
 ** Add Name field to LDAP identity provider

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.215"
+const Version = "0.1.216"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.43:
   - Add `status` attribute to errors.