### PR TITLE
Update to metamodel 0.0.50

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ model_version:=v0.0.169
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.49
+metamodel_version:=v0.0.50
 
 .PHONY: examples
 examples:

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -34,7 +34,14 @@ func AddValue(query *url.Values, name string, value interface{}) {
 	if *query == nil {
 		*query = make(url.Values)
 	}
-	query.Add(name, fmt.Sprintf("%v", value))
+	var text string
+	switch typed := value.(type) {
+	case time.Time:
+		text = typed.UTC().Format(time.RFC3339)
+	default:
+		text = fmt.Sprintf("%v", value)
+	}
+	query.Add(name, text)
 }
 
 // CopyQuery creates a copy of the given set of query parameters.


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Fix format of date query parameters so that it is RFC3339.