### PR TITLE
Add changes to release descriptions

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -27,26 +27,60 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+
+    - name: Install Python modules
+      run: pip install -r .github/workflows/requirements.txt
+
     - name: Create release
+      shell: python
       run: |
-        # Get the version number:
-        version=$(echo -n ${{ github.ref }} | sed -E 's|^refs/tags/v(.*)$|\1|')
+        import re
+        import requests
+
+        # Get the context and secret data that we will need:
+        repository = "${{ github.repository }}"
+        reference = "${{ github.ref }}"
+        token = "${{ secrets.GITHUB_TOKEN }}"
+
+        # Calculate the version number:
+        version = re.sub(r"^refs/tags/v(.*)$", r"\1", reference)
+
+        # Get the list of changes:
+        body = ""
+        with open("CHANGES.md", "r") as stream:
+            while True:
+                line = stream.readline()
+                if line == "" or line.startswith("## " + version):
+                    break
+            while True:
+                line = stream.readline()
+                if line == "" or line.startswith("## "):
+                    break
+                body += line
 
         # Send the request to create the release:
-        cat > request.json <<.
-        {
-          "tag_name": "v${version}",
-          "name": "Release ${version}",
-          "body": "See the [CHANGES](CHANGES.md) file for details."
-        }
-        .
-        curl \
-        --silent \
-        --request "POST" \
-        --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-        --header "Content-Type: application/json" \
-        --header "Accept: application/json" \
-        --url "https://api.github.com/repos/${{ github.repository }}/releases" \
-        --data @request.json \
-        --output response.json \
-        --fail
+        response = requests.post(
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            json={
+                "tag_name": f"v{version}",
+                "name": f"Release {version}",
+                "body": body,
+            },
+            url=(
+                "https://api.github.com"
+                f"/repos/{repository}/releases"
+            ),
+        )
+        response.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file lists the Python dependencies used by the GitHub actions.
+
+requests


### PR DESCRIPTION
This patch changes the publish release GitHub action so that it
automatically adds the changes from the `CHANGES.md` file to the release
descriptions.