### PR TITLE
Update to metamodel 0.0.44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ model_version:=v0.0.152
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.43
+metamodel_version:=v0.0.44
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: examples

--- a/accountsmgmt/v1/access_token_auth_builder.go
+++ b/accountsmgmt/v1/access_token_auth_builder.go
@@ -33,6 +33,11 @@ func NewAccessTokenAuth() *AccessTokenAuthBuilder {
 	return &AccessTokenAuthBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AccessTokenAuthBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Auth sets the value of the 'auth' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/access_token_auth_list_builder.go
+++ b/accountsmgmt/v1/access_token_auth_list_builder.go
@@ -37,6 +37,11 @@ func (b *AccessTokenAuthListBuilder) Items(values ...*AccessTokenAuthBuilder) *A
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AccessTokenAuthListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AccessTokenAuthListBuilder) Copy(list *AccessTokenAuthList) *AccessTokenAuthListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/access_token_builder.go
+++ b/accountsmgmt/v1/access_token_builder.go
@@ -32,6 +32,11 @@ func NewAccessToken() *AccessTokenBuilder {
 	return &AccessTokenBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AccessTokenBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Auths sets the value of the 'auths' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/access_token_list_builder.go
+++ b/accountsmgmt/v1/access_token_list_builder.go
@@ -37,6 +37,11 @@ func (b *AccessTokenListBuilder) Items(values ...*AccessTokenBuilder) *AccessTok
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AccessTokenListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AccessTokenListBuilder) Copy(list *AccessTokenList) *AccessTokenListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/account_builder.go
+++ b/accountsmgmt/v1/account_builder.go
@@ -69,6 +69,11 @@ func (b *AccountBuilder) HREF(value string) *AccountBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AccountBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // BanCode sets the value of the 'ban_code' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/account_list_builder.go
+++ b/accountsmgmt/v1/account_list_builder.go
@@ -37,6 +37,11 @@ func (b *AccountListBuilder) Items(values ...*AccountBuilder) *AccountListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AccountListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AccountListBuilder) Copy(list *AccountList) *AccountListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/capability_builder.go
+++ b/accountsmgmt/v1/capability_builder.go
@@ -34,6 +34,11 @@ func NewCapability() *CapabilityBuilder {
 	return &CapabilityBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CapabilityBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Inherited sets the value of the 'inherited' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/capability_list_builder.go
+++ b/accountsmgmt/v1/capability_list_builder.go
@@ -37,6 +37,11 @@ func (b *CapabilityListBuilder) Items(values ...*CapabilityBuilder) *CapabilityL
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CapabilityListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CapabilityListBuilder) Copy(list *CapabilityList) *CapabilityListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/cluster_authorization_request_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_request_builder.go
@@ -45,6 +45,11 @@ func NewClusterAuthorizationRequest() *ClusterAuthorizationRequestBuilder {
 	return &ClusterAuthorizationRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterAuthorizationRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // BYOC sets the value of the 'BYOC' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/cluster_authorization_request_list_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterAuthorizationRequestListBuilder) Items(values ...*ClusterAuthori
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterAuthorizationRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterAuthorizationRequestListBuilder) Copy(list *ClusterAuthorizationRequestList) *ClusterAuthorizationRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/cluster_authorization_response_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_response_builder.go
@@ -34,6 +34,11 @@ func NewClusterAuthorizationResponse() *ClusterAuthorizationResponseBuilder {
 	return &ClusterAuthorizationResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterAuthorizationResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Allowed sets the value of the 'allowed' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/cluster_authorization_response_list_builder.go
+++ b/accountsmgmt/v1/cluster_authorization_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterAuthorizationResponseListBuilder) Items(values ...*ClusterAuthor
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterAuthorizationResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterAuthorizationResponseListBuilder) Copy(list *ClusterAuthorizationResponseList) *ClusterAuthorizationResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/cluster_metrics_nodes_builder.go
+++ b/accountsmgmt/v1/cluster_metrics_nodes_builder.go
@@ -35,6 +35,11 @@ func NewClusterMetricsNodes() *ClusterMetricsNodesBuilder {
 	return &ClusterMetricsNodesBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterMetricsNodesBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Compute sets the value of the 'compute' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/cluster_metrics_nodes_list_builder.go
+++ b/accountsmgmt/v1/cluster_metrics_nodes_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterMetricsNodesListBuilder) Items(values ...*ClusterMetricsNodesBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterMetricsNodesListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterMetricsNodesListBuilder) Copy(list *ClusterMetricsNodesList) *ClusterMetricsNodesListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/cluster_registration_request_builder.go
+++ b/accountsmgmt/v1/cluster_registration_request_builder.go
@@ -33,6 +33,11 @@ func NewClusterRegistrationRequest() *ClusterRegistrationRequestBuilder {
 	return &ClusterRegistrationRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterRegistrationRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AuthorizationToken sets the value of the 'authorization_token' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/cluster_registration_request_list_builder.go
+++ b/accountsmgmt/v1/cluster_registration_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterRegistrationRequestListBuilder) Items(values ...*ClusterRegistra
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterRegistrationRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterRegistrationRequestListBuilder) Copy(list *ClusterRegistrationRequestList) *ClusterRegistrationRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/cluster_registration_response_builder.go
+++ b/accountsmgmt/v1/cluster_registration_response_builder.go
@@ -35,6 +35,11 @@ func NewClusterRegistrationResponse() *ClusterRegistrationResponseBuilder {
 	return &ClusterRegistrationResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterRegistrationResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountID sets the value of the 'account_ID' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/cluster_registration_response_list_builder.go
+++ b/accountsmgmt/v1/cluster_registration_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterRegistrationResponseListBuilder) Items(values ...*ClusterRegistr
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterRegistrationResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterRegistrationResponseListBuilder) Copy(list *ClusterRegistrationResponseList) *ClusterRegistrationResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/cluster_resource_builder.go
+++ b/accountsmgmt/v1/cluster_resource_builder.go
@@ -38,6 +38,11 @@ func NewClusterResource() *ClusterResourceBuilder {
 	return &ClusterResourceBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterResourceBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Total sets the value of the 'total' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/cluster_resource_list_builder.go
+++ b/accountsmgmt/v1/cluster_resource_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterResourceListBuilder) Items(values ...*ClusterResourceBuilder) *C
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterResourceListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterResourceListBuilder) Copy(list *ClusterResourceList) *ClusterResourceListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/cluster_upgrade_builder.go
+++ b/accountsmgmt/v1/cluster_upgrade_builder.go
@@ -39,6 +39,11 @@ func NewClusterUpgrade() *ClusterUpgradeBuilder {
 	return &ClusterUpgradeBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterUpgradeBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Available sets the value of the 'available' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/cluster_upgrade_list_builder.go
+++ b/accountsmgmt/v1/cluster_upgrade_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterUpgradeListBuilder) Items(values ...*ClusterUpgradeBuilder) *Clu
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterUpgradeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterUpgradeListBuilder) Copy(list *ClusterUpgradeList) *ClusterUpgradeListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/feature_toggle_builder.go
+++ b/accountsmgmt/v1/feature_toggle_builder.go
@@ -54,6 +54,11 @@ func (b *FeatureToggleBuilder) HREF(value string) *FeatureToggleBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *FeatureToggleBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Enabled sets the value of the 'enabled' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/feature_toggle_list_builder.go
+++ b/accountsmgmt/v1/feature_toggle_list_builder.go
@@ -37,6 +37,11 @@ func (b *FeatureToggleListBuilder) Items(values ...*FeatureToggleBuilder) *Featu
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *FeatureToggleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *FeatureToggleListBuilder) Copy(list *FeatureToggleList) *FeatureToggleListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/feature_toggle_query_request_builder.go
+++ b/accountsmgmt/v1/feature_toggle_query_request_builder.go
@@ -32,6 +32,11 @@ func NewFeatureToggleQueryRequest() *FeatureToggleQueryRequestBuilder {
 	return &FeatureToggleQueryRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *FeatureToggleQueryRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // OrganizationID sets the value of the 'organization_ID' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/feature_toggle_query_request_list_builder.go
+++ b/accountsmgmt/v1/feature_toggle_query_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *FeatureToggleQueryRequestListBuilder) Items(values ...*FeatureToggleQue
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *FeatureToggleQueryRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *FeatureToggleQueryRequestListBuilder) Copy(list *FeatureToggleQueryRequestList) *FeatureToggleQueryRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/label_builder.go
+++ b/accountsmgmt/v1/label_builder.go
@@ -62,6 +62,11 @@ func (b *LabelBuilder) HREF(value string) *LabelBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LabelBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // CreatedAt sets the value of the 'created_at' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/label_list_builder.go
+++ b/accountsmgmt/v1/label_list_builder.go
@@ -37,6 +37,11 @@ func (b *LabelListBuilder) Items(values ...*LabelBuilder) *LabelListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LabelListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LabelListBuilder) Copy(list *LabelList) *LabelListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/organization_builder.go
+++ b/accountsmgmt/v1/organization_builder.go
@@ -64,6 +64,11 @@ func (b *OrganizationBuilder) HREF(value string) *OrganizationBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *OrganizationBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Capabilities sets the value of the 'capabilities' attribute to the given values.
 //
 //

--- a/accountsmgmt/v1/organization_list_builder.go
+++ b/accountsmgmt/v1/organization_list_builder.go
@@ -37,6 +37,11 @@ func (b *OrganizationListBuilder) Items(values ...*OrganizationBuilder) *Organiz
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *OrganizationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *OrganizationListBuilder) Copy(list *OrganizationList) *OrganizationListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/permission_builder.go
+++ b/accountsmgmt/v1/permission_builder.go
@@ -55,6 +55,11 @@ func (b *PermissionBuilder) HREF(value string) *PermissionBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *PermissionBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Action sets the value of the 'action' attribute to the given value.
 //
 // Possible actions for a permission.

--- a/accountsmgmt/v1/permission_list_builder.go
+++ b/accountsmgmt/v1/permission_list_builder.go
@@ -37,6 +37,11 @@ func (b *PermissionListBuilder) Items(values ...*PermissionBuilder) *PermissionL
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *PermissionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *PermissionListBuilder) Copy(list *PermissionList) *PermissionListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/plan_builder.go
+++ b/accountsmgmt/v1/plan_builder.go
@@ -56,6 +56,11 @@ func (b *PlanBuilder) HREF(value string) *PlanBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *PlanBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Category sets the value of the 'category' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/plan_list_builder.go
+++ b/accountsmgmt/v1/plan_list_builder.go
@@ -37,6 +37,11 @@ func (b *PlanListBuilder) Items(values ...*PlanBuilder) *PlanListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *PlanListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *PlanListBuilder) Copy(list *PlanList) *PlanListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/pull_secrets_request_builder.go
+++ b/accountsmgmt/v1/pull_secrets_request_builder.go
@@ -32,6 +32,11 @@ func NewPullSecretsRequest() *PullSecretsRequestBuilder {
 	return &PullSecretsRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *PullSecretsRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ExternalResourceId sets the value of the 'external_resource_id' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/pull_secrets_request_list_builder.go
+++ b/accountsmgmt/v1/pull_secrets_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *PullSecretsRequestListBuilder) Items(values ...*PullSecretsRequestBuild
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *PullSecretsRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *PullSecretsRequestListBuilder) Copy(list *PullSecretsRequestList) *PullSecretsRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/quota_cost_builder.go
+++ b/accountsmgmt/v1/quota_cost_builder.go
@@ -36,6 +36,11 @@ func NewQuotaCost() *QuotaCostBuilder {
 	return &QuotaCostBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *QuotaCostBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Allowed sets the value of the 'allowed' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/quota_cost_list_builder.go
+++ b/accountsmgmt/v1/quota_cost_list_builder.go
@@ -37,6 +37,11 @@ func (b *QuotaCostListBuilder) Items(values ...*QuotaCostBuilder) *QuotaCostList
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *QuotaCostListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *QuotaCostListBuilder) Copy(list *QuotaCostList) *QuotaCostListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/quota_summary_builder.go
+++ b/accountsmgmt/v1/quota_summary_builder.go
@@ -38,6 +38,11 @@ func NewQuotaSummary() *QuotaSummaryBuilder {
 	return &QuotaSummaryBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *QuotaSummaryBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // BYOC sets the value of the 'BYOC' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/quota_summary_list_builder.go
+++ b/accountsmgmt/v1/quota_summary_list_builder.go
@@ -37,6 +37,11 @@ func (b *QuotaSummaryListBuilder) Items(values ...*QuotaSummaryBuilder) *QuotaSu
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *QuotaSummaryListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *QuotaSummaryListBuilder) Copy(list *QuotaSummaryList) *QuotaSummaryListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/registry_builder.go
+++ b/accountsmgmt/v1/registry_builder.go
@@ -65,6 +65,11 @@ func (b *RegistryBuilder) HREF(value string) *RegistryBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *RegistryBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // URL sets the value of the 'URL' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/registry_credential_builder.go
+++ b/accountsmgmt/v1/registry_credential_builder.go
@@ -64,6 +64,11 @@ func (b *RegistryCredentialBuilder) HREF(value string) *RegistryCredentialBuilde
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *RegistryCredentialBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Account sets the value of the 'account' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/registry_credential_list_builder.go
+++ b/accountsmgmt/v1/registry_credential_list_builder.go
@@ -37,6 +37,11 @@ func (b *RegistryCredentialListBuilder) Items(values ...*RegistryCredentialBuild
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *RegistryCredentialListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *RegistryCredentialListBuilder) Copy(list *RegistryCredentialList) *RegistryCredentialListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/registry_list_builder.go
+++ b/accountsmgmt/v1/registry_list_builder.go
@@ -37,6 +37,11 @@ func (b *RegistryListBuilder) Items(values ...*RegistryBuilder) *RegistryListBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *RegistryListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *RegistryListBuilder) Copy(list *RegistryList) *RegistryListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/related_resource_builder.go
+++ b/accountsmgmt/v1/related_resource_builder.go
@@ -39,6 +39,11 @@ func NewRelatedResource() *RelatedResourceBuilder {
 	return &RelatedResourceBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *RelatedResourceBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // BYOC sets the value of the 'BYOC' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/related_resource_list_builder.go
+++ b/accountsmgmt/v1/related_resource_list_builder.go
@@ -37,6 +37,11 @@ func (b *RelatedResourceListBuilder) Items(values ...*RelatedResourceBuilder) *R
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *RelatedResourceListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *RelatedResourceListBuilder) Copy(list *RelatedResourceList) *RelatedResourceListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/reserved_resource_builder.go
+++ b/accountsmgmt/v1/reserved_resource_builder.go
@@ -43,6 +43,11 @@ func NewReservedResource() *ReservedResourceBuilder {
 	return &ReservedResourceBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ReservedResourceBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // BYOC sets the value of the 'BYOC' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/reserved_resource_list_builder.go
+++ b/accountsmgmt/v1/reserved_resource_list_builder.go
@@ -37,6 +37,11 @@ func (b *ReservedResourceListBuilder) Items(values ...*ReservedResourceBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ReservedResourceListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ReservedResourceListBuilder) Copy(list *ReservedResourceList) *ReservedResourceListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/resource_builder.go
+++ b/accountsmgmt/v1/resource_builder.go
@@ -59,6 +59,11 @@ func (b *ResourceBuilder) HREF(value string) *ResourceBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ResourceBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // BYOC sets the value of the 'BYOC' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/resource_list_builder.go
+++ b/accountsmgmt/v1/resource_list_builder.go
@@ -37,6 +37,11 @@ func (b *ResourceListBuilder) Items(values ...*ResourceBuilder) *ResourceListBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ResourceListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ResourceListBuilder) Copy(list *ResourceList) *ResourceListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/resource_quota_builder.go
+++ b/accountsmgmt/v1/resource_quota_builder.go
@@ -63,6 +63,11 @@ func (b *ResourceQuotaBuilder) HREF(value string) *ResourceQuotaBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ResourceQuotaBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // SKU sets the value of the 'SKU' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/resource_quota_list_builder.go
+++ b/accountsmgmt/v1/resource_quota_list_builder.go
@@ -37,6 +37,11 @@ func (b *ResourceQuotaListBuilder) Items(values ...*ResourceQuotaBuilder) *Resou
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ResourceQuotaListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ResourceQuotaListBuilder) Copy(list *ResourceQuotaList) *ResourceQuotaListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/role_binding_builder.go
+++ b/accountsmgmt/v1/role_binding_builder.go
@@ -69,6 +69,11 @@ func (b *RoleBindingBuilder) HREF(value string) *RoleBindingBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *RoleBindingBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Account sets the value of the 'account' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/role_binding_list_builder.go
+++ b/accountsmgmt/v1/role_binding_list_builder.go
@@ -37,6 +37,11 @@ func (b *RoleBindingListBuilder) Items(values ...*RoleBindingBuilder) *RoleBindi
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *RoleBindingListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *RoleBindingListBuilder) Copy(list *RoleBindingList) *RoleBindingListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/role_builder.go
+++ b/accountsmgmt/v1/role_builder.go
@@ -55,6 +55,11 @@ func (b *RoleBuilder) HREF(value string) *RoleBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *RoleBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/role_list_builder.go
+++ b/accountsmgmt/v1/role_list_builder.go
@@ -37,6 +37,11 @@ func (b *RoleListBuilder) Items(values ...*RoleBuilder) *RoleListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *RoleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *RoleListBuilder) Copy(list *RoleList) *RoleListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/sku_builder.go
+++ b/accountsmgmt/v1/sku_builder.go
@@ -58,6 +58,11 @@ func (b *SKUBuilder) HREF(value string) *SKUBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SKUBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // BYOC sets the value of the 'BYOC' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/sku_list_builder.go
+++ b/accountsmgmt/v1/sku_list_builder.go
@@ -37,6 +37,11 @@ func (b *SKUListBuilder) Items(values ...*SKUBuilder) *SKUListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SKUListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SKUListBuilder) Copy(list *SKUList) *SKUListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/sku_rule_builder.go
+++ b/accountsmgmt/v1/sku_rule_builder.go
@@ -56,6 +56,11 @@ func (b *SkuRuleBuilder) HREF(value string) *SkuRuleBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SkuRuleBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Allowed sets the value of the 'allowed' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/sku_rule_list_builder.go
+++ b/accountsmgmt/v1/sku_rule_list_builder.go
@@ -37,6 +37,11 @@ func (b *SkuRuleListBuilder) Items(values ...*SkuRuleBuilder) *SkuRuleListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SkuRuleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SkuRuleListBuilder) Copy(list *SkuRuleList) *SkuRuleListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/subscription_builder.go
+++ b/accountsmgmt/v1/subscription_builder.go
@@ -90,6 +90,11 @@ func (b *SubscriptionBuilder) HREF(value string) *SubscriptionBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SubscriptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Capabilities sets the value of the 'capabilities' attribute to the given values.
 //
 //

--- a/accountsmgmt/v1/subscription_list_builder.go
+++ b/accountsmgmt/v1/subscription_list_builder.go
@@ -37,6 +37,11 @@ func (b *SubscriptionListBuilder) Items(values ...*SubscriptionBuilder) *Subscri
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SubscriptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SubscriptionListBuilder) Copy(list *SubscriptionList) *SubscriptionListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/subscription_metrics_builder.go
+++ b/accountsmgmt/v1/subscription_metrics_builder.go
@@ -53,6 +53,11 @@ func NewSubscriptionMetrics() *SubscriptionMetricsBuilder {
 	return &SubscriptionMetricsBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SubscriptionMetricsBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // CloudProvider sets the value of the 'cloud_provider' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/subscription_metrics_list_builder.go
+++ b/accountsmgmt/v1/subscription_metrics_list_builder.go
@@ -37,6 +37,11 @@ func (b *SubscriptionMetricsListBuilder) Items(values ...*SubscriptionMetricsBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SubscriptionMetricsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SubscriptionMetricsListBuilder) Copy(list *SubscriptionMetricsList) *SubscriptionMetricsListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/subscription_notify_builder.go
+++ b/accountsmgmt/v1/subscription_notify_builder.go
@@ -41,6 +41,11 @@ func NewSubscriptionNotify() *SubscriptionNotifyBuilder {
 	return &SubscriptionNotifyBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SubscriptionNotifyBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // BccAddress sets the value of the 'bcc_address' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/subscription_notify_list_builder.go
+++ b/accountsmgmt/v1/subscription_notify_list_builder.go
@@ -37,6 +37,11 @@ func (b *SubscriptionNotifyListBuilder) Items(values ...*SubscriptionNotifyBuild
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SubscriptionNotifyListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SubscriptionNotifyListBuilder) Copy(list *SubscriptionNotifyList) *SubscriptionNotifyListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/subscription_registration_builder.go
+++ b/accountsmgmt/v1/subscription_registration_builder.go
@@ -36,6 +36,11 @@ func NewSubscriptionRegistration() *SubscriptionRegistrationBuilder {
 	return &SubscriptionRegistrationBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SubscriptionRegistrationBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ClusterUUID sets the value of the 'cluster_UUID' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/subscription_registration_list_builder.go
+++ b/accountsmgmt/v1/subscription_registration_list_builder.go
@@ -37,6 +37,11 @@ func (b *SubscriptionRegistrationListBuilder) Items(values ...*SubscriptionRegis
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SubscriptionRegistrationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SubscriptionRegistrationListBuilder) Copy(list *SubscriptionRegistrationList) *SubscriptionRegistrationListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/summary_dashboard_builder.go
+++ b/accountsmgmt/v1/summary_dashboard_builder.go
@@ -54,6 +54,11 @@ func (b *SummaryDashboardBuilder) HREF(value string) *SummaryDashboardBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SummaryDashboardBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Metrics sets the value of the 'metrics' attribute to the given values.
 //
 //

--- a/accountsmgmt/v1/summary_dashboard_list_builder.go
+++ b/accountsmgmt/v1/summary_dashboard_list_builder.go
@@ -37,6 +37,11 @@ func (b *SummaryDashboardListBuilder) Items(values ...*SummaryDashboardBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SummaryDashboardListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SummaryDashboardListBuilder) Copy(list *SummaryDashboardList) *SummaryDashboardListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/summary_metrics_builder.go
+++ b/accountsmgmt/v1/summary_metrics_builder.go
@@ -33,6 +33,11 @@ func NewSummaryMetrics() *SummaryMetricsBuilder {
 	return &SummaryMetricsBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SummaryMetricsBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/summary_metrics_list_builder.go
+++ b/accountsmgmt/v1/summary_metrics_list_builder.go
@@ -37,6 +37,11 @@ func (b *SummaryMetricsListBuilder) Items(values ...*SummaryMetricsBuilder) *Sum
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SummaryMetricsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SummaryMetricsListBuilder) Copy(list *SummaryMetricsList) *SummaryMetricsListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/summary_sample_builder.go
+++ b/accountsmgmt/v1/summary_sample_builder.go
@@ -33,6 +33,11 @@ func NewSummarySample() *SummarySampleBuilder {
 	return &SummarySampleBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SummarySampleBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Time sets the value of the 'time' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/summary_sample_list_builder.go
+++ b/accountsmgmt/v1/summary_sample_list_builder.go
@@ -37,6 +37,11 @@ func (b *SummarySampleListBuilder) Items(values ...*SummarySampleBuilder) *Summa
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SummarySampleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SummarySampleListBuilder) Copy(list *SummarySampleList) *SummarySampleListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/support_case_request_builder.go
+++ b/accountsmgmt/v1/support_case_request_builder.go
@@ -60,6 +60,11 @@ func (b *SupportCaseRequestBuilder) HREF(value string) *SupportCaseRequestBuilde
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SupportCaseRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // ClusterId sets the value of the 'cluster_id' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/support_case_request_list_builder.go
+++ b/accountsmgmt/v1/support_case_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *SupportCaseRequestListBuilder) Items(values ...*SupportCaseRequestBuild
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SupportCaseRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SupportCaseRequestListBuilder) Copy(list *SupportCaseRequestList) *SupportCaseRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/support_case_response_builder.go
+++ b/accountsmgmt/v1/support_case_response_builder.go
@@ -62,6 +62,11 @@ func (b *SupportCaseResponseBuilder) HREF(value string) *SupportCaseResponseBuil
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SupportCaseResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // URI sets the value of the 'URI' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/support_case_response_list_builder.go
+++ b/accountsmgmt/v1/support_case_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *SupportCaseResponseListBuilder) Items(values ...*SupportCaseResponseBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SupportCaseResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SupportCaseResponseListBuilder) Copy(list *SupportCaseResponseList) *SupportCaseResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/template_parameter_builder.go
+++ b/accountsmgmt/v1/template_parameter_builder.go
@@ -34,6 +34,11 @@ func NewTemplateParameter() *TemplateParameterBuilder {
 	return &TemplateParameterBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TemplateParameterBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Content sets the value of the 'content' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/template_parameter_list_builder.go
+++ b/accountsmgmt/v1/template_parameter_list_builder.go
@@ -37,6 +37,11 @@ func (b *TemplateParameterListBuilder) Items(values ...*TemplateParameterBuilder
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *TemplateParameterListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *TemplateParameterListBuilder) Copy(list *TemplateParameterList) *TemplateParameterListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/token_authorization_request_builder.go
+++ b/accountsmgmt/v1/token_authorization_request_builder.go
@@ -32,6 +32,11 @@ func NewTokenAuthorizationRequest() *TokenAuthorizationRequestBuilder {
 	return &TokenAuthorizationRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TokenAuthorizationRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AuthorizationToken sets the value of the 'authorization_token' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/token_authorization_request_list_builder.go
+++ b/accountsmgmt/v1/token_authorization_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *TokenAuthorizationRequestListBuilder) Items(values ...*TokenAuthorizati
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *TokenAuthorizationRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *TokenAuthorizationRequestListBuilder) Copy(list *TokenAuthorizationRequestList) *TokenAuthorizationRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/token_authorization_response_builder.go
+++ b/accountsmgmt/v1/token_authorization_response_builder.go
@@ -32,6 +32,11 @@ func NewTokenAuthorizationResponse() *TokenAuthorizationResponseBuilder {
 	return &TokenAuthorizationResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TokenAuthorizationResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Account sets the value of the 'account' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/token_authorization_response_list_builder.go
+++ b/accountsmgmt/v1/token_authorization_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *TokenAuthorizationResponseListBuilder) Items(values ...*TokenAuthorizat
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *TokenAuthorizationResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *TokenAuthorizationResponseListBuilder) Copy(list *TokenAuthorizationResponseList) *TokenAuthorizationResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/accountsmgmt/v1/value_unit_builder.go
+++ b/accountsmgmt/v1/value_unit_builder.go
@@ -33,6 +33,11 @@ func NewValueUnit() *ValueUnitBuilder {
 	return &ValueUnitBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ValueUnitBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Unit sets the value of the 'unit' attribute to the given value.
 //
 //

--- a/accountsmgmt/v1/value_unit_list_builder.go
+++ b/accountsmgmt/v1/value_unit_list_builder.go
@@ -37,6 +37,11 @@ func (b *ValueUnitListBuilder) Items(values ...*ValueUnitBuilder) *ValueUnitList
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ValueUnitListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ValueUnitListBuilder) Copy(list *ValueUnitList) *ValueUnitListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/access_review_request_builder.go
+++ b/authorizations/v1/access_review_request_builder.go
@@ -38,6 +38,11 @@ func NewAccessReviewRequest() *AccessReviewRequestBuilder {
 	return &AccessReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AccessReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/access_review_request_list_builder.go
+++ b/authorizations/v1/access_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *AccessReviewRequestListBuilder) Items(values ...*AccessReviewRequestBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AccessReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AccessReviewRequestListBuilder) Copy(list *AccessReviewRequestList) *AccessReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/access_review_response_builder.go
+++ b/authorizations/v1/access_review_response_builder.go
@@ -39,6 +39,11 @@ func NewAccessReviewResponse() *AccessReviewResponseBuilder {
 	return &AccessReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AccessReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/access_review_response_list_builder.go
+++ b/authorizations/v1/access_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *AccessReviewResponseListBuilder) Items(values ...*AccessReviewResponseB
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AccessReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AccessReviewResponseListBuilder) Copy(list *AccessReviewResponseList) *AccessReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/capability_review_request_builder.go
+++ b/authorizations/v1/capability_review_request_builder.go
@@ -38,6 +38,11 @@ func NewCapabilityReviewRequest() *CapabilityReviewRequestBuilder {
 	return &CapabilityReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CapabilityReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/capability_review_request_list_builder.go
+++ b/authorizations/v1/capability_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *CapabilityReviewRequestListBuilder) Items(values ...*CapabilityReviewRe
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CapabilityReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CapabilityReviewRequestListBuilder) Copy(list *CapabilityReviewRequestList) *CapabilityReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/capability_review_response_builder.go
+++ b/authorizations/v1/capability_review_response_builder.go
@@ -32,6 +32,11 @@ func NewCapabilityReviewResponse() *CapabilityReviewResponseBuilder {
 	return &CapabilityReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CapabilityReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Result sets the value of the 'result' attribute to the given value.
 //
 //

--- a/authorizations/v1/capability_review_response_list_builder.go
+++ b/authorizations/v1/capability_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *CapabilityReviewResponseListBuilder) Items(values ...*CapabilityReviewR
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CapabilityReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CapabilityReviewResponseListBuilder) Copy(list *CapabilityReviewResponseList) *CapabilityReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/export_control_review_request_builder.go
+++ b/authorizations/v1/export_control_review_request_builder.go
@@ -32,6 +32,11 @@ func NewExportControlReviewRequest() *ExportControlReviewRequestBuilder {
 	return &ExportControlReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExportControlReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/export_control_review_request_list_builder.go
+++ b/authorizations/v1/export_control_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *ExportControlReviewRequestListBuilder) Items(values ...*ExportControlRe
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ExportControlReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ExportControlReviewRequestListBuilder) Copy(list *ExportControlReviewRequestList) *ExportControlReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/export_control_review_response_builder.go
+++ b/authorizations/v1/export_control_review_response_builder.go
@@ -32,6 +32,11 @@ func NewExportControlReviewResponse() *ExportControlReviewResponseBuilder {
 	return &ExportControlReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExportControlReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Restricted sets the value of the 'restricted' attribute to the given value.
 //
 //

--- a/authorizations/v1/export_control_review_response_list_builder.go
+++ b/authorizations/v1/export_control_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *ExportControlReviewResponseListBuilder) Items(values ...*ExportControlR
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ExportControlReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ExportControlReviewResponseListBuilder) Copy(list *ExportControlReviewResponseList) *ExportControlReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/feature_review_request_builder.go
+++ b/authorizations/v1/feature_review_request_builder.go
@@ -33,6 +33,11 @@ func NewFeatureReviewRequest() *FeatureReviewRequestBuilder {
 	return &FeatureReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *FeatureReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/feature_review_request_list_builder.go
+++ b/authorizations/v1/feature_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *FeatureReviewRequestListBuilder) Items(values ...*FeatureReviewRequestB
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *FeatureReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *FeatureReviewRequestListBuilder) Copy(list *FeatureReviewRequestList) *FeatureReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/feature_review_response_builder.go
+++ b/authorizations/v1/feature_review_response_builder.go
@@ -33,6 +33,11 @@ func NewFeatureReviewResponse() *FeatureReviewResponseBuilder {
 	return &FeatureReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *FeatureReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Enabled sets the value of the 'enabled' attribute to the given value.
 //
 //

--- a/authorizations/v1/feature_review_response_list_builder.go
+++ b/authorizations/v1/feature_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *FeatureReviewResponseListBuilder) Items(values ...*FeatureReviewRespons
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *FeatureReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *FeatureReviewResponseListBuilder) Copy(list *FeatureReviewResponseList) *FeatureReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/resource_review_builder.go
+++ b/authorizations/v1/resource_review_builder.go
@@ -38,6 +38,11 @@ func NewResourceReview() *ResourceReviewBuilder {
 	return &ResourceReviewBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ResourceReviewBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/resource_review_list_builder.go
+++ b/authorizations/v1/resource_review_list_builder.go
@@ -37,6 +37,11 @@ func (b *ResourceReviewListBuilder) Items(values ...*ResourceReviewBuilder) *Res
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ResourceReviewListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ResourceReviewListBuilder) Copy(list *ResourceReviewList) *ResourceReviewListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/resource_review_request_builder.go
+++ b/authorizations/v1/resource_review_request_builder.go
@@ -35,6 +35,11 @@ func NewResourceReviewRequest() *ResourceReviewRequestBuilder {
 	return &ResourceReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ResourceReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/resource_review_request_list_builder.go
+++ b/authorizations/v1/resource_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *ResourceReviewRequestListBuilder) Items(values ...*ResourceReviewReques
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ResourceReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ResourceReviewRequestListBuilder) Copy(list *ResourceReviewRequestList) *ResourceReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/self_access_review_request_builder.go
+++ b/authorizations/v1/self_access_review_request_builder.go
@@ -37,6 +37,11 @@ func NewSelfAccessReviewRequest() *SelfAccessReviewRequestBuilder {
 	return &SelfAccessReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SelfAccessReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Action sets the value of the 'action' attribute to the given value.
 //
 //

--- a/authorizations/v1/self_access_review_request_list_builder.go
+++ b/authorizations/v1/self_access_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *SelfAccessReviewRequestListBuilder) Items(values ...*SelfAccessReviewRe
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SelfAccessReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SelfAccessReviewRequestListBuilder) Copy(list *SelfAccessReviewRequestList) *SelfAccessReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/self_access_review_response_builder.go
+++ b/authorizations/v1/self_access_review_response_builder.go
@@ -38,6 +38,11 @@ func NewSelfAccessReviewResponse() *SelfAccessReviewResponseBuilder {
 	return &SelfAccessReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SelfAccessReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Action sets the value of the 'action' attribute to the given value.
 //
 //

--- a/authorizations/v1/self_access_review_response_list_builder.go
+++ b/authorizations/v1/self_access_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *SelfAccessReviewResponseListBuilder) Items(values ...*SelfAccessReviewR
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SelfAccessReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SelfAccessReviewResponseListBuilder) Copy(list *SelfAccessReviewResponseList) *SelfAccessReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/self_capability_review_request_builder.go
+++ b/authorizations/v1/self_capability_review_request_builder.go
@@ -38,6 +38,11 @@ func NewSelfCapabilityReviewRequest() *SelfCapabilityReviewRequestBuilder {
 	return &SelfCapabilityReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SelfCapabilityReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/self_capability_review_request_list_builder.go
+++ b/authorizations/v1/self_capability_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *SelfCapabilityReviewRequestListBuilder) Items(values ...*SelfCapability
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SelfCapabilityReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SelfCapabilityReviewRequestListBuilder) Copy(list *SelfCapabilityReviewRequestList) *SelfCapabilityReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/self_capability_review_response_builder.go
+++ b/authorizations/v1/self_capability_review_response_builder.go
@@ -32,6 +32,11 @@ func NewSelfCapabilityReviewResponse() *SelfCapabilityReviewResponseBuilder {
 	return &SelfCapabilityReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SelfCapabilityReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Result sets the value of the 'result' attribute to the given value.
 //
 //

--- a/authorizations/v1/self_capability_review_response_list_builder.go
+++ b/authorizations/v1/self_capability_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *SelfCapabilityReviewResponseListBuilder) Items(values ...*SelfCapabilit
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SelfCapabilityReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SelfCapabilityReviewResponseListBuilder) Copy(list *SelfCapabilityReviewResponseList) *SelfCapabilityReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/self_feature_review_request_builder.go
+++ b/authorizations/v1/self_feature_review_request_builder.go
@@ -32,6 +32,11 @@ func NewSelfFeatureReviewRequest() *SelfFeatureReviewRequestBuilder {
 	return &SelfFeatureReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SelfFeatureReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Feature sets the value of the 'feature' attribute to the given value.
 //
 //

--- a/authorizations/v1/self_feature_review_request_list_builder.go
+++ b/authorizations/v1/self_feature_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *SelfFeatureReviewRequestListBuilder) Items(values ...*SelfFeatureReview
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SelfFeatureReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SelfFeatureReviewRequestListBuilder) Copy(list *SelfFeatureReviewRequestList) *SelfFeatureReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/self_feature_review_response_builder.go
+++ b/authorizations/v1/self_feature_review_response_builder.go
@@ -33,6 +33,11 @@ func NewSelfFeatureReviewResponse() *SelfFeatureReviewResponseBuilder {
 	return &SelfFeatureReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SelfFeatureReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Enabled sets the value of the 'enabled' attribute to the given value.
 //
 //

--- a/authorizations/v1/self_feature_review_response_list_builder.go
+++ b/authorizations/v1/self_feature_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *SelfFeatureReviewResponseListBuilder) Items(values ...*SelfFeatureRevie
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SelfFeatureReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SelfFeatureReviewResponseListBuilder) Copy(list *SelfFeatureReviewResponseList) *SelfFeatureReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/self_terms_review_request_builder.go
+++ b/authorizations/v1/self_terms_review_request_builder.go
@@ -34,6 +34,11 @@ func NewSelfTermsReviewRequest() *SelfTermsReviewRequestBuilder {
 	return &SelfTermsReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SelfTermsReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // EventCode sets the value of the 'event_code' attribute to the given value.
 //
 //

--- a/authorizations/v1/self_terms_review_request_list_builder.go
+++ b/authorizations/v1/self_terms_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *SelfTermsReviewRequestListBuilder) Items(values ...*SelfTermsReviewRequ
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SelfTermsReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SelfTermsReviewRequestListBuilder) Copy(list *SelfTermsReviewRequestList) *SelfTermsReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/terms_review_request_builder.go
+++ b/authorizations/v1/terms_review_request_builder.go
@@ -36,6 +36,11 @@ func NewTermsReviewRequest() *TermsReviewRequestBuilder {
 	return &TermsReviewRequestBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TermsReviewRequestBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountUsername sets the value of the 'account_username' attribute to the given value.
 //
 //

--- a/authorizations/v1/terms_review_request_list_builder.go
+++ b/authorizations/v1/terms_review_request_list_builder.go
@@ -37,6 +37,11 @@ func (b *TermsReviewRequestListBuilder) Items(values ...*TermsReviewRequestBuild
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *TermsReviewRequestListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *TermsReviewRequestListBuilder) Copy(list *TermsReviewRequestList) *TermsReviewRequestListBuilder {
 	if list == nil || list.items == nil {

--- a/authorizations/v1/terms_review_response_builder.go
+++ b/authorizations/v1/terms_review_response_builder.go
@@ -37,6 +37,11 @@ func NewTermsReviewResponse() *TermsReviewResponseBuilder {
 	return &TermsReviewResponseBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TermsReviewResponseBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AccountId sets the value of the 'account_id' attribute to the given value.
 //
 //

--- a/authorizations/v1/terms_review_response_list_builder.go
+++ b/authorizations/v1/terms_review_response_list_builder.go
@@ -37,6 +37,11 @@ func (b *TermsReviewResponseListBuilder) Items(values ...*TermsReviewResponseBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *TermsReviewResponseListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *TermsReviewResponseListBuilder) Copy(list *TermsReviewResponseList) *TermsReviewResponseListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_builder.go
+++ b/clustersmgmt/v1/add_on_builder.go
@@ -70,6 +70,11 @@ func (b *AddOnBuilder) HREF(value string) *AddOnBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Description sets the value of the 'description' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/add_on_installation_builder.go
+++ b/clustersmgmt/v1/add_on_installation_builder.go
@@ -66,6 +66,11 @@ func (b *AddOnInstallationBuilder) HREF(value string) *AddOnInstallationBuilder 
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnInstallationBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Addon sets the value of the 'addon' attribute to the given value.
 //
 // Representation of an add-on that can be installed in a cluster.

--- a/clustersmgmt/v1/add_on_installation_list_builder.go
+++ b/clustersmgmt/v1/add_on_installation_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnInstallationListBuilder) Items(values ...*AddOnInstallationBuilder
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnInstallationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnInstallationListBuilder) Copy(list *AddOnInstallationList) *AddOnInstallationListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_installation_parameter_builder.go
+++ b/clustersmgmt/v1/add_on_installation_parameter_builder.go
@@ -54,6 +54,11 @@ func (b *AddOnInstallationParameterBuilder) HREF(value string) *AddOnInstallatio
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnInstallationParameterBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Value sets the value of the 'value' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/add_on_installation_parameter_list_builder.go
+++ b/clustersmgmt/v1/add_on_installation_parameter_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnInstallationParameterListBuilder) Items(values ...*AddOnInstallati
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnInstallationParameterListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnInstallationParameterListBuilder) Copy(list *AddOnInstallationParameterList) *AddOnInstallationParameterListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_list_builder.go
+++ b/clustersmgmt/v1/add_on_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnListBuilder) Items(values ...*AddOnBuilder) *AddOnListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnListBuilder) Copy(list *AddOnList) *AddOnListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_parameter_builder.go
+++ b/clustersmgmt/v1/add_on_parameter_builder.go
@@ -63,6 +63,11 @@ func (b *AddOnParameterBuilder) HREF(value string) *AddOnParameterBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnParameterBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Addon sets the value of the 'addon' attribute to the given value.
 //
 // Representation of an add-on that can be installed in a cluster.

--- a/clustersmgmt/v1/add_on_parameter_list_builder.go
+++ b/clustersmgmt/v1/add_on_parameter_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnParameterListBuilder) Items(values ...*AddOnParameterBuilder) *Add
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnParameterListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnParameterListBuilder) Copy(list *AddOnParameterList) *AddOnParameterListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_parameter_option_builder.go
+++ b/clustersmgmt/v1/add_on_parameter_option_builder.go
@@ -33,6 +33,11 @@ func NewAddOnParameterOption() *AddOnParameterOptionBuilder {
 	return &AddOnParameterOptionBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnParameterOptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/add_on_parameter_option_list_builder.go
+++ b/clustersmgmt/v1/add_on_parameter_option_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnParameterOptionListBuilder) Items(values ...*AddOnParameterOptionB
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnParameterOptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnParameterOptionListBuilder) Copy(list *AddOnParameterOptionList) *AddOnParameterOptionListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_requirement_builder.go
+++ b/clustersmgmt/v1/add_on_requirement_builder.go
@@ -36,6 +36,11 @@ func NewAddOnRequirement() *AddOnRequirementBuilder {
 	return &AddOnRequirementBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnRequirementBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ID sets the value of the 'ID' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/add_on_requirement_list_builder.go
+++ b/clustersmgmt/v1/add_on_requirement_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnRequirementListBuilder) Items(values ...*AddOnRequirementBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnRequirementListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnRequirementListBuilder) Copy(list *AddOnRequirementList) *AddOnRequirementListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_requirement_status_builder.go
+++ b/clustersmgmt/v1/add_on_requirement_status_builder.go
@@ -33,6 +33,11 @@ func NewAddOnRequirementStatus() *AddOnRequirementStatusBuilder {
 	return &AddOnRequirementStatusBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnRequirementStatusBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ErrorMsgs sets the value of the 'error_msgs' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/add_on_requirement_status_list_builder.go
+++ b/clustersmgmt/v1/add_on_requirement_status_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnRequirementStatusListBuilder) Items(values ...*AddOnRequirementSta
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnRequirementStatusListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnRequirementStatusListBuilder) Copy(list *AddOnRequirementStatusList) *AddOnRequirementStatusListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_sub_operator_builder.go
+++ b/clustersmgmt/v1/add_on_sub_operator_builder.go
@@ -35,6 +35,11 @@ func NewAddOnSubOperator() *AddOnSubOperatorBuilder {
 	return &AddOnSubOperatorBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnSubOperatorBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Enabled sets the value of the 'enabled' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/add_on_sub_operator_list_builder.go
+++ b/clustersmgmt/v1/add_on_sub_operator_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnSubOperatorListBuilder) Items(values ...*AddOnSubOperatorBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnSubOperatorListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnSubOperatorListBuilder) Copy(list *AddOnSubOperatorList) *AddOnSubOperatorListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/add_on_version_builder.go
+++ b/clustersmgmt/v1/add_on_version_builder.go
@@ -60,6 +60,11 @@ func (b *AddOnVersionBuilder) HREF(value string) *AddOnVersionBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AddOnVersionBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // AvailableUpgrades sets the value of the 'available_upgrades' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/add_on_version_list_builder.go
+++ b/clustersmgmt/v1/add_on_version_list_builder.go
@@ -37,6 +37,11 @@ func (b *AddOnVersionListBuilder) Items(values ...*AddOnVersionBuilder) *AddOnVe
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AddOnVersionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AddOnVersionListBuilder) Copy(list *AddOnVersionList) *AddOnVersionListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/admin_credentials_builder.go
+++ b/clustersmgmt/v1/admin_credentials_builder.go
@@ -34,6 +34,11 @@ func NewAdminCredentials() *AdminCredentialsBuilder {
 	return &AdminCredentialsBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AdminCredentialsBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Password sets the value of the 'password' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/admin_credentials_list_builder.go
+++ b/clustersmgmt/v1/admin_credentials_list_builder.go
@@ -37,6 +37,11 @@ func (b *AdminCredentialsListBuilder) Items(values ...*AdminCredentialsBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AdminCredentialsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AdminCredentialsListBuilder) Copy(list *AdminCredentialsList) *AdminCredentialsListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/alert_info_builder.go
+++ b/clustersmgmt/v1/alert_info_builder.go
@@ -33,6 +33,11 @@ func NewAlertInfo() *AlertInfoBuilder {
 	return &AlertInfoBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AlertInfoBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/alert_info_list_builder.go
+++ b/clustersmgmt/v1/alert_info_list_builder.go
@@ -37,6 +37,11 @@ func (b *AlertInfoListBuilder) Items(values ...*AlertInfoBuilder) *AlertInfoList
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AlertInfoListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AlertInfoListBuilder) Copy(list *AlertInfoList) *AlertInfoListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/alerts_info_builder.go
+++ b/clustersmgmt/v1/alerts_info_builder.go
@@ -32,6 +32,11 @@ func NewAlertsInfo() *AlertsInfoBuilder {
 	return &AlertsInfoBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AlertsInfoBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Alerts sets the value of the 'alerts' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/alerts_info_list_builder.go
+++ b/clustersmgmt/v1/alerts_info_list_builder.go
@@ -37,6 +37,11 @@ func (b *AlertsInfoListBuilder) Items(values ...*AlertsInfoBuilder) *AlertsInfoL
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AlertsInfoListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AlertsInfoListBuilder) Copy(list *AlertsInfoList) *AlertsInfoListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/aws_builder.go
+++ b/clustersmgmt/v1/aws_builder.go
@@ -39,6 +39,11 @@ func NewAWS() *AWSBuilder {
 	return &AWSBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // KMSKeyArn sets the value of the 'KMS_key_arn' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/aws_flavour_builder.go
+++ b/clustersmgmt/v1/aws_flavour_builder.go
@@ -37,6 +37,11 @@ func NewAWSFlavour() *AWSFlavourBuilder {
 	return &AWSFlavourBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSFlavourBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ComputeInstanceType sets the value of the 'compute_instance_type' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/aws_flavour_list_builder.go
+++ b/clustersmgmt/v1/aws_flavour_list_builder.go
@@ -37,6 +37,11 @@ func (b *AWSFlavourListBuilder) Items(values ...*AWSFlavourBuilder) *AWSFlavourL
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AWSFlavourListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AWSFlavourListBuilder) Copy(list *AWSFlavourList) *AWSFlavourListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/aws_infrastructure_access_role_builder.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_builder.go
@@ -56,6 +56,11 @@ func (b *AWSInfrastructureAccessRoleBuilder) HREF(value string) *AWSInfrastructu
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSInfrastructureAccessRoleBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Description sets the value of the 'description' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grant_builder.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grant_builder.go
@@ -58,6 +58,11 @@ func (b *AWSInfrastructureAccessRoleGrantBuilder) HREF(value string) *AWSInfrast
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSInfrastructureAccessRoleGrantBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // ConsoleURL sets the value of the 'console_URL' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grant_list_builder.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grant_list_builder.go
@@ -37,6 +37,11 @@ func (b *AWSInfrastructureAccessRoleGrantListBuilder) Items(values ...*AWSInfras
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AWSInfrastructureAccessRoleGrantListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AWSInfrastructureAccessRoleGrantListBuilder) Copy(list *AWSInfrastructureAccessRoleGrantList) *AWSInfrastructureAccessRoleGrantListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/aws_infrastructure_access_role_list_builder.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_list_builder.go
@@ -37,6 +37,11 @@ func (b *AWSInfrastructureAccessRoleListBuilder) Items(values ...*AWSInfrastruct
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AWSInfrastructureAccessRoleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AWSInfrastructureAccessRoleListBuilder) Copy(list *AWSInfrastructureAccessRoleList) *AWSInfrastructureAccessRoleListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/aws_list_builder.go
+++ b/clustersmgmt/v1/aws_list_builder.go
@@ -37,6 +37,11 @@ func (b *AWSListBuilder) Items(values ...*AWSBuilder) *AWSListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AWSListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AWSListBuilder) Copy(list *AWSList) *AWSListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/aws_machine_pool_builder.go
+++ b/clustersmgmt/v1/aws_machine_pool_builder.go
@@ -54,6 +54,11 @@ func (b *AWSMachinePoolBuilder) HREF(value string) *AWSMachinePoolBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSMachinePoolBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // SpotMarketOptions sets the value of the 'spot_market_options' attribute to the given value.
 //
 // Spot market options for AWS machine pool.

--- a/clustersmgmt/v1/aws_machine_pool_list_builder.go
+++ b/clustersmgmt/v1/aws_machine_pool_list_builder.go
@@ -37,6 +37,11 @@ func (b *AWSMachinePoolListBuilder) Items(values ...*AWSMachinePoolBuilder) *AWS
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AWSMachinePoolListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AWSMachinePoolListBuilder) Copy(list *AWSMachinePoolList) *AWSMachinePoolListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/aws_spot_market_options_builder.go
+++ b/clustersmgmt/v1/aws_spot_market_options_builder.go
@@ -54,6 +54,11 @@ func (b *AWSSpotMarketOptionsBuilder) HREF(value string) *AWSSpotMarketOptionsBu
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSSpotMarketOptionsBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // MaxPrice sets the value of the 'max_price' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/aws_spot_market_options_list_builder.go
+++ b/clustersmgmt/v1/aws_spot_market_options_list_builder.go
@@ -37,6 +37,11 @@ func (b *AWSSpotMarketOptionsListBuilder) Items(values ...*AWSSpotMarketOptionsB
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AWSSpotMarketOptionsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AWSSpotMarketOptionsListBuilder) Copy(list *AWSSpotMarketOptionsList) *AWSSpotMarketOptionsListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/aws_volume_builder.go
+++ b/clustersmgmt/v1/aws_volume_builder.go
@@ -34,6 +34,11 @@ func NewAWSVolume() *AWSVolumeBuilder {
 	return &AWSVolumeBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSVolumeBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // IOPS sets the value of the 'IOPS' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/aws_volume_list_builder.go
+++ b/clustersmgmt/v1/aws_volume_list_builder.go
@@ -37,6 +37,11 @@ func (b *AWSVolumeListBuilder) Items(values ...*AWSVolumeBuilder) *AWSVolumeList
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *AWSVolumeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *AWSVolumeListBuilder) Copy(list *AWSVolumeList) *AWSVolumeListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/ccs_builder.go
+++ b/clustersmgmt/v1/ccs_builder.go
@@ -55,6 +55,11 @@ func (b *CCSBuilder) HREF(value string) *CCSBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CCSBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // DisableSCPChecks sets the value of the 'disable_SCP_checks' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/ccs_list_builder.go
+++ b/clustersmgmt/v1/ccs_list_builder.go
@@ -37,6 +37,11 @@ func (b *CCSListBuilder) Items(values ...*CCSBuilder) *CCSListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CCSListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CCSListBuilder) Copy(list *CCSList) *CCSListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cloud_provider_builder.go
+++ b/clustersmgmt/v1/cloud_provider_builder.go
@@ -55,6 +55,11 @@ func (b *CloudProviderBuilder) HREF(value string) *CloudProviderBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CloudProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // DisplayName sets the value of the 'display_name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cloud_provider_data_builder.go
+++ b/clustersmgmt/v1/cloud_provider_data_builder.go
@@ -36,6 +36,11 @@ func NewCloudProviderData() *CloudProviderDataBuilder {
 	return &CloudProviderDataBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CloudProviderDataBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AWS sets the value of the 'AWS' attribute to the given value.
 //
 // _Amazon Web Services_ specific settings of a cluster.

--- a/clustersmgmt/v1/cloud_provider_data_list_builder.go
+++ b/clustersmgmt/v1/cloud_provider_data_list_builder.go
@@ -37,6 +37,11 @@ func (b *CloudProviderDataListBuilder) Items(values ...*CloudProviderDataBuilder
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CloudProviderDataListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CloudProviderDataListBuilder) Copy(list *CloudProviderDataList) *CloudProviderDataListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cloud_provider_list_builder.go
+++ b/clustersmgmt/v1/cloud_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *CloudProviderListBuilder) Items(values ...*CloudProviderBuilder) *Cloud
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CloudProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CloudProviderListBuilder) Copy(list *CloudProviderList) *CloudProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cloud_region_builder.go
+++ b/clustersmgmt/v1/cloud_region_builder.go
@@ -59,6 +59,11 @@ func (b *CloudRegionBuilder) HREF(value string) *CloudRegionBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CloudRegionBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // CCSOnly sets the value of the 'CCS_only' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cloud_region_list_builder.go
+++ b/clustersmgmt/v1/cloud_region_list_builder.go
@@ -37,6 +37,11 @@ func (b *CloudRegionListBuilder) Items(values ...*CloudRegionBuilder) *CloudRegi
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CloudRegionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CloudRegionListBuilder) Copy(list *CloudRegionList) *CloudRegionListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cloud_vpc_builder.go
+++ b/clustersmgmt/v1/cloud_vpc_builder.go
@@ -33,6 +33,11 @@ func NewCloudVPC() *CloudVPCBuilder {
 	return &CloudVPCBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CloudVPCBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cloud_vpc_list_builder.go
+++ b/clustersmgmt/v1/cloud_vpc_list_builder.go
@@ -37,6 +37,11 @@ func (b *CloudVPCListBuilder) Items(values ...*CloudVPCBuilder) *CloudVPCListBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CloudVPCListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CloudVPCListBuilder) Copy(list *CloudVPCList) *CloudVPCListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_api_builder.go
+++ b/clustersmgmt/v1/cluster_api_builder.go
@@ -33,6 +33,11 @@ func NewClusterAPI() *ClusterAPIBuilder {
 	return &ClusterAPIBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterAPIBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // URL sets the value of the 'URL' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cluster_api_list_builder.go
+++ b/clustersmgmt/v1/cluster_api_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterAPIListBuilder) Items(values ...*ClusterAPIBuilder) *ClusterAPIL
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterAPIListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterAPIListBuilder) Copy(list *ClusterAPIList) *ClusterAPIListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_builder.go
+++ b/clustersmgmt/v1/cluster_builder.go
@@ -136,6 +136,11 @@ func (b *ClusterBuilder) HREF(value string) *ClusterBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // API sets the value of the 'API' attribute to the given value.
 //
 // Information about the API of a cluster.

--- a/clustersmgmt/v1/cluster_console_builder.go
+++ b/clustersmgmt/v1/cluster_console_builder.go
@@ -32,6 +32,11 @@ func NewClusterConsole() *ClusterConsoleBuilder {
 	return &ClusterConsoleBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterConsoleBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // URL sets the value of the 'URL' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cluster_console_list_builder.go
+++ b/clustersmgmt/v1/cluster_console_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterConsoleListBuilder) Items(values ...*ClusterConsoleBuilder) *Clu
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterConsoleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterConsoleListBuilder) Copy(list *ClusterConsoleList) *ClusterConsoleListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_credentials_builder.go
+++ b/clustersmgmt/v1/cluster_credentials_builder.go
@@ -56,6 +56,11 @@ func (b *ClusterCredentialsBuilder) HREF(value string) *ClusterCredentialsBuilde
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterCredentialsBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // SSH sets the value of the 'SSH' attribute to the given value.
 //
 // SSH key pair of a cluster.

--- a/clustersmgmt/v1/cluster_credentials_list_builder.go
+++ b/clustersmgmt/v1/cluster_credentials_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterCredentialsListBuilder) Items(values ...*ClusterCredentialsBuild
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterCredentialsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterCredentialsListBuilder) Copy(list *ClusterCredentialsList) *ClusterCredentialsListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_deployment_builder.go
+++ b/clustersmgmt/v1/cluster_deployment_builder.go
@@ -54,6 +54,11 @@ func (b *ClusterDeploymentBuilder) HREF(value string) *ClusterDeploymentBuilder 
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterDeploymentBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Content sets the value of the 'content' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cluster_deployment_list_builder.go
+++ b/clustersmgmt/v1/cluster_deployment_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterDeploymentListBuilder) Items(values ...*ClusterDeploymentBuilder
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterDeploymentListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterDeploymentListBuilder) Copy(list *ClusterDeploymentList) *ClusterDeploymentListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_list_builder.go
+++ b/clustersmgmt/v1/cluster_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterListBuilder) Items(values ...*ClusterBuilder) *ClusterListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterListBuilder) Copy(list *ClusterList) *ClusterListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_nodes_builder.go
+++ b/clustersmgmt/v1/cluster_nodes_builder.go
@@ -39,6 +39,11 @@ func NewClusterNodes() *ClusterNodesBuilder {
 	return &ClusterNodesBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterNodesBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AutoscaleCompute sets the value of the 'autoscale_compute' attribute to the given value.
 //
 // Representation of a autoscaling in a machine pool.

--- a/clustersmgmt/v1/cluster_nodes_list_builder.go
+++ b/clustersmgmt/v1/cluster_nodes_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterNodesListBuilder) Items(values ...*ClusterNodesBuilder) *Cluster
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterNodesListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterNodesListBuilder) Copy(list *ClusterNodesList) *ClusterNodesListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_operator_info_builder.go
+++ b/clustersmgmt/v1/cluster_operator_info_builder.go
@@ -40,6 +40,11 @@ func NewClusterOperatorInfo() *ClusterOperatorInfoBuilder {
 	return &ClusterOperatorInfoBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterOperatorInfoBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Condition sets the value of the 'condition' attribute to the given value.
 //
 // Overall state of a cluster operator.

--- a/clustersmgmt/v1/cluster_operator_info_list_builder.go
+++ b/clustersmgmt/v1/cluster_operator_info_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterOperatorInfoListBuilder) Items(values ...*ClusterOperatorInfoBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterOperatorInfoListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterOperatorInfoListBuilder) Copy(list *ClusterOperatorInfoList) *ClusterOperatorInfoListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_operators_info_builder.go
+++ b/clustersmgmt/v1/cluster_operators_info_builder.go
@@ -32,6 +32,11 @@ func NewClusterOperatorsInfo() *ClusterOperatorsInfoBuilder {
 	return &ClusterOperatorsInfoBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterOperatorsInfoBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Operators sets the value of the 'operators' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/cluster_operators_info_list_builder.go
+++ b/clustersmgmt/v1/cluster_operators_info_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterOperatorsInfoListBuilder) Items(values ...*ClusterOperatorsInfoB
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterOperatorsInfoListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterOperatorsInfoListBuilder) Copy(list *ClusterOperatorsInfoList) *ClusterOperatorsInfoListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_registration_builder.go
+++ b/clustersmgmt/v1/cluster_registration_builder.go
@@ -34,6 +34,11 @@ func NewClusterRegistration() *ClusterRegistrationBuilder {
 	return &ClusterRegistrationBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterRegistrationBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ExternalID sets the value of the 'external_ID' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cluster_registration_list_builder.go
+++ b/clustersmgmt/v1/cluster_registration_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterRegistrationListBuilder) Items(values ...*ClusterRegistrationBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterRegistrationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterRegistrationListBuilder) Copy(list *ClusterRegistrationList) *ClusterRegistrationListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_resources_builder.go
+++ b/clustersmgmt/v1/cluster_resources_builder.go
@@ -60,6 +60,11 @@ func (b *ClusterResourcesBuilder) HREF(value string) *ClusterResourcesBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterResourcesBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // ClusterID sets the value of the 'cluster_ID' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cluster_resources_list_builder.go
+++ b/clustersmgmt/v1/cluster_resources_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterResourcesListBuilder) Items(values ...*ClusterResourcesBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterResourcesListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterResourcesListBuilder) Copy(list *ClusterResourcesList) *ClusterResourcesListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cluster_status_builder.go
+++ b/clustersmgmt/v1/cluster_status_builder.go
@@ -60,6 +60,11 @@ func (b *ClusterStatusBuilder) HREF(value string) *ClusterStatusBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterStatusBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // DNSReady sets the value of the 'DNS_ready' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cluster_status_list_builder.go
+++ b/clustersmgmt/v1/cluster_status_list_builder.go
@@ -37,6 +37,11 @@ func (b *ClusterStatusListBuilder) Items(values ...*ClusterStatusBuilder) *Clust
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ClusterStatusListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ClusterStatusListBuilder) Copy(list *ClusterStatusList) *ClusterStatusListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cpu_total_node_role_os_metric_node_builder.go
+++ b/clustersmgmt/v1/cpu_total_node_role_os_metric_node_builder.go
@@ -39,6 +39,11 @@ func NewCPUTotalNodeRoleOSMetricNode() *CPUTotalNodeRoleOSMetricNodeBuilder {
 	return &CPUTotalNodeRoleOSMetricNodeBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CPUTotalNodeRoleOSMetricNodeBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // CPUTotal sets the value of the 'CPU_total' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/cpu_total_node_role_os_metric_node_list_builder.go
+++ b/clustersmgmt/v1/cpu_total_node_role_os_metric_node_list_builder.go
@@ -37,6 +37,11 @@ func (b *CPUTotalNodeRoleOSMetricNodeListBuilder) Items(values ...*CPUTotalNodeR
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CPUTotalNodeRoleOSMetricNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CPUTotalNodeRoleOSMetricNodeListBuilder) Copy(list *CPUTotalNodeRoleOSMetricNodeList) *CPUTotalNodeRoleOSMetricNodeListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/cpu_totals_node_role_os_metric_node_builder.go
+++ b/clustersmgmt/v1/cpu_totals_node_role_os_metric_node_builder.go
@@ -33,6 +33,11 @@ func NewCPUTotalsNodeRoleOSMetricNode() *CPUTotalsNodeRoleOSMetricNodeBuilder {
 	return &CPUTotalsNodeRoleOSMetricNodeBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *CPUTotalsNodeRoleOSMetricNodeBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // CPUTotals sets the value of the 'CPU_totals' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/cpu_totals_node_role_os_metric_node_list_builder.go
+++ b/clustersmgmt/v1/cpu_totals_node_role_os_metric_node_list_builder.go
@@ -37,6 +37,11 @@ func (b *CPUTotalsNodeRoleOSMetricNodeListBuilder) Items(values ...*CPUTotalsNod
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *CPUTotalsNodeRoleOSMetricNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *CPUTotalsNodeRoleOSMetricNodeListBuilder) Copy(list *CPUTotalsNodeRoleOSMetricNodeList) *CPUTotalsNodeRoleOSMetricNodeListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/dns_builder.go
+++ b/clustersmgmt/v1/dns_builder.go
@@ -32,6 +32,11 @@ func NewDNS() *DNSBuilder {
 	return &DNSBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *DNSBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // BaseDomain sets the value of the 'base_domain' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/dns_list_builder.go
+++ b/clustersmgmt/v1/dns_list_builder.go
@@ -37,6 +37,11 @@ func (b *DNSListBuilder) Items(values ...*DNSBuilder) *DNSListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *DNSListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *DNSListBuilder) Copy(list *DNSList) *DNSListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/encryption_key_builder.go
+++ b/clustersmgmt/v1/encryption_key_builder.go
@@ -54,6 +54,11 @@ func (b *EncryptionKeyBuilder) HREF(value string) *EncryptionKeyBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *EncryptionKeyBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/encryption_key_list_builder.go
+++ b/clustersmgmt/v1/encryption_key_list_builder.go
@@ -37,6 +37,11 @@ func (b *EncryptionKeyListBuilder) Items(values ...*EncryptionKeyBuilder) *Encry
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *EncryptionKeyListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *EncryptionKeyListBuilder) Copy(list *EncryptionKeyList) *EncryptionKeyListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/event_builder.go
+++ b/clustersmgmt/v1/event_builder.go
@@ -33,6 +33,11 @@ func NewEvent() *EventBuilder {
 	return &EventBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *EventBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Body sets the value of the 'body' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/event_list_builder.go
+++ b/clustersmgmt/v1/event_list_builder.go
@@ -37,6 +37,11 @@ func (b *EventListBuilder) Items(values ...*EventBuilder) *EventListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *EventListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *EventListBuilder) Copy(list *EventList) *EventListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/external_configuration_builder.go
+++ b/clustersmgmt/v1/external_configuration_builder.go
@@ -33,6 +33,11 @@ func NewExternalConfiguration() *ExternalConfigurationBuilder {
 	return &ExternalConfigurationBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalConfigurationBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Labels sets the value of the 'labels' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/external_configuration_list_builder.go
+++ b/clustersmgmt/v1/external_configuration_list_builder.go
@@ -37,6 +37,11 @@ func (b *ExternalConfigurationListBuilder) Items(values ...*ExternalConfiguratio
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ExternalConfigurationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ExternalConfigurationListBuilder) Copy(list *ExternalConfigurationList) *ExternalConfigurationListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/flavour_builder.go
+++ b/clustersmgmt/v1/flavour_builder.go
@@ -59,6 +59,11 @@ func (b *FlavourBuilder) HREF(value string) *FlavourBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *FlavourBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // AWS sets the value of the 'AWS' attribute to the given value.
 //
 // Specification for different classes of nodes inside a flavour.

--- a/clustersmgmt/v1/flavour_list_builder.go
+++ b/clustersmgmt/v1/flavour_list_builder.go
@@ -37,6 +37,11 @@ func (b *FlavourListBuilder) Items(values ...*FlavourBuilder) *FlavourListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *FlavourListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *FlavourListBuilder) Copy(list *FlavourList) *FlavourListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/flavour_nodes_builder.go
+++ b/clustersmgmt/v1/flavour_nodes_builder.go
@@ -32,6 +32,11 @@ func NewFlavourNodes() *FlavourNodesBuilder {
 	return &FlavourNodesBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *FlavourNodesBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Master sets the value of the 'master' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/flavour_nodes_list_builder.go
+++ b/clustersmgmt/v1/flavour_nodes_list_builder.go
@@ -37,6 +37,11 @@ func (b *FlavourNodesListBuilder) Items(values ...*FlavourNodesBuilder) *Flavour
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *FlavourNodesListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *FlavourNodesListBuilder) Copy(list *FlavourNodesList) *FlavourNodesListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/gcp_builder.go
+++ b/clustersmgmt/v1/gcp_builder.go
@@ -41,6 +41,11 @@ func NewGCP() *GCPBuilder {
 	return &GCPBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GCPBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // AuthURI sets the value of the 'auth_URI' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/gcp_flavour_builder.go
+++ b/clustersmgmt/v1/gcp_flavour_builder.go
@@ -34,6 +34,11 @@ func NewGCPFlavour() *GCPFlavourBuilder {
 	return &GCPFlavourBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GCPFlavourBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ComputeInstanceType sets the value of the 'compute_instance_type' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/gcp_flavour_list_builder.go
+++ b/clustersmgmt/v1/gcp_flavour_list_builder.go
@@ -37,6 +37,11 @@ func (b *GCPFlavourListBuilder) Items(values ...*GCPFlavourBuilder) *GCPFlavourL
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *GCPFlavourListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *GCPFlavourListBuilder) Copy(list *GCPFlavourList) *GCPFlavourListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/gcp_list_builder.go
+++ b/clustersmgmt/v1/gcp_list_builder.go
@@ -37,6 +37,11 @@ func (b *GCPListBuilder) Items(values ...*GCPBuilder) *GCPListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *GCPListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *GCPListBuilder) Copy(list *GCPList) *GCPListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/gcp_network_builder.go
+++ b/clustersmgmt/v1/gcp_network_builder.go
@@ -34,6 +34,11 @@ func NewGCPNetwork() *GCPNetworkBuilder {
 	return &GCPNetworkBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GCPNetworkBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // VPCName sets the value of the 'VPC_name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/gcp_network_list_builder.go
+++ b/clustersmgmt/v1/gcp_network_list_builder.go
@@ -37,6 +37,11 @@ func (b *GCPNetworkListBuilder) Items(values ...*GCPNetworkBuilder) *GCPNetworkL
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *GCPNetworkListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *GCPNetworkListBuilder) Copy(list *GCPNetworkList) *GCPNetworkListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/github_identity_provider_builder.go
+++ b/clustersmgmt/v1/github_identity_provider_builder.go
@@ -37,6 +37,11 @@ func NewGithubIdentityProvider() *GithubIdentityProviderBuilder {
 	return &GithubIdentityProviderBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GithubIdentityProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // CA sets the value of the 'CA' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/github_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/github_identity_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *GithubIdentityProviderListBuilder) Items(values ...*GithubIdentityProvi
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *GithubIdentityProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *GithubIdentityProviderListBuilder) Copy(list *GithubIdentityProviderList) *GithubIdentityProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/gitlab_identity_provider_builder.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_builder.go
@@ -35,6 +35,11 @@ func NewGitlabIdentityProvider() *GitlabIdentityProviderBuilder {
 	return &GitlabIdentityProviderBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GitlabIdentityProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // CA sets the value of the 'CA' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/gitlab_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *GitlabIdentityProviderListBuilder) Items(values ...*GitlabIdentityProvi
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *GitlabIdentityProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *GitlabIdentityProviderListBuilder) Copy(list *GitlabIdentityProviderList) *GitlabIdentityProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/google_identity_provider_builder.go
+++ b/clustersmgmt/v1/google_identity_provider_builder.go
@@ -34,6 +34,11 @@ func NewGoogleIdentityProvider() *GoogleIdentityProviderBuilder {
 	return &GoogleIdentityProviderBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GoogleIdentityProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ClientID sets the value of the 'client_ID' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/google_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/google_identity_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *GoogleIdentityProviderListBuilder) Items(values ...*GoogleIdentityProvi
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *GoogleIdentityProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *GoogleIdentityProviderListBuilder) Copy(list *GoogleIdentityProviderList) *GoogleIdentityProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/group_builder.go
+++ b/clustersmgmt/v1/group_builder.go
@@ -54,6 +54,11 @@ func (b *GroupBuilder) HREF(value string) *GroupBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GroupBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Users sets the value of the 'users' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/group_list_builder.go
+++ b/clustersmgmt/v1/group_list_builder.go
@@ -37,6 +37,11 @@ func (b *GroupListBuilder) Items(values ...*GroupBuilder) *GroupListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *GroupListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *GroupListBuilder) Copy(list *GroupList) *GroupListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/ht_passwd_identity_provider_builder.go
+++ b/clustersmgmt/v1/ht_passwd_identity_provider_builder.go
@@ -33,6 +33,11 @@ func NewHTPasswdIdentityProvider() *HTPasswdIdentityProviderBuilder {
 	return &HTPasswdIdentityProviderBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *HTPasswdIdentityProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Password sets the value of the 'password' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/ht_passwd_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/ht_passwd_identity_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *HTPasswdIdentityProviderListBuilder) Items(values ...*HTPasswdIdentityP
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *HTPasswdIdentityProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *HTPasswdIdentityProviderListBuilder) Copy(list *HTPasswdIdentityProviderList) *HTPasswdIdentityProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/identity_provider_builder.go
+++ b/clustersmgmt/v1/identity_provider_builder.go
@@ -64,6 +64,11 @@ func (b *IdentityProviderBuilder) HREF(value string) *IdentityProviderBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *IdentityProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // LDAP sets the value of the 'LDAP' attribute to the given value.
 //
 // Details for `ldap` identity providers.

--- a/clustersmgmt/v1/identity_provider_list_builder.go
+++ b/clustersmgmt/v1/identity_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *IdentityProviderListBuilder) Items(values ...*IdentityProviderBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *IdentityProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *IdentityProviderListBuilder) Copy(list *IdentityProviderList) *IdentityProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/ingress_builder.go
+++ b/clustersmgmt/v1/ingress_builder.go
@@ -58,6 +58,11 @@ func (b *IngressBuilder) HREF(value string) *IngressBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *IngressBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // DNSName sets the value of the 'DNS_name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/ingress_list_builder.go
+++ b/clustersmgmt/v1/ingress_list_builder.go
@@ -37,6 +37,11 @@ func (b *IngressListBuilder) Items(values ...*IngressBuilder) *IngressListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *IngressListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *IngressListBuilder) Copy(list *IngressList) *IngressListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/instance_iam_roles_builder.go
+++ b/clustersmgmt/v1/instance_iam_roles_builder.go
@@ -33,6 +33,11 @@ func NewInstanceIAMRoles() *InstanceIAMRolesBuilder {
 	return &InstanceIAMRolesBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *InstanceIAMRolesBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // MasterRoleARN sets the value of the 'master_role_ARN' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/instance_iam_roles_list_builder.go
+++ b/clustersmgmt/v1/instance_iam_roles_list_builder.go
@@ -37,6 +37,11 @@ func (b *InstanceIAMRolesListBuilder) Items(values ...*InstanceIAMRolesBuilder) 
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *InstanceIAMRolesListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *InstanceIAMRolesListBuilder) Copy(list *InstanceIAMRolesList) *InstanceIAMRolesListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/key_ring_builder.go
+++ b/clustersmgmt/v1/key_ring_builder.go
@@ -54,6 +54,11 @@ func (b *KeyRingBuilder) HREF(value string) *KeyRingBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *KeyRingBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/key_ring_list_builder.go
+++ b/clustersmgmt/v1/key_ring_list_builder.go
@@ -37,6 +37,11 @@ func (b *KeyRingListBuilder) Items(values ...*KeyRingBuilder) *KeyRingListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *KeyRingListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *KeyRingListBuilder) Copy(list *KeyRingList) *KeyRingListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/label_builder.go
+++ b/clustersmgmt/v1/label_builder.go
@@ -55,6 +55,11 @@ func (b *LabelBuilder) HREF(value string) *LabelBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LabelBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Key sets the value of the 'key' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/label_list_builder.go
+++ b/clustersmgmt/v1/label_list_builder.go
@@ -37,6 +37,11 @@ func (b *LabelListBuilder) Items(values ...*LabelBuilder) *LabelListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LabelListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LabelListBuilder) Copy(list *LabelList) *LabelListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/ldap_attributes_builder.go
+++ b/clustersmgmt/v1/ldap_attributes_builder.go
@@ -35,6 +35,11 @@ func NewLDAPAttributes() *LDAPAttributesBuilder {
 	return &LDAPAttributesBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LDAPAttributesBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // ID sets the value of the 'ID' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/ldap_attributes_list_builder.go
+++ b/clustersmgmt/v1/ldap_attributes_list_builder.go
@@ -37,6 +37,11 @@ func (b *LDAPAttributesListBuilder) Items(values ...*LDAPAttributesBuilder) *LDA
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LDAPAttributesListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LDAPAttributesListBuilder) Copy(list *LDAPAttributesList) *LDAPAttributesListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/ldap_identity_provider_builder.go
+++ b/clustersmgmt/v1/ldap_identity_provider_builder.go
@@ -37,6 +37,11 @@ func NewLDAPIdentityProvider() *LDAPIdentityProviderBuilder {
 	return &LDAPIdentityProviderBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LDAPIdentityProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // CA sets the value of the 'CA' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/ldap_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/ldap_identity_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *LDAPIdentityProviderListBuilder) Items(values ...*LDAPIdentityProviderB
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LDAPIdentityProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LDAPIdentityProviderListBuilder) Copy(list *LDAPIdentityProviderList) *LDAPIdentityProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/limited_support_reason_builder.go
+++ b/clustersmgmt/v1/limited_support_reason_builder.go
@@ -62,6 +62,11 @@ func (b *LimitedSupportReasonBuilder) HREF(value string) *LimitedSupportReasonBu
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LimitedSupportReasonBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // CreationTimestamp sets the value of the 'creation_timestamp' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/limited_support_reason_list_builder.go
+++ b/clustersmgmt/v1/limited_support_reason_list_builder.go
@@ -37,6 +37,11 @@ func (b *LimitedSupportReasonListBuilder) Items(values ...*LimitedSupportReasonB
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LimitedSupportReasonListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LimitedSupportReasonListBuilder) Copy(list *LimitedSupportReasonList) *LimitedSupportReasonListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/limited_support_reason_template_builder.go
+++ b/clustersmgmt/v1/limited_support_reason_template_builder.go
@@ -55,6 +55,11 @@ func (b *LimitedSupportReasonTemplateBuilder) HREF(value string) *LimitedSupport
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LimitedSupportReasonTemplateBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Details sets the value of the 'details' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/limited_support_reason_template_list_builder.go
+++ b/clustersmgmt/v1/limited_support_reason_template_list_builder.go
@@ -37,6 +37,11 @@ func (b *LimitedSupportReasonTemplateListBuilder) Items(values ...*LimitedSuppor
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LimitedSupportReasonTemplateListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LimitedSupportReasonTemplateListBuilder) Copy(list *LimitedSupportReasonTemplateList) *LimitedSupportReasonTemplateListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/log_builder.go
+++ b/clustersmgmt/v1/log_builder.go
@@ -54,6 +54,11 @@ func (b *LogBuilder) HREF(value string) *LogBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LogBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Content sets the value of the 'content' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/log_list_builder.go
+++ b/clustersmgmt/v1/log_list_builder.go
@@ -37,6 +37,11 @@ func (b *LogListBuilder) Items(values ...*LogBuilder) *LogListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LogListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LogListBuilder) Copy(list *LogList) *LogListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/machine_pool_autoscaling_builder.go
+++ b/clustersmgmt/v1/machine_pool_autoscaling_builder.go
@@ -55,6 +55,11 @@ func (b *MachinePoolAutoscalingBuilder) HREF(value string) *MachinePoolAutoscali
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *MachinePoolAutoscalingBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // MaxReplicas sets the value of the 'max_replicas' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/machine_pool_autoscaling_list_builder.go
+++ b/clustersmgmt/v1/machine_pool_autoscaling_list_builder.go
@@ -37,6 +37,11 @@ func (b *MachinePoolAutoscalingListBuilder) Items(values ...*MachinePoolAutoscal
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *MachinePoolAutoscalingListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *MachinePoolAutoscalingListBuilder) Copy(list *MachinePoolAutoscalingList) *MachinePoolAutoscalingListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/machine_pool_builder.go
+++ b/clustersmgmt/v1/machine_pool_builder.go
@@ -61,6 +61,11 @@ func (b *MachinePoolBuilder) HREF(value string) *MachinePoolBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *MachinePoolBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // AWS sets the value of the 'AWS' attribute to the given value.
 //
 // Representation of aws machine pool specific parameters.

--- a/clustersmgmt/v1/machine_pool_list_builder.go
+++ b/clustersmgmt/v1/machine_pool_list_builder.go
@@ -37,6 +37,11 @@ func (b *MachinePoolListBuilder) Items(values ...*MachinePoolBuilder) *MachinePo
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *MachinePoolListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *MachinePoolListBuilder) Copy(list *MachinePoolList) *MachinePoolListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/machine_type_builder.go
+++ b/clustersmgmt/v1/machine_type_builder.go
@@ -61,6 +61,11 @@ func (b *MachineTypeBuilder) HREF(value string) *MachineTypeBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *MachineTypeBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // CCSOnly sets the value of the 'CCS_only' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/machine_type_list_builder.go
+++ b/clustersmgmt/v1/machine_type_list_builder.go
@@ -37,6 +37,11 @@ func (b *MachineTypeListBuilder) Items(values ...*MachineTypeBuilder) *MachineTy
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *MachineTypeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *MachineTypeListBuilder) Copy(list *MachineTypeList) *MachineTypeListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/network_builder.go
+++ b/clustersmgmt/v1/network_builder.go
@@ -35,6 +35,11 @@ func NewNetwork() *NetworkBuilder {
 	return &NetworkBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *NetworkBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // HostPrefix sets the value of the 'host_prefix' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/network_list_builder.go
+++ b/clustersmgmt/v1/network_list_builder.go
@@ -37,6 +37,11 @@ func (b *NetworkListBuilder) Items(values ...*NetworkBuilder) *NetworkListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *NetworkListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *NetworkListBuilder) Copy(list *NetworkList) *NetworkListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/node_info_builder.go
+++ b/clustersmgmt/v1/node_info_builder.go
@@ -33,6 +33,11 @@ func NewNodeInfo() *NodeInfoBuilder {
 	return &NodeInfoBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *NodeInfoBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Amount sets the value of the 'amount' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/node_info_list_builder.go
+++ b/clustersmgmt/v1/node_info_list_builder.go
@@ -37,6 +37,11 @@ func (b *NodeInfoListBuilder) Items(values ...*NodeInfoBuilder) *NodeInfoListBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *NodeInfoListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *NodeInfoListBuilder) Copy(list *NodeInfoList) *NodeInfoListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/nodes_info_builder.go
+++ b/clustersmgmt/v1/nodes_info_builder.go
@@ -32,6 +32,11 @@ func NewNodesInfo() *NodesInfoBuilder {
 	return &NodesInfoBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *NodesInfoBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Nodes sets the value of the 'nodes' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/nodes_info_list_builder.go
+++ b/clustersmgmt/v1/nodes_info_list_builder.go
@@ -37,6 +37,11 @@ func (b *NodesInfoListBuilder) Items(values ...*NodesInfoBuilder) *NodesInfoList
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *NodesInfoListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *NodesInfoListBuilder) Copy(list *NodesInfoList) *NodesInfoListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/open_id_claims_builder.go
+++ b/clustersmgmt/v1/open_id_claims_builder.go
@@ -34,6 +34,11 @@ func NewOpenIDClaims() *OpenIDClaimsBuilder {
 	return &OpenIDClaimsBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *OpenIDClaimsBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Email sets the value of the 'email' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/open_id_claims_list_builder.go
+++ b/clustersmgmt/v1/open_id_claims_list_builder.go
@@ -37,6 +37,11 @@ func (b *OpenIDClaimsListBuilder) Items(values ...*OpenIDClaimsBuilder) *OpenIDC
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *OpenIDClaimsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *OpenIDClaimsListBuilder) Copy(list *OpenIDClaimsList) *OpenIDClaimsListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/open_id_identity_provider_builder.go
+++ b/clustersmgmt/v1/open_id_identity_provider_builder.go
@@ -38,6 +38,11 @@ func NewOpenIDIdentityProvider() *OpenIDIdentityProviderBuilder {
 	return &OpenIDIdentityProviderBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *OpenIDIdentityProviderBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // CA sets the value of the 'CA' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/open_id_identity_provider_list_builder.go
+++ b/clustersmgmt/v1/open_id_identity_provider_list_builder.go
@@ -37,6 +37,11 @@ func (b *OpenIDIdentityProviderListBuilder) Items(values ...*OpenIDIdentityProvi
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *OpenIDIdentityProviderListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *OpenIDIdentityProviderListBuilder) Copy(list *OpenIDIdentityProviderList) *OpenIDIdentityProviderListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/operator_iam_role_builder.go
+++ b/clustersmgmt/v1/operator_iam_role_builder.go
@@ -34,6 +34,11 @@ func NewOperatorIAMRole() *OperatorIAMRoleBuilder {
 	return &OperatorIAMRoleBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *OperatorIAMRoleBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/operator_iam_role_list_builder.go
+++ b/clustersmgmt/v1/operator_iam_role_list_builder.go
@@ -37,6 +37,11 @@ func (b *OperatorIAMRoleListBuilder) Items(values ...*OperatorIAMRoleBuilder) *O
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *OperatorIAMRoleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *OperatorIAMRoleListBuilder) Copy(list *OperatorIAMRoleList) *OperatorIAMRoleListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/product_builder.go
+++ b/clustersmgmt/v1/product_builder.go
@@ -54,6 +54,11 @@ func (b *ProductBuilder) HREF(value string) *ProductBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ProductBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Name sets the value of the 'name' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/product_list_builder.go
+++ b/clustersmgmt/v1/product_list_builder.go
@@ -37,6 +37,11 @@ func (b *ProductListBuilder) Items(values ...*ProductBuilder) *ProductListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ProductListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ProductListBuilder) Copy(list *ProductList) *ProductListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/provision_shard_builder.go
+++ b/clustersmgmt/v1/provision_shard_builder.go
@@ -58,6 +58,11 @@ func (b *ProvisionShardBuilder) HREF(value string) *ProvisionShardBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ProvisionShardBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // AWSAccountOperatorConfig sets the value of the 'AWS_account_operator_config' attribute to the given value.
 //
 // Representation of a server config

--- a/clustersmgmt/v1/provision_shard_list_builder.go
+++ b/clustersmgmt/v1/provision_shard_list_builder.go
@@ -37,6 +37,11 @@ func (b *ProvisionShardListBuilder) Items(values ...*ProvisionShardBuilder) *Pro
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ProvisionShardListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ProvisionShardListBuilder) Copy(list *ProvisionShardList) *ProvisionShardListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/proxy_builder.go
+++ b/clustersmgmt/v1/proxy_builder.go
@@ -33,6 +33,11 @@ func NewProxy() *ProxyBuilder {
 	return &ProxyBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ProxyBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // HTTPProxy sets the value of the 'HTTP_proxy' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/proxy_list_builder.go
+++ b/clustersmgmt/v1/proxy_list_builder.go
@@ -37,6 +37,11 @@ func (b *ProxyListBuilder) Items(values ...*ProxyBuilder) *ProxyListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ProxyListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ProxyListBuilder) Copy(list *ProxyList) *ProxyListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/server_config_builder.go
+++ b/clustersmgmt/v1/server_config_builder.go
@@ -54,6 +54,11 @@ func (b *ServerConfigBuilder) HREF(value string) *ServerConfigBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ServerConfigBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Server sets the value of the 'server' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/server_config_list_builder.go
+++ b/clustersmgmt/v1/server_config_list_builder.go
@@ -37,6 +37,11 @@ func (b *ServerConfigListBuilder) Items(values ...*ServerConfigBuilder) *ServerC
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ServerConfigListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ServerConfigListBuilder) Copy(list *ServerConfigList) *ServerConfigListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/socket_total_node_role_os_metric_node_builder.go
+++ b/clustersmgmt/v1/socket_total_node_role_os_metric_node_builder.go
@@ -40,6 +40,11 @@ func NewSocketTotalNodeRoleOSMetricNode() *SocketTotalNodeRoleOSMetricNodeBuilde
 	return &SocketTotalNodeRoleOSMetricNodeBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SocketTotalNodeRoleOSMetricNodeBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // NodeRoles sets the value of the 'node_roles' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/socket_total_node_role_os_metric_node_list_builder.go
+++ b/clustersmgmt/v1/socket_total_node_role_os_metric_node_list_builder.go
@@ -37,6 +37,11 @@ func (b *SocketTotalNodeRoleOSMetricNodeListBuilder) Items(values ...*SocketTota
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SocketTotalNodeRoleOSMetricNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SocketTotalNodeRoleOSMetricNodeListBuilder) Copy(list *SocketTotalNodeRoleOSMetricNodeList) *SocketTotalNodeRoleOSMetricNodeListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/socket_totals_node_role_os_metric_node_builder.go
+++ b/clustersmgmt/v1/socket_totals_node_role_os_metric_node_builder.go
@@ -33,6 +33,11 @@ func NewSocketTotalsNodeRoleOSMetricNode() *SocketTotalsNodeRoleOSMetricNodeBuil
 	return &SocketTotalsNodeRoleOSMetricNodeBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SocketTotalsNodeRoleOSMetricNodeBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // SocketTotals sets the value of the 'socket_totals' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/socket_totals_node_role_os_metric_node_list_builder.go
+++ b/clustersmgmt/v1/socket_totals_node_role_os_metric_node_list_builder.go
@@ -37,6 +37,11 @@ func (b *SocketTotalsNodeRoleOSMetricNodeListBuilder) Items(values ...*SocketTot
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SocketTotalsNodeRoleOSMetricNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SocketTotalsNodeRoleOSMetricNodeListBuilder) Copy(list *SocketTotalsNodeRoleOSMetricNodeList) *SocketTotalsNodeRoleOSMetricNodeListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/ssh_credentials_builder.go
+++ b/clustersmgmt/v1/ssh_credentials_builder.go
@@ -33,6 +33,11 @@ func NewSSHCredentials() *SSHCredentialsBuilder {
 	return &SSHCredentialsBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SSHCredentialsBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // PrivateKey sets the value of the 'private_key' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/ssh_credentials_list_builder.go
+++ b/clustersmgmt/v1/ssh_credentials_list_builder.go
@@ -37,6 +37,11 @@ func (b *SSHCredentialsListBuilder) Items(values ...*SSHCredentialsBuilder) *SSH
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SSHCredentialsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SSHCredentialsListBuilder) Copy(list *SSHCredentialsList) *SSHCredentialsListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/sts_builder.go
+++ b/clustersmgmt/v1/sts_builder.go
@@ -37,6 +37,11 @@ func NewSTS() *STSBuilder {
 	return &STSBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *STSBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // OIDCEndpointURL sets the value of the 'OIDC_endpoint_URL' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/sts_list_builder.go
+++ b/clustersmgmt/v1/sts_list_builder.go
@@ -37,6 +37,11 @@ func (b *STSListBuilder) Items(values ...*STSBuilder) *STSListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *STSListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *STSListBuilder) Copy(list *STSList) *STSListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/subscription_builder.go
+++ b/clustersmgmt/v1/subscription_builder.go
@@ -53,6 +53,11 @@ func (b *SubscriptionBuilder) HREF(value string) *SubscriptionBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SubscriptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Copy copies the attributes of the given object into this builder, discarding any previous values.
 func (b *SubscriptionBuilder) Copy(object *Subscription) *SubscriptionBuilder {
 	if object == nil {

--- a/clustersmgmt/v1/subscription_list_builder.go
+++ b/clustersmgmt/v1/subscription_list_builder.go
@@ -37,6 +37,11 @@ func (b *SubscriptionListBuilder) Items(values ...*SubscriptionBuilder) *Subscri
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SubscriptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SubscriptionListBuilder) Copy(list *SubscriptionList) *SubscriptionListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/syncset_builder.go
+++ b/clustersmgmt/v1/syncset_builder.go
@@ -54,6 +54,11 @@ func (b *SyncsetBuilder) HREF(value string) *SyncsetBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *SyncsetBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Resources sets the value of the 'resources' attribute to the given values.
 //
 //

--- a/clustersmgmt/v1/syncset_list_builder.go
+++ b/clustersmgmt/v1/syncset_list_builder.go
@@ -37,6 +37,11 @@ func (b *SyncsetListBuilder) Items(values ...*SyncsetBuilder) *SyncsetListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *SyncsetListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *SyncsetListBuilder) Copy(list *SyncsetList) *SyncsetListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/taint_builder.go
+++ b/clustersmgmt/v1/taint_builder.go
@@ -34,6 +34,11 @@ func NewTaint() *TaintBuilder {
 	return &TaintBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TaintBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Effect sets the value of the 'effect' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/taint_list_builder.go
+++ b/clustersmgmt/v1/taint_list_builder.go
@@ -37,6 +37,11 @@ func (b *TaintListBuilder) Items(values ...*TaintBuilder) *TaintListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *TaintListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *TaintListBuilder) Copy(list *TaintList) *TaintListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/upgrade_policy_builder.go
+++ b/clustersmgmt/v1/upgrade_policy_builder.go
@@ -63,6 +63,11 @@ func (b *UpgradePolicyBuilder) HREF(value string) *UpgradePolicyBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *UpgradePolicyBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // ClusterID sets the value of the 'cluster_ID' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/upgrade_policy_list_builder.go
+++ b/clustersmgmt/v1/upgrade_policy_list_builder.go
@@ -37,6 +37,11 @@ func (b *UpgradePolicyListBuilder) Items(values ...*UpgradePolicyBuilder) *Upgra
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *UpgradePolicyListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *UpgradePolicyListBuilder) Copy(list *UpgradePolicyList) *UpgradePolicyListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/upgrade_policy_state_builder.go
+++ b/clustersmgmt/v1/upgrade_policy_state_builder.go
@@ -55,6 +55,11 @@ func (b *UpgradePolicyStateBuilder) HREF(value string) *UpgradePolicyStateBuilde
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *UpgradePolicyStateBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Description sets the value of the 'description' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/upgrade_policy_state_list_builder.go
+++ b/clustersmgmt/v1/upgrade_policy_state_list_builder.go
@@ -37,6 +37,11 @@ func (b *UpgradePolicyStateListBuilder) Items(values ...*UpgradePolicyStateBuild
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *UpgradePolicyStateListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *UpgradePolicyStateListBuilder) Copy(list *UpgradePolicyStateList) *UpgradePolicyStateListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/user_builder.go
+++ b/clustersmgmt/v1/user_builder.go
@@ -53,6 +53,11 @@ func (b *UserBuilder) HREF(value string) *UserBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *UserBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // Copy copies the attributes of the given object into this builder, discarding any previous values.
 func (b *UserBuilder) Copy(object *User) *UserBuilder {
 	if object == nil {

--- a/clustersmgmt/v1/user_list_builder.go
+++ b/clustersmgmt/v1/user_list_builder.go
@@ -37,6 +37,11 @@ func (b *UserListBuilder) Items(values ...*UserBuilder) *UserListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *UserListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *UserListBuilder) Copy(list *UserList) *UserListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/value_builder.go
+++ b/clustersmgmt/v1/value_builder.go
@@ -50,6 +50,11 @@ func NewValue() *ValueBuilder {
 	return &ValueBuilder{}
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ValueBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
 // Unit sets the value of the 'unit' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/value_list_builder.go
+++ b/clustersmgmt/v1/value_list_builder.go
@@ -37,6 +37,11 @@ func (b *ValueListBuilder) Items(values ...*ValueBuilder) *ValueListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *ValueListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *ValueListBuilder) Copy(list *ValueList) *ValueListBuilder {
 	if list == nil || list.items == nil {

--- a/clustersmgmt/v1/version_builder.go
+++ b/clustersmgmt/v1/version_builder.go
@@ -64,6 +64,11 @@ func (b *VersionBuilder) HREF(value string) *VersionBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *VersionBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // ROSAEnabled sets the value of the 'ROSA_enabled' attribute to the given value.
 //
 //

--- a/clustersmgmt/v1/version_list_builder.go
+++ b/clustersmgmt/v1/version_list_builder.go
@@ -37,6 +37,11 @@ func (b *VersionListBuilder) Items(values ...*VersionBuilder) *VersionListBuilde
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *VersionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *VersionListBuilder) Copy(list *VersionList) *VersionListBuilder {
 	if list == nil || list.items == nil {

--- a/jobqueue/v1/job_builder.go
+++ b/jobqueue/v1/job_builder.go
@@ -63,6 +63,11 @@ func (b *JobBuilder) HREF(value string) *JobBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *JobBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // AbandonedAt sets the value of the 'abandoned_at' attribute to the given value.
 //
 //

--- a/jobqueue/v1/job_list_builder.go
+++ b/jobqueue/v1/job_list_builder.go
@@ -37,6 +37,11 @@ func (b *JobListBuilder) Items(values ...*JobBuilder) *JobListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *JobListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *JobListBuilder) Copy(list *JobList) *JobListBuilder {
 	if list == nil || list.items == nil {

--- a/jobqueue/v1/queue_builder.go
+++ b/jobqueue/v1/queue_builder.go
@@ -62,6 +62,11 @@ func (b *QueueBuilder) HREF(value string) *QueueBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *QueueBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // CreatedAt sets the value of the 'created_at' attribute to the given value.
 //
 //

--- a/jobqueue/v1/queue_list_builder.go
+++ b/jobqueue/v1/queue_list_builder.go
@@ -37,6 +37,11 @@ func (b *QueueListBuilder) Items(values ...*QueueBuilder) *QueueListBuilder {
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *QueueListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *QueueListBuilder) Copy(list *QueueList) *QueueListBuilder {
 	if list == nil || list.items == nil {

--- a/servicelogs/v1/log_entry_builder.go
+++ b/servicelogs/v1/log_entry_builder.go
@@ -65,6 +65,11 @@ func (b *LogEntryBuilder) HREF(value string) *LogEntryBuilder {
 	return b
 }
 
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *LogEntryBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
 // ClusterUUID sets the value of the 'cluster_UUID' attribute to the given value.
 //
 //

--- a/servicelogs/v1/log_entry_list_builder.go
+++ b/servicelogs/v1/log_entry_list_builder.go
@@ -37,6 +37,11 @@ func (b *LogEntryListBuilder) Items(values ...*LogEntryBuilder) *LogEntryListBui
 	return b
 }
 
+// Empty returns true if the list is empty.
+func (b *LogEntryListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
 // Copy copies the items of the given list into this builder, discarding any previous items.
 func (b *LogEntryListBuilder) Copy(list *LogEntryList) *LogEntryListBuilder {
 	if list == nil || list.items == nil {


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Check for loops in locator paths.
- Add `Empty` method to builders.