### PR TITLE
Fix bug - service log is not terminating properly

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -991,6 +991,11 @@ func (c *Connection) JobQueue() *jobqueue.Client {
 func (c *Connection) Close() error {
 	var err error
 
+	// in case the connection is already closed, return instead of printing an error message
+	if c.closed {
+		return nil
+	}
+
 	// Close the HTTP clients:
 	err = c.clientSelector.Close()
 	if err != nil {

--- a/connection_test.go
+++ b/connection_test.go
@@ -973,6 +973,20 @@ var _ = Describe("Connection", func() {
 		Expect(message).To(ContainSubstring("socket"))
 		Expect(message).To(ContainSubstring("path"))
 	})
+
+	It("Function Close returns nil when trying to close a closed connection", func() {
+		offlineToken := MakeTokenString("Offline", 0)
+		connection, err := NewConnectionBuilder().
+			Logger(logger).
+			Tokens(offlineToken).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		err = connection.Close()
+		Expect(err).ToNot(HaveOccurred())
+		// Try to close the connection again
+		err = connection.Close()
+		Expect(err).To(BeNil())
+	})
 })
 
 type TestTransport struct {


### PR DESCRIPTION
- Modify ``func (c *Connection) Close()`` to **return nil in case the connection is already closed**,
to avoid causing an error when trying to destroy OSL client when the connection
is already closed.
- Adding a test to close a closed connection returns nil.

After this PR is merged - trying to destroy a component when the connection is closed
won't cause an error.

Solve [SDA-4085](https://issues.redhat.com/browse/SDA-4085)