### PR TITLE
Release 0.1.218

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+== 0.1.218 Nov 22 2021
+
+- Update to metamodel 0.0.44:
+** Check for loops in locator paths.
+** Add `Empty` method to builders.
+
 == 0.1.217 Nov 18 2021
 
 - Update to model 0.0.152

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.217"
+const Version = "0.1.218"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.44:
  - Check for loops in locator paths.
  - Add `Empty` method to builders.