### PR TITLE
Update to version 4 of JWT library

### DIFF
--- a/authentication/context.go
+++ b/authentication/context.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // ContextWithToken creates a new context containing the given token.

--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -35,8 +35,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt"
 	"gopkg.in/yaml.v3"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/openshift-online/ocm-sdk-go/errors"
 	"github.com/openshift-online/ocm-sdk-go/logging"

--- a/authentication/handler_test.go
+++ b/authentication/handler_test.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"                         // nolint

--- a/authentication/helpers.go
+++ b/authentication/helpers.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // tokenRemaining determines if the given token will eventually expire (offile access tokens and

--- a/authentication/token_info.go
+++ b/authentication/token_info.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package authentication
 
-import "github.com/golang-jwt/jwt"
+import (
+	"github.com/golang-jwt/jwt/v4"
+)
 
 // tokenInfo stores information about a token. We need to store both the original text and the
 // parsed objects because some tokens (refresh tokens in particular) may be opaque strings instead

--- a/authentication/transport_wrapper.go
+++ b/authentication/transport_wrapper.go
@@ -24,23 +24,22 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"sync"
-
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
-	//
 	"github.com/cenkalti/backoff/v4"
-	jwt "github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/openshift-online/ocm-sdk-go/internal"
 	"github.com/openshift-online/ocm-sdk-go/logging"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Default values:

--- a/authentication/transport_wrapper_test.go
+++ b/authentication/transport_wrapper_test.go
@@ -28,8 +28,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
+
 	. "github.com/onsi/ginkgo/v2"                      // nolint
 	. "github.com/onsi/gomega"                         // nolint
 	. "github.com/onsi/gomega/ghttp"                   // nolint

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -104,8 +104,8 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/cenkalti/backoff/v4 v4.0.0
 	github.com/evanphx/json-patch/v5 v5.6.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/uuid v1.2.0
 	github.com/itchyny/gojq v0.12.5

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/testing/tokens.go
+++ b/testing/tokens.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 
 	. "github.com/onsi/gomega" // nolint
 )
@@ -69,10 +69,12 @@ func MakeClaims() jwt.MapClaims {
 // token will be valid, and expire after that time. If the life is negative the token will be
 // already expired that time ago.
 func MakeTokenString(typ string, life time.Duration) string {
-	token := MakeTokenObject(jwt.MapClaims{
-		"typ": typ,
-		"exp": time.Now().Add(life).Unix(),
-	})
+	claims := jwt.MapClaims{}
+	claims["typ"] = typ
+	if life != 0 {
+		claims["exp"] = time.Now().Add(life).Unix()
+	}
+	token := MakeTokenObject(claims)
 	return token.Raw
 }
 


### PR DESCRIPTION
This patch updates the code of the project to use version 4 of the
`github.com/jwt-go/jwt` library. The new version is backwards compatible
with version 3, but it is part of the contract of the SDK, so
applications using the SDK will also need to update. The only required
change is to replace import `github.com/jwt-go/jwt` with
`github.com/jwt-go/jwt/v4`.