### PR TITLE
Release 0.1.237

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.237 Jan 25 2022
+
+- Update to metamodel 0.0.50:
+  - Fix format of date query parameters so that it is RFC3339.
+
 ## 0.1.236 Jan 25 2022
 - Update to model v0.0.169
   - Version gate type: Add warning message field

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.236"
+const Version = "0.1.237"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.50:
  - Fix format of date query parameters so that it is RFC3339.