### PR TITLE
Increase sleep time of leadership flag test

### DIFF
--- a/leadership/flag_test.go
+++ b/leadership/flag_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Flag behaviour", func() {
 		})
 
 		It("It is raised when the previous holder fails to renew", func() {
-			time.Sleep(300 * time.Millisecond)
+			time.Sleep(400 * time.Millisecond)
 			Expect(flag.Raised()).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
The test that checks that the leadership flag is raised by a new holder
when the previous holder fails to renew is failing because the database
access in the GitHub actions environment seems to be quite slow. This
patch increases the sleep time to avoid that.