### PR TITLE
Release 0.1.221

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.221 Dec 1 2021
+
+- Modify `func (c *Connection) Close()` to return nil in case the connection is already closed.
+
 ## 0.1.220 Nov 25 2021
 
 - Added utilities to test with `jq` expressions and JSON patches.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.220"
+const Version = "0.1.221"


### PR DESCRIPTION
This release changes the return value of ``Connection.Close()``
to avoid causing an error when trying to destroy a client
when the connection is already closed.

Related #506