### PR TITLE
Don't use `github.com/ghodss/yaml`

### DIFF
--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -35,7 +35,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ghodss/yaml"
+	"gopkg.in/yaml.v3"
 	"github.com/golang-jwt/jwt"
 
 	"github.com/openshift-online/ocm-sdk-go/errors"
@@ -388,8 +388,8 @@ func (b *HandlerBuilder) Build() (handler *Handler, err error) {
 
 // aclItem is the type used to read a single ACL item from a YAML document.
 type aclItem struct {
-	Claim   string `json:"claim"`
-	Pattern string `json:"pattern"`
+	Claim   string `yaml:"claim"`
+	Pattern string `yaml:"pattern"`
 }
 
 // loadACLFile loads the given ACL file into the given map of ACL items.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,13 +1,12 @@
 module github.com/openshift-online/ocm-sdk-go/examples
 
-go 1.14
+go 1.16
 
 // We don't want to use the latest released versio of the SDK, but exactly the same version that
 // is in the parent directory.
 replace github.com/openshift-online/ocm-sdk-go => ../
 
 require (
-	github.com/ghodss/yaml v1.0.0
 	github.com/openshift-online/ocm-sdk-go v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.9.0
 	k8s.io/api v0.22.1

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -80,7 +80,6 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/examples/sync_addons.go
+++ b/examples/sync_addons.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // This example shows how to update the collection of add-ons from an external source. To simplify
-// things that external source is a YAML document embedded in this source file, but it could be an
+// things that external source is a JSON document embedded in this source file, but it could be an
 // external file or an external collection of files.
 
 package main
@@ -24,8 +24,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-
-	"github.com/ghodss/yaml"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -62,10 +60,10 @@ func main() {
 	// Get the client for the collection of add-ons:
 	collection := connection.ClustersMgmt().V1().Addons()
 
-	// Load the sets of add-ons from the YAML file and from the API:
-	fileIndex, err := loadYAML(ctx, fileData)
+	// Load the sets of add-ons from the JSON file and from the API:
+	fileIndex, err := loadJSON(ctx, fileData)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't load YAML data: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Can't load JSON data: %v\n", err)
 		os.Exit(1)
 	}
 	apiIndex, err := loadAPI(ctx, collection)
@@ -142,14 +140,10 @@ func main() {
 	}
 }
 
-// loadYAML loads the add-ons from the YAML document and returns a map where the key is the
+// loadJSON loads the add-ons from the JSON document and returns a map where the key is the
 // identifier of the add-on and the value is the add-on object.
-func loadYAML(ctx context.Context, data []byte) (result map[string]*cmv1.AddOn, err error) {
-	// Load the list of add-ons from the API:
-	data, err = yaml.YAMLToJSON(data)
-	if err != nil {
-		return
-	}
+func loadJSON(ctx context.Context, data []byte) (result map[string]*cmv1.AddOn, err error) {
+	// Load the list of add-ons:
 	items, err := cmv1.UnmarshalAddOnList(data)
 	if err != nil {
 		return
@@ -201,13 +195,17 @@ func loadAPI(ctx context.Context, collection *cmv1.AddOnsClient) (result map[str
 	return
 }
 
-var fileData = []byte(`
-- id: black
-  name: Black add-on
-  description: Very black add-on
-  icon: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==
-- id: white
-  name: White add-on
-  description: Very white add-on
-  icon: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==
-`)
+var fileData = []byte(`[
+  {
+    "id": "black",
+    "name": "Black add-on",
+    "description": "Very black add-on",
+    "icon": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg=="
+  },
+  {
+    "id": "white",
+    "name": "White add-on",
+    "description": "Very white add-on",
+    "icon": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg=="
+  }
+]`)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/cenkalti/backoff/v4 v4.0.0
 	github.com/evanphx/json-patch/v5 v5.6.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -70,7 +70,6 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=


### PR DESCRIPTION
This package isn't maintained, and it is used only to parse the ACLs
used by the authentication handler. That can also be done with the
`gopkg.in/yaml.v3` package that is also used for other things in the
SDK. This patch does that replacement.