### PR TITLE
Update to metamodel 0.0.51

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ model_version:=v0.0.170
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.50
+metamodel_version:=v0.0.51
 
 .PHONY: examples
 examples:

--- a/accountsmgmt/v1/access_token_auth_type_json.go
+++ b/accountsmgmt/v1/access_token_auth_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeAccessTokenAuth(object *AccessTokenAuth, stream *jsoniter.Stream) {
 // UnmarshalAccessTokenAuth reads a value of the 'access_token_auth' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAccessTokenAuth(source interface{}) (object *AccessTokenAuth, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/access_token_client.go
+++ b/accountsmgmt/v1/access_token_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -108,15 +110,21 @@ func (r *AccessTokenPostRequest) SendContext(ctx context.Context) (result *Acces
 	result = &AccessTokenPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAccessTokenPostResponse(result, response.Body)
+	err = readAccessTokenPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/access_token_type_json.go
+++ b/accountsmgmt/v1/access_token_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -78,9 +77,6 @@ func writeAccessToken(object *AccessToken, stream *jsoniter.Stream) {
 // UnmarshalAccessToken reads a value of the 'access_token' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAccessToken(source interface{}) (object *AccessToken, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/account_client.go
+++ b/accountsmgmt/v1/account_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -253,15 +255,21 @@ func (r *AccountGetRequest) SendContext(ctx context.Context) (result *AccountGet
 	result = &AccountGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAccountGetResponse(result, response.Body)
+	err = readAccountGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -389,15 +397,21 @@ func (r *AccountUpdateRequest) SendContext(ctx context.Context) (result *Account
 	result = &AccountUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAccountUpdateResponse(result, response.Body)
+	err = readAccountUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/account_type_json.go
+++ b/accountsmgmt/v1/account_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -180,9 +179,6 @@ func writeAccount(object *Account, stream *jsoniter.Stream) {
 // UnmarshalAccount reads a value of the 'account' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAccount(source interface{}) (object *Account, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/accounts_client.go
+++ b/accountsmgmt/v1/accounts_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *AccountsAddRequest) SendContext(ctx context.Context) (result *AccountsA
 	result = &AccountsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAccountsAddResponse(result, response.Body)
+	err = readAccountsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -367,15 +375,21 @@ func (r *AccountsListRequest) SendContext(ctx context.Context) (result *Accounts
 	result = &AccountsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAccountsListResponse(result, response.Body)
+	err = readAccountsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/capability_type_json.go
+++ b/accountsmgmt/v1/capability_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeCapability(object *Capability, stream *jsoniter.Stream) {
 // UnmarshalCapability reads a value of the 'capability' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCapability(source interface{}) (object *Capability, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/cluster_authorization_request_type_json.go
+++ b/accountsmgmt/v1/cluster_authorization_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -174,9 +173,6 @@ func writeClusterAuthorizationRequest(object *ClusterAuthorizationRequest, strea
 // UnmarshalClusterAuthorizationRequest reads a value of the 'cluster_authorization_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterAuthorizationRequest(source interface{}) (object *ClusterAuthorizationRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/cluster_authorization_response_type_json.go
+++ b/accountsmgmt/v1/cluster_authorization_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeClusterAuthorizationResponse(object *ClusterAuthorizationResponse, str
 // UnmarshalClusterAuthorizationResponse reads a value of the 'cluster_authorization_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterAuthorizationResponse(source interface{}) (object *ClusterAuthorizationResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/cluster_authorizations_client.go
+++ b/accountsmgmt/v1/cluster_authorizations_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *ClusterAuthorizationsPostRequest) SendContext(ctx context.Context) (res
 	result = &ClusterAuthorizationsPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterAuthorizationsPostResponse(result, response.Body)
+	err = readClusterAuthorizationsPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/cluster_metrics_nodes_type_json.go
+++ b/accountsmgmt/v1/cluster_metrics_nodes_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -84,9 +83,6 @@ func writeClusterMetricsNodes(object *ClusterMetricsNodes, stream *jsoniter.Stre
 // UnmarshalClusterMetricsNodes reads a value of the 'cluster_metrics_nodes' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterMetricsNodes(source interface{}) (object *ClusterMetricsNodes, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/cluster_registration_request_type_json.go
+++ b/accountsmgmt/v1/cluster_registration_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeClusterRegistrationRequest(object *ClusterRegistrationRequest, stream 
 // UnmarshalClusterRegistrationRequest reads a value of the 'cluster_registration_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterRegistrationRequest(source interface{}) (object *ClusterRegistrationRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/cluster_registration_response_type_json.go
+++ b/accountsmgmt/v1/cluster_registration_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -84,9 +83,6 @@ func writeClusterRegistrationResponse(object *ClusterRegistrationResponse, strea
 // UnmarshalClusterRegistrationResponse reads a value of the 'cluster_registration_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterRegistrationResponse(source interface{}) (object *ClusterRegistrationResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/cluster_registrations_client.go
+++ b/accountsmgmt/v1/cluster_registrations_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -126,15 +128,21 @@ func (r *ClusterRegistrationsPostRequest) SendContext(ctx context.Context) (resu
 	result = &ClusterRegistrationsPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterRegistrationsPostResponse(result, response.Body)
+	err = readClusterRegistrationsPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/cluster_resource_type_json.go
+++ b/accountsmgmt/v1/cluster_resource_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -76,9 +75,6 @@ func writeClusterResource(object *ClusterResource, stream *jsoniter.Stream) {
 // UnmarshalClusterResource reads a value of the 'cluster_resource' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterResource(source interface{}) (object *ClusterResource, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/cluster_upgrade_type_json.go
+++ b/accountsmgmt/v1/cluster_upgrade_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -85,9 +84,6 @@ func writeClusterUpgrade(object *ClusterUpgrade, stream *jsoniter.Stream) {
 // UnmarshalClusterUpgrade reads a value of the 'cluster_upgrade' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterUpgrade(source interface{}) (object *ClusterUpgrade, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/current_access_client.go
+++ b/accountsmgmt/v1/current_access_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -132,15 +134,21 @@ func (r *CurrentAccessListRequest) SendContext(ctx context.Context) (result *Cur
 	result = &CurrentAccessListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCurrentAccessListResponse(result, response.Body)
+	err = readCurrentAccessListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/current_account_client.go
+++ b/accountsmgmt/v1/current_account_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *CurrentAccountGetRequest) SendContext(ctx context.Context) (result *Cur
 	result = &CurrentAccountGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCurrentAccountGetResponse(result, response.Body)
+	err = readCurrentAccountGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/feature_toggle_query_client.go
+++ b/accountsmgmt/v1/feature_toggle_query_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *FeatureToggleQueryPostRequest) SendContext(ctx context.Context) (result
 	result = &FeatureToggleQueryPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readFeatureToggleQueryPostResponse(result, response.Body)
+	err = readFeatureToggleQueryPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/feature_toggle_query_request_type_json.go
+++ b/accountsmgmt/v1/feature_toggle_query_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeFeatureToggleQueryRequest(object *FeatureToggleQueryRequest, stream *j
 // UnmarshalFeatureToggleQueryRequest reads a value of the 'feature_toggle_query_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalFeatureToggleQueryRequest(source interface{}) (object *FeatureToggleQueryRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/feature_toggle_type_json.go
+++ b/accountsmgmt/v1/feature_toggle_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeFeatureToggle(object *FeatureToggle, stream *jsoniter.Stream) {
 // UnmarshalFeatureToggle reads a value of the 'feature_toggle' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalFeatureToggle(source interface{}) (object *FeatureToggle, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/generic_label_client.go
+++ b/accountsmgmt/v1/generic_label_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *GenericLabelDeleteRequest) SendContext(ctx context.Context) (result *Ge
 	result = &GenericLabelDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *GenericLabelGetRequest) SendContext(ctx context.Context) (result *Gener
 	result = &GenericLabelGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readGenericLabelGetResponse(result, response.Body)
+	err = readGenericLabelGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *GenericLabelUpdateRequest) SendContext(ctx context.Context) (result *Ge
 	result = &GenericLabelUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readGenericLabelUpdateResponse(result, response.Body)
+	err = readGenericLabelUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/generic_labels_client.go
+++ b/accountsmgmt/v1/generic_labels_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -150,15 +152,21 @@ func (r *GenericLabelsAddRequest) SendContext(ctx context.Context) (result *Gene
 	result = &GenericLabelsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readGenericLabelsAddResponse(result, response.Body)
+	err = readGenericLabelsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -298,15 +306,21 @@ func (r *GenericLabelsListRequest) SendContext(ctx context.Context) (result *Gen
 	result = &GenericLabelsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readGenericLabelsListResponse(result, response.Body)
+	err = readGenericLabelsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/label_type_json.go
+++ b/accountsmgmt/v1/label_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -117,9 +116,6 @@ func writeLabel(object *Label, stream *jsoniter.Stream) {
 // UnmarshalLabel reads a value of the 'label' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLabel(source interface{}) (object *Label, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/labels_client.go
+++ b/accountsmgmt/v1/labels_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -156,15 +158,21 @@ func (r *LabelsListRequest) SendContext(ctx context.Context) (result *LabelsList
 	result = &LabelsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLabelsListResponse(result, response.Body)
+	err = readLabelsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/metadata_client.go
+++ b/accountsmgmt/v1/metadata_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -89,15 +91,20 @@ func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResp
 		status: response.StatusCode,
 		header: response.Header,
 	}
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	result.body, err = UnmarshalMetadata(response.Body)
+	result.body, err = UnmarshalMetadata(reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/notify_client.go
+++ b/accountsmgmt/v1/notify_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *NotifyAddRequest) SendContext(ctx context.Context) (result *NotifyAddRe
 	result = &NotifyAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readNotifyAddResponse(result, response.Body)
+	err = readNotifyAddResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/organization_client.go
+++ b/accountsmgmt/v1/organization_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -296,15 +298,21 @@ func (r *OrganizationGetRequest) SendContext(ctx context.Context) (result *Organ
 	result = &OrganizationGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readOrganizationGetResponse(result, response.Body)
+	err = readOrganizationGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -432,15 +440,21 @@ func (r *OrganizationUpdateRequest) SendContext(ctx context.Context) (result *Or
 	result = &OrganizationUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readOrganizationUpdateResponse(result, response.Body)
+	err = readOrganizationUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/organization_type_json.go
+++ b/accountsmgmt/v1/organization_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -135,9 +134,6 @@ func writeOrganization(object *Organization, stream *jsoniter.Stream) {
 // UnmarshalOrganization reads a value of the 'organization' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalOrganization(source interface{}) (object *Organization, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/organizations_client.go
+++ b/accountsmgmt/v1/organizations_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *OrganizationsAddRequest) SendContext(ctx context.Context) (result *Orga
 	result = &OrganizationsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readOrganizationsAddResponse(result, response.Body)
+	err = readOrganizationsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -344,15 +352,21 @@ func (r *OrganizationsListRequest) SendContext(ctx context.Context) (result *Org
 	result = &OrganizationsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readOrganizationsListResponse(result, response.Body)
+	err = readOrganizationsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/permission_client.go
+++ b/accountsmgmt/v1/permission_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -240,8 +242,14 @@ func (r *PermissionDeleteRequest) SendContext(ctx context.Context) (result *Perm
 	result = &PermissionDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -334,15 +342,21 @@ func (r *PermissionGetRequest) SendContext(ctx context.Context) (result *Permiss
 	result = &PermissionGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPermissionGetResponse(result, response.Body)
+	err = readPermissionGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/permission_type_json.go
+++ b/accountsmgmt/v1/permission_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writePermission(object *Permission, stream *jsoniter.Stream) {
 // UnmarshalPermission reads a value of the 'permission' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalPermission(source interface{}) (object *Permission, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/permissions_client.go
+++ b/accountsmgmt/v1/permissions_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *PermissionsAddRequest) SendContext(ctx context.Context) (result *Permis
 	result = &PermissionsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPermissionsAddResponse(result, response.Body)
+	err = readPermissionsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *PermissionsListRequest) SendContext(ctx context.Context) (result *Permi
 	result = &PermissionsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPermissionsListResponse(result, response.Body)
+	err = readPermissionsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/plan_type_json.go
+++ b/accountsmgmt/v1/plan_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -98,9 +97,6 @@ func writePlan(object *Plan, stream *jsoniter.Stream) {
 // UnmarshalPlan reads a value of the 'plan' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalPlan(source interface{}) (object *Plan, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/pull_secret_client.go
+++ b/accountsmgmt/v1/pull_secret_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -108,8 +110,14 @@ func (r *PullSecretDeleteRequest) SendContext(ctx context.Context) (result *Pull
 	result = &PullSecretDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}

--- a/accountsmgmt/v1/pull_secrets_client.go
+++ b/accountsmgmt/v1/pull_secrets_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -136,15 +138,21 @@ func (r *PullSecretsPostRequest) SendContext(ctx context.Context) (result *PullS
 	result = &PullSecretsPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPullSecretsPostResponse(result, response.Body)
+	err = readPullSecretsPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/pull_secrets_request_type_json.go
+++ b/accountsmgmt/v1/pull_secrets_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writePullSecretsRequest(object *PullSecretsRequest, stream *jsoniter.Stream
 // UnmarshalPullSecretsRequest reads a value of the 'pull_secrets_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalPullSecretsRequest(source interface{}) (object *PullSecretsRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/quota_cost_client.go
+++ b/accountsmgmt/v1/quota_cost_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -156,15 +158,21 @@ func (r *QuotaCostListRequest) SendContext(ctx context.Context) (result *QuotaCo
 	result = &QuotaCostListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readQuotaCostListResponse(result, response.Body)
+	err = readQuotaCostListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/quota_cost_type_json.go
+++ b/accountsmgmt/v1/quota_cost_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -93,9 +92,6 @@ func writeQuotaCost(object *QuotaCost, stream *jsoniter.Stream) {
 // UnmarshalQuotaCost reads a value of the 'quota_cost' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalQuotaCost(source interface{}) (object *QuotaCost, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/quota_summary_client.go
+++ b/accountsmgmt/v1/quota_summary_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -157,15 +159,21 @@ func (r *QuotaSummaryListRequest) SendContext(ctx context.Context) (result *Quot
 	result = &QuotaSummaryListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readQuotaSummaryListResponse(result, response.Body)
+	err = readQuotaSummaryListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/quota_summary_type_json.go
+++ b/accountsmgmt/v1/quota_summary_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -111,9 +110,6 @@ func writeQuotaSummary(object *QuotaSummary, stream *jsoniter.Stream) {
 // UnmarshalQuotaSummary reads a value of the 'quota_summary' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalQuotaSummary(source interface{}) (object *QuotaSummary, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/registry_client.go
+++ b/accountsmgmt/v1/registry_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *RegistryGetRequest) SendContext(ctx context.Context) (result *RegistryG
 	result = &RegistryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRegistryGetResponse(result, response.Body)
+	err = readRegistryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/registry_credential_client.go
+++ b/accountsmgmt/v1/registry_credential_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *RegistryCredentialGetRequest) SendContext(ctx context.Context) (result 
 	result = &RegistryCredentialGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRegistryCredentialGetResponse(result, response.Body)
+	err = readRegistryCredentialGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/registry_credential_type_json.go
+++ b/accountsmgmt/v1/registry_credential_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -135,9 +134,6 @@ func writeRegistryCredential(object *RegistryCredential, stream *jsoniter.Stream
 // UnmarshalRegistryCredential reads a value of the 'registry_credential' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalRegistryCredential(source interface{}) (object *RegistryCredential, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/registry_credentials_client.go
+++ b/accountsmgmt/v1/registry_credentials_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *RegistryCredentialsAddRequest) SendContext(ctx context.Context) (result
 	result = &RegistryCredentialsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRegistryCredentialsAddResponse(result, response.Body)
+	err = readRegistryCredentialsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -338,15 +346,21 @@ func (r *RegistryCredentialsListRequest) SendContext(ctx context.Context) (resul
 	result = &RegistryCredentialsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRegistryCredentialsListResponse(result, response.Body)
+	err = readRegistryCredentialsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/registry_type_json.go
+++ b/accountsmgmt/v1/registry_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -144,9 +143,6 @@ func writeRegistry(object *Registry, stream *jsoniter.Stream) {
 // UnmarshalRegistry reads a value of the 'registry' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalRegistry(source interface{}) (object *Registry, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/related_resource_type_json.go
+++ b/accountsmgmt/v1/related_resource_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -120,9 +119,6 @@ func writeRelatedResource(object *RelatedResource, stream *jsoniter.Stream) {
 // UnmarshalRelatedResource reads a value of the 'related_resource' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalRelatedResource(source interface{}) (object *RelatedResource, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/reserved_resource_type_json.go
+++ b/accountsmgmt/v1/reserved_resource_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -121,9 +120,6 @@ func writeReservedResource(object *ReservedResource, stream *jsoniter.Stream) {
 // UnmarshalReservedResource reads a value of the 'reserved_resource' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalReservedResource(source interface{}) (object *ReservedResource, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/resource_quota_client.go
+++ b/accountsmgmt/v1/resource_quota_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *ResourceQuotaDeleteRequest) SendContext(ctx context.Context) (result *R
 	result = &ResourceQuotaDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *ResourceQuotaGetRequest) SendContext(ctx context.Context) (result *Reso
 	result = &ResourceQuotaGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readResourceQuotaGetResponse(result, response.Body)
+	err = readResourceQuotaGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *ResourceQuotaUpdateRequest) SendContext(ctx context.Context) (result *R
 	result = &ResourceQuotaUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readResourceQuotaUpdateResponse(result, response.Body)
+	err = readResourceQuotaUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/resource_quota_type_json.go
+++ b/accountsmgmt/v1/resource_quota_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -126,9 +125,6 @@ func writeResourceQuota(object *ResourceQuota, stream *jsoniter.Stream) {
 // UnmarshalResourceQuota reads a value of the 'resource_quota' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalResourceQuota(source interface{}) (object *ResourceQuota, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/resource_quotas_client.go
+++ b/accountsmgmt/v1/resource_quotas_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *ResourceQuotasAddRequest) SendContext(ctx context.Context) (result *Res
 	result = &ResourceQuotasAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readResourceQuotasAddResponse(result, response.Body)
+	err = readResourceQuotasAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -315,15 +323,21 @@ func (r *ResourceQuotasListRequest) SendContext(ctx context.Context) (result *Re
 	result = &ResourceQuotasListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readResourceQuotasListResponse(result, response.Body)
+	err = readResourceQuotasListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/resource_type_json.go
+++ b/accountsmgmt/v1/resource_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -125,9 +124,6 @@ func writeResource(object *Resource, stream *jsoniter.Stream) {
 // UnmarshalResource reads a value of the 'resource' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalResource(source interface{}) (object *Resource, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/role_binding_client.go
+++ b/accountsmgmt/v1/role_binding_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *RoleBindingDeleteRequest) SendContext(ctx context.Context) (result *Rol
 	result = &RoleBindingDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *RoleBindingGetRequest) SendContext(ctx context.Context) (result *RoleBi
 	result = &RoleBindingGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRoleBindingGetResponse(result, response.Body)
+	err = readRoleBindingGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *RoleBindingUpdateRequest) SendContext(ctx context.Context) (result *Rol
 	result = &RoleBindingUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRoleBindingUpdateResponse(result, response.Body)
+	err = readRoleBindingUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/role_binding_type_json.go
+++ b/accountsmgmt/v1/role_binding_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -180,9 +179,6 @@ func writeRoleBinding(object *RoleBinding, stream *jsoniter.Stream) {
 // UnmarshalRoleBinding reads a value of the 'role_binding' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalRoleBinding(source interface{}) (object *RoleBinding, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/role_bindings_client.go
+++ b/accountsmgmt/v1/role_bindings_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *RoleBindingsAddRequest) SendContext(ctx context.Context) (result *RoleB
 	result = &RoleBindingsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRoleBindingsAddResponse(result, response.Body)
+	err = readRoleBindingsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -315,15 +323,21 @@ func (r *RoleBindingsListRequest) SendContext(ctx context.Context) (result *Role
 	result = &RoleBindingsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRoleBindingsListResponse(result, response.Body)
+	err = readRoleBindingsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/role_client.go
+++ b/accountsmgmt/v1/role_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *RoleDeleteRequest) SendContext(ctx context.Context) (result *RoleDelete
 	result = &RoleDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *RoleGetRequest) SendContext(ctx context.Context) (result *RoleGetRespon
 	result = &RoleGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRoleGetResponse(result, response.Body)
+	err = readRoleGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *RoleUpdateRequest) SendContext(ctx context.Context) (result *RoleUpdate
 	result = &RoleUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRoleUpdateResponse(result, response.Body)
+	err = readRoleUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/role_type_json.go
+++ b/accountsmgmt/v1/role_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeRole(object *Role, stream *jsoniter.Stream) {
 // UnmarshalRole reads a value of the 'role' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalRole(source interface{}) (object *Role, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/roles_client.go
+++ b/accountsmgmt/v1/roles_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *RolesAddRequest) SendContext(ctx context.Context) (result *RolesAddResp
 	result = &RolesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRolesAddResponse(result, response.Body)
+	err = readRolesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -315,15 +323,21 @@ func (r *RolesListRequest) SendContext(ctx context.Context) (result *RolesListRe
 	result = &RolesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readRolesListResponse(result, response.Body)
+	err = readRolesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/sku_client.go
+++ b/accountsmgmt/v1/sku_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *SKUGetRequest) SendContext(ctx context.Context) (result *SKUGetResponse
 	result = &SKUGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSKUGetResponse(result, response.Body)
+	err = readSKUGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/sku_rule_client.go
+++ b/accountsmgmt/v1/sku_rule_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *SkuRuleGetRequest) SendContext(ctx context.Context) (result *SkuRuleGet
 	result = &SkuRuleGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSkuRuleGetResponse(result, response.Body)
+	err = readSkuRuleGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/sku_rule_type_json.go
+++ b/accountsmgmt/v1/sku_rule_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -98,9 +97,6 @@ func writeSkuRule(object *SkuRule, stream *jsoniter.Stream) {
 // UnmarshalSkuRule reads a value of the 'sku_rule' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSkuRule(source interface{}) (object *SkuRule, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/sku_rules_client.go
+++ b/accountsmgmt/v1/sku_rules_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -167,15 +169,21 @@ func (r *SkuRulesListRequest) SendContext(ctx context.Context) (result *SkuRules
 	result = &SkuRulesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSkuRulesListResponse(result, response.Body)
+	err = readSkuRulesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/sku_type_json.go
+++ b/accountsmgmt/v1/sku_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -116,9 +115,6 @@ func writeSKU(object *SKU, stream *jsoniter.Stream) {
 // UnmarshalSKU reads a value of the 'SKU' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSKU(source interface{}) (object *SKU, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/skus_client.go
+++ b/accountsmgmt/v1/skus_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -167,15 +169,21 @@ func (r *SKUSListRequest) SendContext(ctx context.Context) (result *SKUSListResp
 	result = &SKUSListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSKUSListResponse(result, response.Body)
+	err = readSKUSListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/subscription_client.go
+++ b/accountsmgmt/v1/subscription_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -284,8 +286,14 @@ func (r *SubscriptionDeleteRequest) SendContext(ctx context.Context) (result *Su
 	result = &SubscriptionDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -378,15 +386,21 @@ func (r *SubscriptionGetRequest) SendContext(ctx context.Context) (result *Subsc
 	result = &SubscriptionGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSubscriptionGetResponse(result, response.Body)
+	err = readSubscriptionGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -514,15 +528,21 @@ func (r *SubscriptionUpdateRequest) SendContext(ctx context.Context) (result *Su
 	result = &SubscriptionUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSubscriptionUpdateResponse(result, response.Body)
+	err = readSubscriptionUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/subscription_metrics_type_json.go
+++ b/accountsmgmt/v1/subscription_metrics_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -246,9 +245,6 @@ func writeSubscriptionMetrics(object *SubscriptionMetrics, stream *jsoniter.Stre
 // UnmarshalSubscriptionMetrics reads a value of the 'subscription_metrics' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSubscriptionMetrics(source interface{}) (object *SubscriptionMetrics, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/subscription_notify_client.go
+++ b/accountsmgmt/v1/subscription_notify_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *SubscriptionNotifyAddRequest) SendContext(ctx context.Context) (result 
 	result = &SubscriptionNotifyAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSubscriptionNotifyAddResponse(result, response.Body)
+	err = readSubscriptionNotifyAddResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/subscription_notify_type_json.go
+++ b/accountsmgmt/v1/subscription_notify_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -129,9 +128,6 @@ func writeSubscriptionNotify(object *SubscriptionNotify, stream *jsoniter.Stream
 // UnmarshalSubscriptionNotify reads a value of the 'subscription_notify' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSubscriptionNotify(source interface{}) (object *SubscriptionNotify, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/subscription_registration_type_json.go
+++ b/accountsmgmt/v1/subscription_registration_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -93,9 +92,6 @@ func writeSubscriptionRegistration(object *SubscriptionRegistration, stream *jso
 // UnmarshalSubscriptionRegistration reads a value of the 'subscription_registration' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSubscriptionRegistration(source interface{}) (object *SubscriptionRegistration, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/subscription_reserved_resource_client.go
+++ b/accountsmgmt/v1/subscription_reserved_resource_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *SubscriptionReservedResourceGetRequest) SendContext(ctx context.Context
 	result = &SubscriptionReservedResourceGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSubscriptionReservedResourceGetResponse(result, response.Body)
+	err = readSubscriptionReservedResourceGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/subscription_reserved_resources_client.go
+++ b/accountsmgmt/v1/subscription_reserved_resources_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -144,15 +146,21 @@ func (r *SubscriptionReservedResourcesListRequest) SendContext(ctx context.Conte
 	result = &SubscriptionReservedResourcesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSubscriptionReservedResourcesListResponse(result, response.Body)
+	err = readSubscriptionReservedResourcesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/subscription_type_json.go
+++ b/accountsmgmt/v1/subscription_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -369,9 +368,6 @@ func writeSubscription(object *Subscription, stream *jsoniter.Stream) {
 // UnmarshalSubscription reads a value of the 'subscription' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSubscription(source interface{}) (object *Subscription, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/subscriptions_client.go
+++ b/accountsmgmt/v1/subscriptions_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -271,15 +273,21 @@ func (r *SubscriptionsListRequest) SendContext(ctx context.Context) (result *Sub
 	result = &SubscriptionsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSubscriptionsListResponse(result, response.Body)
+	err = readSubscriptionsListResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -478,15 +486,21 @@ func (r *SubscriptionsPostRequest) SendContext(ctx context.Context) (result *Sub
 	result = &SubscriptionsPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSubscriptionsPostResponse(result, response.Body)
+	err = readSubscriptionsPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/summary_dashboard_client.go
+++ b/accountsmgmt/v1/summary_dashboard_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *SummaryDashboardGetRequest) SendContext(ctx context.Context) (result *S
 	result = &SummaryDashboardGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSummaryDashboardGetResponse(result, response.Body)
+	err = readSummaryDashboardGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/summary_dashboard_type_json.go
+++ b/accountsmgmt/v1/summary_dashboard_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeSummaryDashboard(object *SummaryDashboard, stream *jsoniter.Stream) {
 // UnmarshalSummaryDashboard reads a value of the 'summary_dashboard' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSummaryDashboard(source interface{}) (object *SummaryDashboard, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/summary_metrics_type_json.go
+++ b/accountsmgmt/v1/summary_metrics_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeSummaryMetrics(object *SummaryMetrics, stream *jsoniter.Stream) {
 // UnmarshalSummaryMetrics reads a value of the 'summary_metrics' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSummaryMetrics(source interface{}) (object *SummaryMetrics, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/summary_sample_type_json.go
+++ b/accountsmgmt/v1/summary_sample_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeSummarySample(object *SummarySample, stream *jsoniter.Stream) {
 // UnmarshalSummarySample reads a value of the 'summary_sample' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSummarySample(source interface{}) (object *SummarySample, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/support_case_client.go
+++ b/accountsmgmt/v1/support_case_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -108,8 +110,14 @@ func (r *SupportCaseDeleteRequest) SendContext(ctx context.Context) (result *Sup
 	result = &SupportCaseDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}

--- a/accountsmgmt/v1/support_case_request_type_json.go
+++ b/accountsmgmt/v1/support_case_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -134,9 +133,6 @@ func writeSupportCaseRequest(object *SupportCaseRequest, stream *jsoniter.Stream
 // UnmarshalSupportCaseRequest reads a value of the 'support_case_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSupportCaseRequest(source interface{}) (object *SupportCaseRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/support_case_response_type_json.go
+++ b/accountsmgmt/v1/support_case_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -152,9 +151,6 @@ func writeSupportCaseResponse(object *SupportCaseResponse, stream *jsoniter.Stre
 // UnmarshalSupportCaseResponse reads a value of the 'support_case_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSupportCaseResponse(source interface{}) (object *SupportCaseResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/support_cases_client.go
+++ b/accountsmgmt/v1/support_cases_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -136,15 +138,21 @@ func (r *SupportCasesPostRequest) SendContext(ctx context.Context) (result *Supp
 	result = &SupportCasesPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSupportCasesPostResponse(result, response.Body)
+	err = readSupportCasesPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/template_parameter_type_json.go
+++ b/accountsmgmt/v1/template_parameter_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeTemplateParameter(object *TemplateParameter, stream *jsoniter.Stream) 
 // UnmarshalTemplateParameter reads a value of the 'template_parameter' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalTemplateParameter(source interface{}) (object *TemplateParameter, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/token_authorization_client.go
+++ b/accountsmgmt/v1/token_authorization_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *TokenAuthorizationPostRequest) SendContext(ctx context.Context) (result
 	result = &TokenAuthorizationPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readTokenAuthorizationPostResponse(result, response.Body)
+	err = readTokenAuthorizationPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/accountsmgmt/v1/token_authorization_request_type_json.go
+++ b/accountsmgmt/v1/token_authorization_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeTokenAuthorizationRequest(object *TokenAuthorizationRequest, stream *j
 // UnmarshalTokenAuthorizationRequest reads a value of the 'token_authorization_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalTokenAuthorizationRequest(source interface{}) (object *TokenAuthorizationRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/token_authorization_response_type_json.go
+++ b/accountsmgmt/v1/token_authorization_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeTokenAuthorizationResponse(object *TokenAuthorizationResponse, stream 
 // UnmarshalTokenAuthorizationResponse reads a value of the 'token_authorization_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalTokenAuthorizationResponse(source interface{}) (object *TokenAuthorizationResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/accountsmgmt/v1/value_unit_type_json.go
+++ b/accountsmgmt/v1/value_unit_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeValueUnit(object *ValueUnit, stream *jsoniter.Stream) {
 // UnmarshalValueUnit reads a value of the 'value_unit' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalValueUnit(source interface{}) (object *ValueUnit, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/access_review_client.go
+++ b/authorizations/v1/access_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *AccessReviewPostRequest) SendContext(ctx context.Context) (result *Acce
 	result = &AccessReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAccessReviewPostResponse(result, response.Body)
+	err = readAccessReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/access_review_request_type_json.go
+++ b/authorizations/v1/access_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -111,9 +110,6 @@ func writeAccessReviewRequest(object *AccessReviewRequest, stream *jsoniter.Stre
 // UnmarshalAccessReviewRequest reads a value of the 'access_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAccessReviewRequest(source interface{}) (object *AccessReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/access_review_response_type_json.go
+++ b/authorizations/v1/access_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -120,9 +119,6 @@ func writeAccessReviewResponse(object *AccessReviewResponse, stream *jsoniter.St
 // UnmarshalAccessReviewResponse reads a value of the 'access_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAccessReviewResponse(source interface{}) (object *AccessReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/capability_review_client.go
+++ b/authorizations/v1/capability_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *CapabilityReviewPostRequest) SendContext(ctx context.Context) (result *
 	result = &CapabilityReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCapabilityReviewPostResponse(result, response.Body)
+	err = readCapabilityReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/capability_review_request_type_json.go
+++ b/authorizations/v1/capability_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -111,9 +110,6 @@ func writeCapabilityReviewRequest(object *CapabilityReviewRequest, stream *jsoni
 // UnmarshalCapabilityReviewRequest reads a value of the 'capability_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCapabilityReviewRequest(source interface{}) (object *CapabilityReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/capability_review_response_type_json.go
+++ b/authorizations/v1/capability_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeCapabilityReviewResponse(object *CapabilityReviewResponse, stream *jso
 // UnmarshalCapabilityReviewResponse reads a value of the 'capability_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCapabilityReviewResponse(source interface{}) (object *CapabilityReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/export_control_review_client.go
+++ b/authorizations/v1/export_control_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *ExportControlReviewPostRequest) SendContext(ctx context.Context) (resul
 	result = &ExportControlReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readExportControlReviewPostResponse(result, response.Body)
+	err = readExportControlReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/export_control_review_request_type_json.go
+++ b/authorizations/v1/export_control_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeExportControlReviewRequest(object *ExportControlReviewRequest, stream 
 // UnmarshalExportControlReviewRequest reads a value of the 'export_control_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalExportControlReviewRequest(source interface{}) (object *ExportControlReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/export_control_review_response_type_json.go
+++ b/authorizations/v1/export_control_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeExportControlReviewResponse(object *ExportControlReviewResponse, strea
 // UnmarshalExportControlReviewResponse reads a value of the 'export_control_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalExportControlReviewResponse(source interface{}) (object *ExportControlReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/feature_review_request_type_json.go
+++ b/authorizations/v1/feature_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeFeatureReviewRequest(object *FeatureReviewRequest, stream *jsoniter.St
 // UnmarshalFeatureReviewRequest reads a value of the 'feature_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalFeatureReviewRequest(source interface{}) (object *FeatureReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/feature_review_response_type_json.go
+++ b/authorizations/v1/feature_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeFeatureReviewResponse(object *FeatureReviewResponse, stream *jsoniter.
 // UnmarshalFeatureReviewResponse reads a value of the 'feature_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalFeatureReviewResponse(source interface{}) (object *FeatureReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/metadata_client.go
+++ b/authorizations/v1/metadata_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -89,15 +91,20 @@ func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResp
 		status: response.StatusCode,
 		header: response.Header,
 	}
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	result.body, err = UnmarshalMetadata(response.Body)
+	result.body, err = UnmarshalMetadata(reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/resource_review_client.go
+++ b/authorizations/v1/resource_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -126,15 +128,21 @@ func (r *ResourceReviewPostRequest) SendContext(ctx context.Context) (result *Re
 	result = &ResourceReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readResourceReviewPostResponse(result, response.Body)
+	err = readResourceReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/resource_review_request_type_json.go
+++ b/authorizations/v1/resource_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -84,9 +83,6 @@ func writeResourceReviewRequest(object *ResourceReviewRequest, stream *jsoniter.
 // UnmarshalResourceReviewRequest reads a value of the 'resource_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalResourceReviewRequest(source interface{}) (object *ResourceReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/resource_review_type_json.go
+++ b/authorizations/v1/resource_review_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -111,9 +110,6 @@ func writeResourceReview(object *ResourceReview, stream *jsoniter.Stream) {
 // UnmarshalResourceReview reads a value of the 'resource_review' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalResourceReview(source interface{}) (object *ResourceReview, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/self_access_review_client.go
+++ b/authorizations/v1/self_access_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *SelfAccessReviewPostRequest) SendContext(ctx context.Context) (result *
 	result = &SelfAccessReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSelfAccessReviewPostResponse(result, response.Body)
+	err = readSelfAccessReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/self_access_review_request_type_json.go
+++ b/authorizations/v1/self_access_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -102,9 +101,6 @@ func writeSelfAccessReviewRequest(object *SelfAccessReviewRequest, stream *jsoni
 // UnmarshalSelfAccessReviewRequest reads a value of the 'self_access_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSelfAccessReviewRequest(source interface{}) (object *SelfAccessReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/self_access_review_response_type_json.go
+++ b/authorizations/v1/self_access_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -111,9 +110,6 @@ func writeSelfAccessReviewResponse(object *SelfAccessReviewResponse, stream *jso
 // UnmarshalSelfAccessReviewResponse reads a value of the 'self_access_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSelfAccessReviewResponse(source interface{}) (object *SelfAccessReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/self_capability_review_client.go
+++ b/authorizations/v1/self_capability_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *SelfCapabilityReviewPostRequest) SendContext(ctx context.Context) (resu
 	result = &SelfCapabilityReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSelfCapabilityReviewPostResponse(result, response.Body)
+	err = readSelfCapabilityReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/self_capability_review_request_type_json.go
+++ b/authorizations/v1/self_capability_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -111,9 +110,6 @@ func writeSelfCapabilityReviewRequest(object *SelfCapabilityReviewRequest, strea
 // UnmarshalSelfCapabilityReviewRequest reads a value of the 'self_capability_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSelfCapabilityReviewRequest(source interface{}) (object *SelfCapabilityReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/self_capability_review_response_type_json.go
+++ b/authorizations/v1/self_capability_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeSelfCapabilityReviewResponse(object *SelfCapabilityReviewResponse, str
 // UnmarshalSelfCapabilityReviewResponse reads a value of the 'self_capability_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSelfCapabilityReviewResponse(source interface{}) (object *SelfCapabilityReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/self_feature_review_client.go
+++ b/authorizations/v1/self_feature_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -125,15 +127,21 @@ func (r *SelfFeatureReviewPostRequest) SendContext(ctx context.Context) (result 
 	result = &SelfFeatureReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSelfFeatureReviewPostResponse(result, response.Body)
+	err = readSelfFeatureReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/self_feature_review_request_type_json.go
+++ b/authorizations/v1/self_feature_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeSelfFeatureReviewRequest(object *SelfFeatureReviewRequest, stream *jso
 // UnmarshalSelfFeatureReviewRequest reads a value of the 'self_feature_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSelfFeatureReviewRequest(source interface{}) (object *SelfFeatureReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/self_feature_review_response_type_json.go
+++ b/authorizations/v1/self_feature_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeSelfFeatureReviewResponse(object *SelfFeatureReviewResponse, stream *j
 // UnmarshalSelfFeatureReviewResponse reads a value of the 'self_feature_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSelfFeatureReviewResponse(source interface{}) (object *SelfFeatureReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/self_terms_review_client.go
+++ b/authorizations/v1/self_terms_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -126,15 +128,21 @@ func (r *SelfTermsReviewPostRequest) SendContext(ctx context.Context) (result *S
 	result = &SelfTermsReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSelfTermsReviewPostResponse(result, response.Body)
+	err = readSelfTermsReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/self_terms_review_request_type_json.go
+++ b/authorizations/v1/self_terms_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeSelfTermsReviewRequest(object *SelfTermsReviewRequest, stream *jsonite
 // UnmarshalSelfTermsReviewRequest reads a value of the 'self_terms_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSelfTermsReviewRequest(source interface{}) (object *SelfTermsReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/terms_review_client.go
+++ b/authorizations/v1/terms_review_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -126,15 +128,21 @@ func (r *TermsReviewPostRequest) SendContext(ctx context.Context) (result *Terms
 	result = &TermsReviewPostResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readTermsReviewPostResponse(result, response.Body)
+	err = readTermsReviewPostResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/authorizations/v1/terms_review_request_type_json.go
+++ b/authorizations/v1/terms_review_request_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -84,9 +83,6 @@ func writeTermsReviewRequest(object *TermsReviewRequest, stream *jsoniter.Stream
 // UnmarshalTermsReviewRequest reads a value of the 'terms_review_request' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalTermsReviewRequest(source interface{}) (object *TermsReviewRequest, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/authorizations/v1/terms_review_response_type_json.go
+++ b/authorizations/v1/terms_review_response_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/authorizations/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -93,9 +92,6 @@ func writeTermsReviewResponse(object *TermsReviewResponse, stream *jsoniter.Stre
 // UnmarshalTermsReviewResponse reads a value of the 'terms_review_response' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalTermsReviewResponse(source interface{}) (object *TermsReviewResponse, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_client.go
+++ b/clustersmgmt/v1/add_on_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -263,8 +265,14 @@ func (r *AddOnDeleteRequest) SendContext(ctx context.Context) (result *AddOnDele
 	result = &AddOnDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -357,15 +365,21 @@ func (r *AddOnGetRequest) SendContext(ctx context.Context) (result *AddOnGetResp
 	result = &AddOnGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnGetResponse(result, response.Body)
+	err = readAddOnGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -493,15 +507,21 @@ func (r *AddOnUpdateRequest) SendContext(ctx context.Context) (result *AddOnUpda
 	result = &AddOnUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnUpdateResponse(result, response.Body)
+	err = readAddOnUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/add_on_installation_client.go
+++ b/clustersmgmt/v1/add_on_installation_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *AddOnInstallationDeleteRequest) SendContext(ctx context.Context) (resul
 	result = &AddOnInstallationDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *AddOnInstallationGetRequest) SendContext(ctx context.Context) (result *
 	result = &AddOnInstallationGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnInstallationGetResponse(result, response.Body)
+	err = readAddOnInstallationGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *AddOnInstallationUpdateRequest) SendContext(ctx context.Context) (resul
 	result = &AddOnInstallationUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnInstallationUpdateResponse(result, response.Body)
+	err = readAddOnInstallationUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/add_on_installation_parameter_type_json.go
+++ b/clustersmgmt/v1/add_on_installation_parameter_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeAddOnInstallationParameter(object *AddOnInstallationParameter, stream 
 // UnmarshalAddOnInstallationParameter reads a value of the 'add_on_installation_parameter' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnInstallationParameter(source interface{}) (object *AddOnInstallationParameter, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_installation_type_json.go
+++ b/clustersmgmt/v1/add_on_installation_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -156,9 +155,6 @@ func writeAddOnInstallation(object *AddOnInstallation, stream *jsoniter.Stream) 
 // UnmarshalAddOnInstallation reads a value of the 'add_on_installation' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnInstallation(source interface{}) (object *AddOnInstallation, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_installations_client.go
+++ b/clustersmgmt/v1/add_on_installations_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *AddOnInstallationsAddRequest) SendContext(ctx context.Context) (result 
 	result = &AddOnInstallationsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnInstallationsAddResponse(result, response.Body)
+	err = readAddOnInstallationsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -339,15 +347,21 @@ func (r *AddOnInstallationsListRequest) SendContext(ctx context.Context) (result
 	result = &AddOnInstallationsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnInstallationsListResponse(result, response.Body)
+	err = readAddOnInstallationsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/add_on_parameter_option_type_json.go
+++ b/clustersmgmt/v1/add_on_parameter_option_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeAddOnParameterOption(object *AddOnParameterOption, stream *jsoniter.St
 // UnmarshalAddOnParameterOption reads a value of the 'add_on_parameter_option' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnParameterOption(source interface{}) (object *AddOnParameterOption, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_parameter_type_json.go
+++ b/clustersmgmt/v1/add_on_parameter_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -170,9 +169,6 @@ func writeAddOnParameter(object *AddOnParameter, stream *jsoniter.Stream) {
 // UnmarshalAddOnParameter reads a value of the 'add_on_parameter' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnParameter(source interface{}) (object *AddOnParameter, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_requirement_status_type_json.go
+++ b/clustersmgmt/v1/add_on_requirement_status_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeAddOnRequirementStatus(object *AddOnRequirementStatus, stream *jsonite
 // UnmarshalAddOnRequirementStatus reads a value of the 'add_on_requirement_status' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnRequirementStatus(source interface{}) (object *AddOnRequirementStatus, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_requirement_type_json.go
+++ b/clustersmgmt/v1/add_on_requirement_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -114,9 +113,6 @@ func writeAddOnRequirement(object *AddOnRequirement, stream *jsoniter.Stream) {
 // UnmarshalAddOnRequirement reads a value of the 'add_on_requirement' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnRequirement(source interface{}) (object *AddOnRequirement, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_sub_operator_type_json.go
+++ b/clustersmgmt/v1/add_on_sub_operator_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeAddOnSubOperator(object *AddOnSubOperator, stream *jsoniter.Stream) {
 // UnmarshalAddOnSubOperator reads a value of the 'add_on_sub_operator' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnSubOperator(source interface{}) (object *AddOnSubOperator, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_type_json.go
+++ b/clustersmgmt/v1/add_on_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -227,9 +226,6 @@ func writeAddOn(object *AddOn, stream *jsoniter.Stream) {
 // UnmarshalAddOn reads a value of the 'add_on' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOn(source interface{}) (object *AddOn, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_version_client.go
+++ b/clustersmgmt/v1/add_on_version_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *AddOnVersionDeleteRequest) SendContext(ctx context.Context) (result *Ad
 	result = &AddOnVersionDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *AddOnVersionGetRequest) SendContext(ctx context.Context) (result *AddOn
 	result = &AddOnVersionGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnVersionGetResponse(result, response.Body)
+	err = readAddOnVersionGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *AddOnVersionUpdateRequest) SendContext(ctx context.Context) (result *Ad
 	result = &AddOnVersionUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnVersionUpdateResponse(result, response.Body)
+	err = readAddOnVersionUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/add_on_version_type_json.go
+++ b/clustersmgmt/v1/add_on_version_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -137,9 +136,6 @@ func writeAddOnVersion(object *AddOnVersion, stream *jsoniter.Stream) {
 // UnmarshalAddOnVersion reads a value of the 'add_on_version' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAddOnVersion(source interface{}) (object *AddOnVersion, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/add_on_versions_client.go
+++ b/clustersmgmt/v1/add_on_versions_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *AddOnVersionsAddRequest) SendContext(ctx context.Context) (result *AddO
 	result = &AddOnVersionsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnVersionsAddResponse(result, response.Body)
+	err = readAddOnVersionsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -339,15 +347,21 @@ func (r *AddOnVersionsListRequest) SendContext(ctx context.Context) (result *Add
 	result = &AddOnVersionsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnVersionsListResponse(result, response.Body)
+	err = readAddOnVersionsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/add_ons_client.go
+++ b/clustersmgmt/v1/add_ons_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *AddOnsAddRequest) SendContext(ctx context.Context) (result *AddOnsAddRe
 	result = &AddOnsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnsAddResponse(result, response.Body)
+	err = readAddOnsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -339,15 +347,21 @@ func (r *AddOnsListRequest) SendContext(ctx context.Context) (result *AddOnsList
 	result = &AddOnsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddOnsListResponse(result, response.Body)
+	err = readAddOnsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/addon_inquiries_client.go
+++ b/clustersmgmt/v1/addon_inquiries_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -192,15 +194,21 @@ func (r *AddonInquiriesListRequest) SendContext(ctx context.Context) (result *Ad
 	result = &AddonInquiriesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddonInquiriesListResponse(result, response.Body)
+	err = readAddonInquiriesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/addon_inquiry_client.go
+++ b/clustersmgmt/v1/addon_inquiry_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *AddonInquiryGetRequest) SendContext(ctx context.Context) (result *Addon
 	result = &AddonInquiryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAddonInquiryGetResponse(result, response.Body)
+	err = readAddonInquiryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/admin_credentials_type_json.go
+++ b/clustersmgmt/v1/admin_credentials_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeAdminCredentials(object *AdminCredentials, stream *jsoniter.Stream) {
 // UnmarshalAdminCredentials reads a value of the 'admin_credentials' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAdminCredentials(source interface{}) (object *AdminCredentials, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/alert_info_type_json.go
+++ b/clustersmgmt/v1/alert_info_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeAlertInfo(object *AlertInfo, stream *jsoniter.Stream) {
 // UnmarshalAlertInfo reads a value of the 'alert_info' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAlertInfo(source interface{}) (object *AlertInfo, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/alerts_info_type_json.go
+++ b/clustersmgmt/v1/alerts_info_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeAlertsInfo(object *AlertsInfo, stream *jsoniter.Stream) {
 // UnmarshalAlertsInfo reads a value of the 'alerts_info' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAlertsInfo(source interface{}) (object *AlertsInfo, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/alerts_metric_query_client.go
+++ b/clustersmgmt/v1/alerts_metric_query_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *AlertsMetricQueryGetRequest) SendContext(ctx context.Context) (result *
 	result = &AlertsMetricQueryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAlertsMetricQueryGetResponse(result, response.Body)
+	err = readAlertsMetricQueryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/available_regions_client.go
+++ b/clustersmgmt/v1/available_regions_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -156,15 +158,21 @@ func (r *AvailableRegionsSearchRequest) SendContext(ctx context.Context) (result
 	result = &AvailableRegionsSearchResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAvailableRegionsSearchResponse(result, response.Body)
+	err = readAvailableRegionsSearchResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/available_regions_inquiry_client.go
+++ b/clustersmgmt/v1/available_regions_inquiry_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -155,15 +157,21 @@ func (r *AvailableRegionsInquirySearchRequest) SendContext(ctx context.Context) 
 	result = &AvailableRegionsInquirySearchResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAvailableRegionsInquirySearchResponse(result, response.Body)
+	err = readAvailableRegionsInquirySearchResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/aws_flavour_type_json.go
+++ b/clustersmgmt/v1/aws_flavour_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -102,9 +101,6 @@ func writeAWSFlavour(object *AWSFlavour, stream *jsoniter.Stream) {
 // UnmarshalAWSFlavour reads a value of the 'AWS_flavour' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAWSFlavour(source interface{}) (object *AWSFlavour, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/aws_infrastructure_access_role_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *AWSInfrastructureAccessRoleGetRequest) SendContext(ctx context.Context)
 	result = &AWSInfrastructureAccessRoleGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAWSInfrastructureAccessRoleGetResponse(result, response.Body)
+	err = readAWSInfrastructureAccessRoleGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grant_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grant_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -240,8 +242,14 @@ func (r *AWSInfrastructureAccessRoleGrantDeleteRequest) SendContext(ctx context.
 	result = &AWSInfrastructureAccessRoleGrantDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -334,15 +342,21 @@ func (r *AWSInfrastructureAccessRoleGrantGetRequest) SendContext(ctx context.Con
 	result = &AWSInfrastructureAccessRoleGrantGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAWSInfrastructureAccessRoleGrantGetResponse(result, response.Body)
+	err = readAWSInfrastructureAccessRoleGrantGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grant_type_json.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grant_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -116,9 +115,6 @@ func writeAWSInfrastructureAccessRoleGrant(object *AWSInfrastructureAccessRoleGr
 // UnmarshalAWSInfrastructureAccessRoleGrant reads a value of the 'AWS_infrastructure_access_role_grant' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAWSInfrastructureAccessRoleGrant(source interface{}) (object *AWSInfrastructureAccessRoleGrant, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grants_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grants_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -147,15 +149,21 @@ func (r *AWSInfrastructureAccessRoleGrantsAddRequest) SendContext(ctx context.Co
 	result = &AWSInfrastructureAccessRoleGrantsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAWSInfrastructureAccessRoleGrantsAddResponse(result, response.Body)
+	err = readAWSInfrastructureAccessRoleGrantsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -340,15 +348,21 @@ func (r *AWSInfrastructureAccessRoleGrantsListRequest) SendContext(ctx context.C
 	result = &AWSInfrastructureAccessRoleGrantsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAWSInfrastructureAccessRoleGrantsListResponse(result, response.Body)
+	err = readAWSInfrastructureAccessRoleGrantsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/aws_infrastructure_access_role_type_json.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -98,9 +97,6 @@ func writeAWSInfrastructureAccessRole(object *AWSInfrastructureAccessRole, strea
 // UnmarshalAWSInfrastructureAccessRole reads a value of the 'AWS_infrastructure_access_role' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAWSInfrastructureAccessRole(source interface{}) (object *AWSInfrastructureAccessRole, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -191,15 +193,21 @@ func (r *AWSInfrastructureAccessRolesListRequest) SendContext(ctx context.Contex
 	result = &AWSInfrastructureAccessRolesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readAWSInfrastructureAccessRolesListResponse(result, response.Body)
+	err = readAWSInfrastructureAccessRolesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/aws_machine_pool_type_json.go
+++ b/clustersmgmt/v1/aws_machine_pool_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeAWSMachinePool(object *AWSMachinePool, stream *jsoniter.Stream) {
 // UnmarshalAWSMachinePool reads a value of the 'AWS_machine_pool' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAWSMachinePool(source interface{}) (object *AWSMachinePool, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/aws_spot_market_options_type_json.go
+++ b/clustersmgmt/v1/aws_spot_market_options_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeAWSSpotMarketOptions(object *AWSSpotMarketOptions, stream *jsoniter.St
 // UnmarshalAWSSpotMarketOptions reads a value of the 'AWS_spot_market_options' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAWSSpotMarketOptions(source interface{}) (object *AWSSpotMarketOptions, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/aws_type_json.go
+++ b/clustersmgmt/v1/aws_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -141,9 +140,6 @@ func writeAWS(object *AWS, stream *jsoniter.Stream) {
 // UnmarshalAWS reads a value of the 'AWS' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAWS(source interface{}) (object *AWS, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/aws_volume_type_json.go
+++ b/clustersmgmt/v1/aws_volume_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeAWSVolume(object *AWSVolume, stream *jsoniter.Stream) {
 // UnmarshalAWSVolume reads a value of the 'AWS_volume' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalAWSVolume(source interface{}) (object *AWSVolume, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/ccs_type_json.go
+++ b/clustersmgmt/v1/ccs_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeCCS(object *CCS, stream *jsoniter.Stream) {
 // UnmarshalCCS reads a value of the 'CCS' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCCS(source interface{}) (object *CCS, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cloud_provider_client.go
+++ b/clustersmgmt/v1/cloud_provider_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -253,15 +255,21 @@ func (r *CloudProviderGetRequest) SendContext(ctx context.Context) (result *Clou
 	result = &CloudProviderGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCloudProviderGetResponse(result, response.Body)
+	err = readCloudProviderGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cloud_provider_data_type_json.go
+++ b/clustersmgmt/v1/cloud_provider_data_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -93,9 +92,6 @@ func writeCloudProviderData(object *CloudProviderData, stream *jsoniter.Stream) 
 // UnmarshalCloudProviderData reads a value of the 'cloud_provider_data' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCloudProviderData(source interface{}) (object *CloudProviderData, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cloud_provider_type_json.go
+++ b/clustersmgmt/v1/cloud_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeCloudProvider(object *CloudProvider, stream *jsoniter.Stream) {
 // UnmarshalCloudProvider reads a value of the 'cloud_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCloudProvider(source interface{}) (object *CloudProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cloud_providers_client.go
+++ b/clustersmgmt/v1/cloud_providers_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -191,15 +193,21 @@ func (r *CloudProvidersListRequest) SendContext(ctx context.Context) (result *Cl
 	result = &CloudProvidersListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCloudProvidersListResponse(result, response.Body)
+	err = readCloudProvidersListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cloud_region_client.go
+++ b/clustersmgmt/v1/cloud_region_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *CloudRegionGetRequest) SendContext(ctx context.Context) (result *CloudR
 	result = &CloudRegionGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCloudRegionGetResponse(result, response.Body)
+	err = readCloudRegionGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cloud_region_type_json.go
+++ b/clustersmgmt/v1/cloud_region_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -125,9 +124,6 @@ func writeCloudRegion(object *CloudRegion, stream *jsoniter.Stream) {
 // UnmarshalCloudRegion reads a value of the 'cloud_region' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCloudRegion(source interface{}) (object *CloudRegion, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cloud_regions_client.go
+++ b/clustersmgmt/v1/cloud_regions_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -150,15 +152,21 @@ func (r *CloudRegionsListRequest) SendContext(ctx context.Context) (result *Clou
 	result = &CloudRegionsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCloudRegionsListResponse(result, response.Body)
+	err = readCloudRegionsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cloud_vpc_type_json.go
+++ b/clustersmgmt/v1/cloud_vpc_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeCloudVPC(object *CloudVPC, stream *jsoniter.Stream) {
 // UnmarshalCloudVPC reads a value of the 'cloud_VPC' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCloudVPC(source interface{}) (object *CloudVPC, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_api_type_json.go
+++ b/clustersmgmt/v1/cluster_api_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeClusterAPI(object *ClusterAPI, stream *jsoniter.Stream) {
 // UnmarshalClusterAPI reads a value of the 'cluster_API' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterAPI(source interface{}) (object *ClusterAPI, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_client.go
+++ b/clustersmgmt/v1/cluster_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -478,8 +480,14 @@ func (r *ClusterDeleteRequest) SendContext(ctx context.Context) (result *Cluster
 	result = &ClusterDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -572,15 +580,21 @@ func (r *ClusterGetRequest) SendContext(ctx context.Context) (result *ClusterGet
 	result = &ClusterGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterGetResponse(result, response.Body)
+	err = readClusterGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -693,8 +707,14 @@ func (r *ClusterHibernateRequest) SendContext(ctx context.Context) (result *Clus
 	result = &ClusterHibernateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -787,8 +807,14 @@ func (r *ClusterResumeRequest) SendContext(ctx context.Context) (result *Cluster
 	result = &ClusterResumeResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -896,15 +922,21 @@ func (r *ClusterUpdateRequest) SendContext(ctx context.Context) (result *Cluster
 	result = &ClusterUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterUpdateResponse(result, response.Body)
+	err = readClusterUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cluster_console_type_json.go
+++ b/clustersmgmt/v1/cluster_console_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeClusterConsole(object *ClusterConsole, stream *jsoniter.Stream) {
 // UnmarshalClusterConsole reads a value of the 'cluster_console' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterConsole(source interface{}) (object *ClusterConsole, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_credentials_type_json.go
+++ b/clustersmgmt/v1/cluster_credentials_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -98,9 +97,6 @@ func writeClusterCredentials(object *ClusterCredentials, stream *jsoniter.Stream
 // UnmarshalClusterCredentials reads a value of the 'cluster_credentials' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterCredentials(source interface{}) (object *ClusterCredentials, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_deployment_type_json.go
+++ b/clustersmgmt/v1/cluster_deployment_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeClusterDeployment(object *ClusterDeployment, stream *jsoniter.Stream) 
 // UnmarshalClusterDeployment reads a value of the 'cluster_deployment' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterDeployment(source interface{}) (object *ClusterDeployment, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_nodes_type_json.go
+++ b/clustersmgmt/v1/cluster_nodes_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -141,9 +140,6 @@ func writeClusterNodes(object *ClusterNodes, stream *jsoniter.Stream) {
 // UnmarshalClusterNodes reads a value of the 'cluster_nodes' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterNodes(source interface{}) (object *ClusterNodes, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_operator_info_type_json.go
+++ b/clustersmgmt/v1/cluster_operator_info_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -94,9 +93,6 @@ func writeClusterOperatorInfo(object *ClusterOperatorInfo, stream *jsoniter.Stre
 // UnmarshalClusterOperatorInfo reads a value of the 'cluster_operator_info' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterOperatorInfo(source interface{}) (object *ClusterOperatorInfo, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_operators_info_type_json.go
+++ b/clustersmgmt/v1/cluster_operators_info_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeClusterOperatorsInfo(object *ClusterOperatorsInfo, stream *jsoniter.St
 // UnmarshalClusterOperatorsInfo reads a value of the 'cluster_operators_info' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterOperatorsInfo(source interface{}) (object *ClusterOperatorsInfo, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_operators_metric_query_client.go
+++ b/clustersmgmt/v1/cluster_operators_metric_query_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *ClusterOperatorsMetricQueryGetRequest) SendContext(ctx context.Context)
 	result = &ClusterOperatorsMetricQueryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterOperatorsMetricQueryGetResponse(result, response.Body)
+	err = readClusterOperatorsMetricQueryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cluster_registration_type_json.go
+++ b/clustersmgmt/v1/cluster_registration_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeClusterRegistration(object *ClusterRegistration, stream *jsoniter.Stre
 // UnmarshalClusterRegistration reads a value of the 'cluster_registration' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterRegistration(source interface{}) (object *ClusterRegistration, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_resources_client.go
+++ b/clustersmgmt/v1/cluster_resources_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *ClusterResourcesGetRequest) SendContext(ctx context.Context) (result *C
 	result = &ClusterResourcesGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterResourcesGetResponse(result, response.Body)
+	err = readClusterResourcesGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cluster_resources_type_json.go
+++ b/clustersmgmt/v1/cluster_resources_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 	"time"
 
@@ -120,9 +119,6 @@ func writeClusterResources(object *ClusterResources, stream *jsoniter.Stream) {
 // UnmarshalClusterResources reads a value of the 'cluster_resources' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterResources(source interface{}) (object *ClusterResources, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_status_client.go
+++ b/clustersmgmt/v1/cluster_status_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *ClusterStatusGetRequest) SendContext(ctx context.Context) (result *Clus
 	result = &ClusterStatusGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterStatusGetResponse(result, response.Body)
+	err = readClusterStatusGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cluster_status_type_json.go
+++ b/clustersmgmt/v1/cluster_status_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -134,9 +133,6 @@ func writeClusterStatus(object *ClusterStatus, stream *jsoniter.Stream) {
 // UnmarshalClusterStatus reads a value of the 'cluster_status' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalClusterStatus(source interface{}) (object *ClusterStatus, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cluster_type_json.go
+++ b/clustersmgmt/v1/cluster_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 	"time"
 
@@ -507,9 +506,6 @@ func writeCluster(object *Cluster, stream *jsoniter.Stream) {
 // UnmarshalCluster reads a value of the 'cluster' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCluster(source interface{}) (object *Cluster, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/clusterdeployment_client.go
+++ b/clustersmgmt/v1/clusterdeployment_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -108,8 +110,14 @@ func (r *ClusterdeploymentDeleteRequest) SendContext(ctx context.Context) (resul
 	result = &ClusterdeploymentDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}

--- a/clustersmgmt/v1/clusters_client.go
+++ b/clustersmgmt/v1/clusters_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -148,15 +150,21 @@ func (r *ClustersAddRequest) SendContext(ctx context.Context) (result *ClustersA
 	result = &ClustersAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClustersAddResponse(result, response.Body)
+	err = readClustersAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -342,15 +350,21 @@ func (r *ClustersListRequest) SendContext(ctx context.Context) (result *Clusters
 	result = &ClustersListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClustersListResponse(result, response.Body)
+	err = readClustersListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_client.go
+++ b/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *CPUTotalByNodeRolesOSMetricQueryGetRequest) SendContext(ctx context.Con
 	result = &CPUTotalByNodeRolesOSMetricQueryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCPUTotalByNodeRolesOSMetricQueryGetResponse(result, response.Body)
+	err = readCPUTotalByNodeRolesOSMetricQueryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/cpu_total_node_role_os_metric_node_type_json.go
+++ b/clustersmgmt/v1/cpu_total_node_role_os_metric_node_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -85,9 +84,6 @@ func writeCPUTotalNodeRoleOSMetricNode(object *CPUTotalNodeRoleOSMetricNode, str
 // UnmarshalCPUTotalNodeRoleOSMetricNode reads a value of the 'CPU_total_node_role_OS_metric_node' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCPUTotalNodeRoleOSMetricNode(source interface{}) (object *CPUTotalNodeRoleOSMetricNode, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/cpu_totals_node_role_os_metric_node_type_json.go
+++ b/clustersmgmt/v1/cpu_totals_node_role_os_metric_node_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeCPUTotalsNodeRoleOSMetricNode(object *CPUTotalsNodeRoleOSMetricNode, s
 // UnmarshalCPUTotalsNodeRoleOSMetricNode reads a value of the 'CPU_totals_node_role_OS_metric_node' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalCPUTotalsNodeRoleOSMetricNode(source interface{}) (object *CPUTotalsNodeRoleOSMetricNode, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/credentials_client.go
+++ b/clustersmgmt/v1/credentials_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *CredentialsGetRequest) SendContext(ctx context.Context) (result *Creden
 	result = &CredentialsGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readCredentialsGetResponse(result, response.Body)
+	err = readCredentialsGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/dns_type_json.go
+++ b/clustersmgmt/v1/dns_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeDNS(object *DNS, stream *jsoniter.Stream) {
 // UnmarshalDNS reads a value of the 'DNS' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalDNS(source interface{}) (object *DNS, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/encryption_key_type_json.go
+++ b/clustersmgmt/v1/encryption_key_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeEncryptionKey(object *EncryptionKey, stream *jsoniter.Stream) {
 // UnmarshalEncryptionKey reads a value of the 'encryption_key' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalEncryptionKey(source interface{}) (object *EncryptionKey, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/encryption_keys_inquiry_client.go
+++ b/clustersmgmt/v1/encryption_keys_inquiry_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -155,15 +157,21 @@ func (r *EncryptionKeysInquirySearchRequest) SendContext(ctx context.Context) (r
 	result = &EncryptionKeysInquirySearchResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readEncryptionKeysInquirySearchResponse(result, response.Body)
+	err = readEncryptionKeysInquirySearchResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/event_type_json.go
+++ b/clustersmgmt/v1/event_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -87,9 +86,6 @@ func writeEvent(object *Event, stream *jsoniter.Stream) {
 // UnmarshalEvent reads a value of the 'event' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalEvent(source interface{}) (object *Event, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/events_client.go
+++ b/clustersmgmt/v1/events_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -130,15 +132,21 @@ func (r *EventsAddRequest) SendContext(ctx context.Context) (result *EventsAddRe
 	result = &EventsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readEventsAddResponse(result, response.Body)
+	err = readEventsAddResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/external_configuration_client.go
+++ b/clustersmgmt/v1/external_configuration_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -251,15 +253,21 @@ func (r *ExternalConfigurationGetRequest) SendContext(ctx context.Context) (resu
 	result = &ExternalConfigurationGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readExternalConfigurationGetResponse(result, response.Body)
+	err = readExternalConfigurationGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/external_configuration_type_json.go
+++ b/clustersmgmt/v1/external_configuration_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -72,9 +71,6 @@ func writeExternalConfiguration(object *ExternalConfiguration, stream *jsoniter.
 // UnmarshalExternalConfiguration reads a value of the 'external_configuration' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalExternalConfiguration(source interface{}) (object *ExternalConfiguration, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/flavour_client.go
+++ b/clustersmgmt/v1/flavour_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -248,15 +250,21 @@ func (r *FlavourGetRequest) SendContext(ctx context.Context) (result *FlavourGet
 	result = &FlavourGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readFlavourGetResponse(result, response.Body)
+	err = readFlavourGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -384,15 +392,21 @@ func (r *FlavourUpdateRequest) SendContext(ctx context.Context) (result *Flavour
 	result = &FlavourUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readFlavourUpdateResponse(result, response.Body)
+	err = readFlavourUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/flavour_nodes_type_json.go
+++ b/clustersmgmt/v1/flavour_nodes_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeFlavourNodes(object *FlavourNodes, stream *jsoniter.Stream) {
 // UnmarshalFlavourNodes reads a value of the 'flavour_nodes' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalFlavourNodes(source interface{}) (object *FlavourNodes, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/flavour_type_json.go
+++ b/clustersmgmt/v1/flavour_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -116,9 +115,6 @@ func writeFlavour(object *Flavour, stream *jsoniter.Stream) {
 // UnmarshalFlavour reads a value of the 'flavour' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalFlavour(source interface{}) (object *Flavour, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/flavours_client.go
+++ b/clustersmgmt/v1/flavours_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *FlavoursAddRequest) SendContext(ctx context.Context) (result *FlavoursA
 	result = &FlavoursAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readFlavoursAddResponse(result, response.Body)
+	err = readFlavoursAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -339,15 +347,21 @@ func (r *FlavoursListRequest) SendContext(ctx context.Context) (result *Flavours
 	result = &FlavoursListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readFlavoursListResponse(result, response.Body)
+	err = readFlavoursListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/gcp_flavour_type_json.go
+++ b/clustersmgmt/v1/gcp_flavour_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeGCPFlavour(object *GCPFlavour, stream *jsoniter.Stream) {
 // UnmarshalGCPFlavour reads a value of the 'GCP_flavour' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalGCPFlavour(source interface{}) (object *GCPFlavour, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/gcp_network_type_json.go
+++ b/clustersmgmt/v1/gcp_network_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 // UnmarshalGCPNetwork reads a value of the 'GCP_network' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalGCPNetwork(source interface{}) (object *GCPNetwork, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/gcp_type_json.go
+++ b/clustersmgmt/v1/gcp_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -138,9 +137,6 @@ func writeGCP(object *GCP, stream *jsoniter.Stream) {
 // UnmarshalGCP reads a value of the 'GCP' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalGCP(source interface{}) (object *GCP, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/github_identity_provider_type_json.go
+++ b/clustersmgmt/v1/github_identity_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -102,9 +101,6 @@ func writeGithubIdentityProvider(object *GithubIdentityProvider, stream *jsonite
 // UnmarshalGithubIdentityProvider reads a value of the 'github_identity_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalGithubIdentityProvider(source interface{}) (object *GithubIdentityProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/gitlab_identity_provider_type_json.go
+++ b/clustersmgmt/v1/gitlab_identity_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -84,9 +83,6 @@ func writeGitlabIdentityProvider(object *GitlabIdentityProvider, stream *jsonite
 // UnmarshalGitlabIdentityProvider reads a value of the 'gitlab_identity_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalGitlabIdentityProvider(source interface{}) (object *GitlabIdentityProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/google_identity_provider_type_json.go
+++ b/clustersmgmt/v1/google_identity_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeGoogleIdentityProvider(object *GoogleIdentityProvider, stream *jsonite
 // UnmarshalGoogleIdentityProvider reads a value of the 'google_identity_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalGoogleIdentityProvider(source interface{}) (object *GoogleIdentityProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/group_client.go
+++ b/clustersmgmt/v1/group_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -241,15 +243,21 @@ func (r *GroupGetRequest) SendContext(ctx context.Context) (result *GroupGetResp
 	result = &GroupGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readGroupGetResponse(result, response.Body)
+	err = readGroupGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/group_type_json.go
+++ b/clustersmgmt/v1/group_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -83,9 +82,6 @@ func writeGroup(object *Group, stream *jsoniter.Stream) {
 // UnmarshalGroup reads a value of the 'group' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalGroup(source interface{}) (object *Group, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/groups_client.go
+++ b/clustersmgmt/v1/groups_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -143,15 +145,21 @@ func (r *GroupsListRequest) SendContext(ctx context.Context) (result *GroupsList
 	result = &GroupsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readGroupsListResponse(result, response.Body)
+	err = readGroupsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/ht_passwd_identity_provider_type_json.go
+++ b/clustersmgmt/v1/ht_passwd_identity_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -78,9 +77,6 @@ func writeHTPasswdIdentityProvider(object *HTPasswdIdentityProvider, stream *jso
 // UnmarshalHTPasswdIdentityProvider reads a value of the 'HT_passwd_identity_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalHTPasswdIdentityProvider(source interface{}) (object *HTPasswdIdentityProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/ht_passwd_user_client.go
+++ b/clustersmgmt/v1/ht_passwd_user_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *HTPasswdUserDeleteRequest) SendContext(ctx context.Context) (result *HT
 	result = &HTPasswdUserDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *HTPasswdUserGetRequest) SendContext(ctx context.Context) (result *HTPas
 	result = &HTPasswdUserGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readHTPasswdUserGetResponse(result, response.Body)
+	err = readHTPasswdUserGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *HTPasswdUserUpdateRequest) SendContext(ctx context.Context) (result *HT
 	result = &HTPasswdUserUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readHTPasswdUserUpdateResponse(result, response.Body)
+	err = readHTPasswdUserUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/ht_passwd_user_type_json.go
+++ b/clustersmgmt/v1/ht_passwd_user_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeHTPasswdUser(object *HTPasswdUser, stream *jsoniter.Stream) {
 // UnmarshalHTPasswdUser reads a value of the 'HT_passwd_user' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalHTPasswdUser(source interface{}) (object *HTPasswdUser, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/ht_passwd_users_client.go
+++ b/clustersmgmt/v1/ht_passwd_users_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *HTPasswdUsersAddRequest) SendContext(ctx context.Context) (result *HTPa
 	result = &HTPasswdUsersAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readHTPasswdUsersAddResponse(result, response.Body)
+	err = readHTPasswdUsersAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *HTPasswdUsersListRequest) SendContext(ctx context.Context) (result *HTP
 	result = &HTPasswdUsersListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readHTPasswdUsersListResponse(result, response.Body)
+	err = readHTPasswdUsersListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/identity_provider_client.go
+++ b/clustersmgmt/v1/identity_provider_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -263,8 +265,14 @@ func (r *IdentityProviderDeleteRequest) SendContext(ctx context.Context) (result
 	result = &IdentityProviderDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -357,15 +365,21 @@ func (r *IdentityProviderGetRequest) SendContext(ctx context.Context) (result *I
 	result = &IdentityProviderGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIdentityProviderGetResponse(result, response.Body)
+	err = readIdentityProviderGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -493,15 +507,21 @@ func (r *IdentityProviderUpdateRequest) SendContext(ctx context.Context) (result
 	result = &IdentityProviderUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIdentityProviderUpdateResponse(result, response.Body)
+	err = readIdentityProviderUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/identity_provider_type_json.go
+++ b/clustersmgmt/v1/identity_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -170,9 +169,6 @@ func writeIdentityProvider(object *IdentityProvider, stream *jsoniter.Stream) {
 // UnmarshalIdentityProvider reads a value of the 'identity_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalIdentityProvider(source interface{}) (object *IdentityProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/identity_providers_client.go
+++ b/clustersmgmt/v1/identity_providers_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *IdentityProvidersAddRequest) SendContext(ctx context.Context) (result *
 	result = &IdentityProvidersAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIdentityProvidersAddResponse(result, response.Body)
+	err = readIdentityProvidersAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *IdentityProvidersListRequest) SendContext(ctx context.Context) (result 
 	result = &IdentityProvidersListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIdentityProvidersListResponse(result, response.Body)
+	err = readIdentityProvidersListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/ingress_client.go
+++ b/clustersmgmt/v1/ingress_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *IngressDeleteRequest) SendContext(ctx context.Context) (result *Ingress
 	result = &IngressDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *IngressGetRequest) SendContext(ctx context.Context) (result *IngressGet
 	result = &IngressGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIngressGetResponse(result, response.Body)
+	err = readIngressGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *IngressUpdateRequest) SendContext(ctx context.Context) (result *Ingress
 	result = &IngressUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIngressUpdateResponse(result, response.Body)
+	err = readIngressUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/ingress_type_json.go
+++ b/clustersmgmt/v1/ingress_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -137,9 +136,6 @@ func writeIngress(object *Ingress, stream *jsoniter.Stream) {
 // UnmarshalIngress reads a value of the 'ingress' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalIngress(source interface{}) (object *Ingress, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/ingresses_client.go
+++ b/clustersmgmt/v1/ingresses_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -156,15 +158,21 @@ func (r *IngressesAddRequest) SendContext(ctx context.Context) (result *Ingresse
 	result = &IngressesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIngressesAddResponse(result, response.Body)
+	err = readIngressesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -301,15 +309,21 @@ func (r *IngressesListRequest) SendContext(ctx context.Context) (result *Ingress
 	result = &IngressesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIngressesListResponse(result, response.Body)
+	err = readIngressesListResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -506,15 +520,21 @@ func (r *IngressesUpdateRequest) SendContext(ctx context.Context) (result *Ingre
 	result = &IngressesUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readIngressesUpdateResponse(result, response.Body)
+	err = readIngressesUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/instance_iam_roles_type_json.go
+++ b/clustersmgmt/v1/instance_iam_roles_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeInstanceIAMRoles(object *InstanceIAMRoles, stream *jsoniter.Stream) {
 // UnmarshalInstanceIAMRoles reads a value of the 'instance_IAM_roles' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalInstanceIAMRoles(source interface{}) (object *InstanceIAMRoles, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/key_ring_type_json.go
+++ b/clustersmgmt/v1/key_ring_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeKeyRing(object *KeyRing, stream *jsoniter.Stream) {
 // UnmarshalKeyRing reads a value of the 'key_ring' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalKeyRing(source interface{}) (object *KeyRing, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/key_rings_inquiry_client.go
+++ b/clustersmgmt/v1/key_rings_inquiry_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -155,15 +157,21 @@ func (r *KeyRingsInquirySearchRequest) SendContext(ctx context.Context) (result 
 	result = &KeyRingsInquirySearchResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readKeyRingsInquirySearchResponse(result, response.Body)
+	err = readKeyRingsInquirySearchResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/label_client.go
+++ b/clustersmgmt/v1/label_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *LabelDeleteRequest) SendContext(ctx context.Context) (result *LabelDele
 	result = &LabelDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *LabelGetRequest) SendContext(ctx context.Context) (result *LabelGetResp
 	result = &LabelGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLabelGetResponse(result, response.Body)
+	err = readLabelGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *LabelUpdateRequest) SendContext(ctx context.Context) (result *LabelUpda
 	result = &LabelUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLabelUpdateResponse(result, response.Body)
+	err = readLabelUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/label_type_json.go
+++ b/clustersmgmt/v1/label_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeLabel(object *Label, stream *jsoniter.Stream) {
 // UnmarshalLabel reads a value of the 'label' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLabel(source interface{}) (object *Label, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/labels_client.go
+++ b/clustersmgmt/v1/labels_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *LabelsAddRequest) SendContext(ctx context.Context) (result *LabelsAddRe
 	result = &LabelsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLabelsAddResponse(result, response.Body)
+	err = readLabelsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *LabelsListRequest) SendContext(ctx context.Context) (result *LabelsList
 	result = &LabelsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLabelsListResponse(result, response.Body)
+	err = readLabelsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/ldap_attributes_type_json.go
+++ b/clustersmgmt/v1/ldap_attributes_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -84,9 +83,6 @@ func writeLDAPAttributes(object *LDAPAttributes, stream *jsoniter.Stream) {
 // UnmarshalLDAPAttributes reads a value of the 'LDAP_attributes' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLDAPAttributes(source interface{}) (object *LDAPAttributes, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/ldap_identity_provider_type_json.go
+++ b/clustersmgmt/v1/ldap_identity_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -102,9 +101,6 @@ func writeLDAPIdentityProvider(object *LDAPIdentityProvider, stream *jsoniter.St
 // UnmarshalLDAPIdentityProvider reads a value of the 'LDAP_identity_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLDAPIdentityProvider(source interface{}) (object *LDAPIdentityProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/limited_support_reason_client.go
+++ b/clustersmgmt/v1/limited_support_reason_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -240,8 +242,14 @@ func (r *LimitedSupportReasonDeleteRequest) SendContext(ctx context.Context) (re
 	result = &LimitedSupportReasonDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -334,15 +342,21 @@ func (r *LimitedSupportReasonGetRequest) SendContext(ctx context.Context) (resul
 	result = &LimitedSupportReasonGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLimitedSupportReasonGetResponse(result, response.Body)
+	err = readLimitedSupportReasonGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/limited_support_reason_template_client.go
+++ b/clustersmgmt/v1/limited_support_reason_template_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *LimitedSupportReasonTemplateGetRequest) SendContext(ctx context.Context
 	result = &LimitedSupportReasonTemplateGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLimitedSupportReasonTemplateGetResponse(result, response.Body)
+	err = readLimitedSupportReasonTemplateGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/limited_support_reason_template_type_json.go
+++ b/clustersmgmt/v1/limited_support_reason_template_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeLimitedSupportReasonTemplate(object *LimitedSupportReasonTemplate, str
 // UnmarshalLimitedSupportReasonTemplate reads a value of the 'limited_support_reason_template' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLimitedSupportReasonTemplate(source interface{}) (object *LimitedSupportReasonTemplate, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/limited_support_reason_templates_client.go
+++ b/clustersmgmt/v1/limited_support_reason_templates_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -143,15 +145,21 @@ func (r *LimitedSupportReasonTemplatesListRequest) SendContext(ctx context.Conte
 	result = &LimitedSupportReasonTemplatesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLimitedSupportReasonTemplatesListResponse(result, response.Body)
+	err = readLimitedSupportReasonTemplatesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/limited_support_reason_type_json.go
+++ b/clustersmgmt/v1/limited_support_reason_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -117,9 +116,6 @@ func writeLimitedSupportReason(object *LimitedSupportReason, stream *jsoniter.St
 // UnmarshalLimitedSupportReason reads a value of the 'limited_support_reason' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLimitedSupportReason(source interface{}) (object *LimitedSupportReason, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/limited_support_reasons_client.go
+++ b/clustersmgmt/v1/limited_support_reasons_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *LimitedSupportReasonsAddRequest) SendContext(ctx context.Context) (resu
 	result = &LimitedSupportReasonsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLimitedSupportReasonsAddResponse(result, response.Body)
+	err = readLimitedSupportReasonsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *LimitedSupportReasonsListRequest) SendContext(ctx context.Context) (res
 	result = &LimitedSupportReasonsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLimitedSupportReasonsListResponse(result, response.Body)
+	err = readLimitedSupportReasonsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/log_client.go
+++ b/clustersmgmt/v1/log_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -280,15 +282,21 @@ func (r *LogGetRequest) SendContext(ctx context.Context) (result *LogGetResponse
 	result = &LogGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLogGetResponse(result, response.Body)
+	err = readLogGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/log_type_json.go
+++ b/clustersmgmt/v1/log_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeLog(object *Log, stream *jsoniter.Stream) {
 // UnmarshalLog reads a value of the 'log' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLog(source interface{}) (object *Log, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/logs_client.go
+++ b/clustersmgmt/v1/logs_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -153,15 +155,21 @@ func (r *LogsListRequest) SendContext(ctx context.Context) (result *LogsListResp
 	result = &LogsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLogsListResponse(result, response.Body)
+	err = readLogsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/machine_pool_autoscaling_type_json.go
+++ b/clustersmgmt/v1/machine_pool_autoscaling_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeMachinePoolAutoscaling(object *MachinePoolAutoscaling, stream *jsonite
 // UnmarshalMachinePoolAutoscaling reads a value of the 'machine_pool_autoscaling' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalMachinePoolAutoscaling(source interface{}) (object *MachinePoolAutoscaling, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/machine_pool_client.go
+++ b/clustersmgmt/v1/machine_pool_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *MachinePoolDeleteRequest) SendContext(ctx context.Context) (result *Mac
 	result = &MachinePoolDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *MachinePoolGetRequest) SendContext(ctx context.Context) (result *Machin
 	result = &MachinePoolGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readMachinePoolGetResponse(result, response.Body)
+	err = readMachinePoolGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *MachinePoolUpdateRequest) SendContext(ctx context.Context) (result *Mac
 	result = &MachinePoolUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readMachinePoolUpdateResponse(result, response.Body)
+	err = readMachinePoolUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/machine_pool_type_json.go
+++ b/clustersmgmt/v1/machine_pool_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -164,9 +163,6 @@ func writeMachinePool(object *MachinePool, stream *jsoniter.Stream) {
 // UnmarshalMachinePool reads a value of the 'machine_pool' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalMachinePool(source interface{}) (object *MachinePool, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/machine_pools_client.go
+++ b/clustersmgmt/v1/machine_pools_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *MachinePoolsAddRequest) SendContext(ctx context.Context) (result *Machi
 	result = &MachinePoolsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readMachinePoolsAddResponse(result, response.Body)
+	err = readMachinePoolsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *MachinePoolsListRequest) SendContext(ctx context.Context) (result *Mach
 	result = &MachinePoolsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readMachinePoolsListResponse(result, response.Body)
+	err = readMachinePoolsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/machine_type_client.go
+++ b/clustersmgmt/v1/machine_type_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *MachineTypeGetRequest) SendContext(ctx context.Context) (result *Machin
 	result = &MachineTypeGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readMachineTypeGetResponse(result, response.Body)
+	err = readMachineTypeGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/machine_type_type_json.go
+++ b/clustersmgmt/v1/machine_type_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -143,9 +142,6 @@ func writeMachineType(object *MachineType, stream *jsoniter.Stream) {
 // UnmarshalMachineType reads a value of the 'machine_type' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalMachineType(source interface{}) (object *MachineType, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/machine_types_client.go
+++ b/clustersmgmt/v1/machine_types_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -180,15 +182,21 @@ func (r *MachineTypesListRequest) SendContext(ctx context.Context) (result *Mach
 	result = &MachineTypesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readMachineTypesListResponse(result, response.Body)
+	err = readMachineTypesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/metadata_client.go
+++ b/clustersmgmt/v1/metadata_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -89,15 +91,20 @@ func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResp
 		status: response.StatusCode,
 		header: response.Header,
 	}
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	result.body, err = UnmarshalMetadata(response.Body)
+	result.body, err = UnmarshalMetadata(reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/network_type_json.go
+++ b/clustersmgmt/v1/network_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -93,9 +92,6 @@ func writeNetwork(object *Network, stream *jsoniter.Stream) {
 // UnmarshalNetwork reads a value of the 'network' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalNetwork(source interface{}) (object *Network, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/node_info_type_json.go
+++ b/clustersmgmt/v1/node_info_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeNodeInfo(object *NodeInfo, stream *jsoniter.Stream) {
 // UnmarshalNodeInfo reads a value of the 'node_info' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalNodeInfo(source interface{}) (object *NodeInfo, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/nodes_info_type_json.go
+++ b/clustersmgmt/v1/nodes_info_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeNodesInfo(object *NodesInfo, stream *jsoniter.Stream) {
 // UnmarshalNodesInfo reads a value of the 'nodes_info' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalNodesInfo(source interface{}) (object *NodesInfo, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/nodes_metric_query_client.go
+++ b/clustersmgmt/v1/nodes_metric_query_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *NodesMetricQueryGetRequest) SendContext(ctx context.Context) (result *N
 	result = &NodesMetricQueryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readNodesMetricQueryGetResponse(result, response.Body)
+	err = readNodesMetricQueryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/open_id_claims_type_json.go
+++ b/clustersmgmt/v1/open_id_claims_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeOpenIDClaims(object *OpenIDClaims, stream *jsoniter.Stream) {
 // UnmarshalOpenIDClaims reads a value of the 'open_ID_claims' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalOpenIDClaims(source interface{}) (object *OpenIDClaims, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/open_id_identity_provider_type_json.go
+++ b/clustersmgmt/v1/open_id_identity_provider_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"sort"
 
 	jsoniter "github.com/json-iterator/go"
@@ -132,9 +131,6 @@ func writeOpenIDIdentityProvider(object *OpenIDIdentityProvider, stream *jsonite
 // UnmarshalOpenIDIdentityProvider reads a value of the 'open_ID_identity_provider' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalOpenIDIdentityProvider(source interface{}) (object *OpenIDIdentityProvider, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/operator_iam_role_type_json.go
+++ b/clustersmgmt/v1/operator_iam_role_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeOperatorIAMRole(object *OperatorIAMRole, stream *jsoniter.Stream) {
 // UnmarshalOperatorIAMRole reads a value of the 'operator_IAM_role' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalOperatorIAMRole(source interface{}) (object *OperatorIAMRole, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/product_client.go
+++ b/clustersmgmt/v1/product_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *ProductGetRequest) SendContext(ctx context.Context) (result *ProductGet
 	result = &ProductGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProductGetResponse(result, response.Body)
+	err = readProductGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/product_type_json.go
+++ b/clustersmgmt/v1/product_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeProduct(object *Product, stream *jsoniter.Stream) {
 // UnmarshalProduct reads a value of the 'product' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalProduct(source interface{}) (object *Product, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/products_client.go
+++ b/clustersmgmt/v1/products_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -191,15 +193,21 @@ func (r *ProductsListRequest) SendContext(ctx context.Context) (result *Products
 	result = &ProductsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProductsListResponse(result, response.Body)
+	err = readProductsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/provision_shard_client.go
+++ b/clustersmgmt/v1/provision_shard_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *ProvisionShardGetRequest) SendContext(ctx context.Context) (result *Pro
 	result = &ProvisionShardGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProvisionShardGetResponse(result, response.Body)
+	err = readProvisionShardGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/provision_shard_type_json.go
+++ b/clustersmgmt/v1/provision_shard_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -116,9 +115,6 @@ func writeProvisionShard(object *ProvisionShard, stream *jsoniter.Stream) {
 // UnmarshalProvisionShard reads a value of the 'provision_shard' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalProvisionShard(source interface{}) (object *ProvisionShard, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/provision_shards_client.go
+++ b/clustersmgmt/v1/provision_shards_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -143,15 +145,21 @@ func (r *ProvisionShardsListRequest) SendContext(ctx context.Context) (result *P
 	result = &ProvisionShardsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProvisionShardsListResponse(result, response.Body)
+	err = readProvisionShardsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/proxy_type_json.go
+++ b/clustersmgmt/v1/proxy_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeProxy(object *Proxy, stream *jsoniter.Stream) {
 // UnmarshalProxy reads a value of the 'proxy' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalProxy(source interface{}) (object *Proxy, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/resources_client.go
+++ b/clustersmgmt/v1/resources_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -241,15 +243,21 @@ func (r *ResourcesGetRequest) SendContext(ctx context.Context) (result *Resource
 	result = &ResourcesGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readResourcesGetResponse(result, response.Body)
+	err = readResourcesGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/server_config_type_json.go
+++ b/clustersmgmt/v1/server_config_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeServerConfig(object *ServerConfig, stream *jsoniter.Stream) {
 // UnmarshalServerConfig reads a value of the 'server_config' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalServerConfig(source interface{}) (object *ServerConfig, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_client.go
+++ b/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *SocketTotalByNodeRolesOSMetricQueryGetRequest) SendContext(ctx context.
 	result = &SocketTotalByNodeRolesOSMetricQueryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSocketTotalByNodeRolesOSMetricQueryGetResponse(result, response.Body)
+	err = readSocketTotalByNodeRolesOSMetricQueryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/socket_total_node_role_os_metric_node_type_json.go
+++ b/clustersmgmt/v1/socket_total_node_role_os_metric_node_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -85,9 +84,6 @@ func writeSocketTotalNodeRoleOSMetricNode(object *SocketTotalNodeRoleOSMetricNod
 // UnmarshalSocketTotalNodeRoleOSMetricNode reads a value of the 'socket_total_node_role_OS_metric_node' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSocketTotalNodeRoleOSMetricNode(source interface{}) (object *SocketTotalNodeRoleOSMetricNode, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/socket_totals_node_role_os_metric_node_type_json.go
+++ b/clustersmgmt/v1/socket_totals_node_role_os_metric_node_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -57,9 +56,6 @@ func writeSocketTotalsNodeRoleOSMetricNode(object *SocketTotalsNodeRoleOSMetricN
 // UnmarshalSocketTotalsNodeRoleOSMetricNode reads a value of the 'socket_totals_node_role_OS_metric_node' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSocketTotalsNodeRoleOSMetricNode(source interface{}) (object *SocketTotalsNodeRoleOSMetricNode, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/ssh_credentials_type_json.go
+++ b/clustersmgmt/v1/ssh_credentials_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeSSHCredentials(object *SSHCredentials, stream *jsoniter.Stream) {
 // UnmarshalSSHCredentials reads a value of the 'SSH_credentials' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSSHCredentials(source interface{}) (object *SSHCredentials, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/sts_type_json.go
+++ b/clustersmgmt/v1/sts_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -102,9 +101,6 @@ func writeSTS(object *STS, stream *jsoniter.Stream) {
 // UnmarshalSTS reads a value of the 'STS' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSTS(source interface{}) (object *STS, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/subnetwork_type_json.go
+++ b/clustersmgmt/v1/subnetwork_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeSubnetwork(object *Subnetwork, stream *jsoniter.Stream) {
 // UnmarshalSubnetwork reads a value of the 'subnetwork' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSubnetwork(source interface{}) (object *Subnetwork, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/subscription_type_json.go
+++ b/clustersmgmt/v1/subscription_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -70,9 +69,6 @@ func writeSubscription(object *Subscription, stream *jsoniter.Stream) {
 // UnmarshalSubscription reads a value of the 'subscription' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSubscription(source interface{}) (object *Subscription, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/syncset_client.go
+++ b/clustersmgmt/v1/syncset_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *SyncsetDeleteRequest) SendContext(ctx context.Context) (result *Syncset
 	result = &SyncsetDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *SyncsetGetRequest) SendContext(ctx context.Context) (result *SyncsetGet
 	result = &SyncsetGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSyncsetGetResponse(result, response.Body)
+	err = readSyncsetGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *SyncsetUpdateRequest) SendContext(ctx context.Context) (result *Syncset
 	result = &SyncsetUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSyncsetUpdateResponse(result, response.Body)
+	err = readSyncsetUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/syncset_type_json.go
+++ b/clustersmgmt/v1/syncset_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -80,9 +79,6 @@ func writeSyncset(object *Syncset, stream *jsoniter.Stream) {
 // UnmarshalSyncset reads a value of the 'syncset' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalSyncset(source interface{}) (object *Syncset, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/syncsets_client.go
+++ b/clustersmgmt/v1/syncsets_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *SyncsetsAddRequest) SendContext(ctx context.Context) (result *SyncsetsA
 	result = &SyncsetsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSyncsetsAddResponse(result, response.Body)
+	err = readSyncsetsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *SyncsetsListRequest) SendContext(ctx context.Context) (result *Syncsets
 	result = &SyncsetsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readSyncsetsListResponse(result, response.Body)
+	err = readSyncsetsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/taint_type_json.go
+++ b/clustersmgmt/v1/taint_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -75,9 +74,6 @@ func writeTaint(object *Taint, stream *jsoniter.Stream) {
 // UnmarshalTaint reads a value of the 'taint' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalTaint(source interface{}) (object *Taint, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/upgrade_policies_client.go
+++ b/clustersmgmt/v1/upgrade_policies_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *UpgradePoliciesAddRequest) SendContext(ctx context.Context) (result *Up
 	result = &UpgradePoliciesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUpgradePoliciesAddResponse(result, response.Body)
+	err = readUpgradePoliciesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *UpgradePoliciesListRequest) SendContext(ctx context.Context) (result *U
 	result = &UpgradePoliciesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUpgradePoliciesListResponse(result, response.Body)
+	err = readUpgradePoliciesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/upgrade_policy_client.go
+++ b/clustersmgmt/v1/upgrade_policy_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -263,8 +265,14 @@ func (r *UpgradePolicyDeleteRequest) SendContext(ctx context.Context) (result *U
 	result = &UpgradePolicyDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -357,15 +365,21 @@ func (r *UpgradePolicyGetRequest) SendContext(ctx context.Context) (result *Upgr
 	result = &UpgradePolicyGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUpgradePolicyGetResponse(result, response.Body)
+	err = readUpgradePolicyGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -493,15 +507,21 @@ func (r *UpgradePolicyUpdateRequest) SendContext(ctx context.Context) (result *U
 	result = &UpgradePolicyUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUpgradePolicyUpdateResponse(result, response.Body)
+	err = readUpgradePolicyUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/upgrade_policy_state_client.go
+++ b/clustersmgmt/v1/upgrade_policy_state_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -242,15 +244,21 @@ func (r *UpgradePolicyStateGetRequest) SendContext(ctx context.Context) (result 
 	result = &UpgradePolicyStateGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUpgradePolicyStateGetResponse(result, response.Body)
+	err = readUpgradePolicyStateGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -378,15 +386,21 @@ func (r *UpgradePolicyStateUpdateRequest) SendContext(ctx context.Context) (resu
 	result = &UpgradePolicyStateUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUpgradePolicyStateUpdateResponse(result, response.Body)
+	err = readUpgradePolicyStateUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/upgrade_policy_state_type_json.go
+++ b/clustersmgmt/v1/upgrade_policy_state_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeUpgradePolicyState(object *UpgradePolicyState, stream *jsoniter.Stream
 // UnmarshalUpgradePolicyState reads a value of the 'upgrade_policy_state' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalUpgradePolicyState(source interface{}) (object *UpgradePolicyState, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/upgrade_policy_type_json.go
+++ b/clustersmgmt/v1/upgrade_policy_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -126,9 +125,6 @@ func writeUpgradePolicy(object *UpgradePolicy, stream *jsoniter.Stream) {
 // UnmarshalUpgradePolicy reads a value of the 'upgrade_policy' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalUpgradePolicy(source interface{}) (object *UpgradePolicy, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/user_client.go
+++ b/clustersmgmt/v1/user_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -240,8 +242,14 @@ func (r *UserDeleteRequest) SendContext(ctx context.Context) (result *UserDelete
 	result = &UserDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -334,15 +342,21 @@ func (r *UserGetRequest) SendContext(ctx context.Context) (result *UserGetRespon
 	result = &UserGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUserGetResponse(result, response.Body)
+	err = readUserGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/user_type_json.go
+++ b/clustersmgmt/v1/user_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -70,9 +69,6 @@ func writeUser(object *User, stream *jsoniter.Stream) {
 // UnmarshalUser reads a value of the 'user' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalUser(source interface{}) (object *User, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/users_client.go
+++ b/clustersmgmt/v1/users_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *UsersAddRequest) SendContext(ctx context.Context) (result *UsersAddResp
 	result = &UsersAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUsersAddResponse(result, response.Body)
+	err = readUsersAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *UsersListRequest) SendContext(ctx context.Context) (result *UsersListRe
 	result = &UsersListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readUsersListResponse(result, response.Body)
+	err = readUsersListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/value_type_json.go
+++ b/clustersmgmt/v1/value_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeValue(object *Value, stream *jsoniter.Stream) {
 // UnmarshalValue reads a value of the 'value' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalValue(source interface{}) (object *Value, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/version_client.go
+++ b/clustersmgmt/v1/version_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -230,15 +232,21 @@ func (r *VersionGetRequest) SendContext(ctx context.Context) (result *VersionGet
 	result = &VersionGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionGetResponse(result, response.Body)
+	err = readVersionGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/version_gate_agreement_client.go
+++ b/clustersmgmt/v1/version_gate_agreement_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -240,8 +242,14 @@ func (r *VersionGateAgreementDeleteRequest) SendContext(ctx context.Context) (re
 	result = &VersionGateAgreementDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -334,15 +342,21 @@ func (r *VersionGateAgreementGetRequest) SendContext(ctx context.Context) (resul
 	result = &VersionGateAgreementGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionGateAgreementGetResponse(result, response.Body)
+	err = readVersionGateAgreementGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/version_gate_agreement_type_json.go
+++ b/clustersmgmt/v1/version_gate_agreement_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -90,9 +89,6 @@ func writeVersionGateAgreement(object *VersionGateAgreement, stream *jsoniter.St
 // UnmarshalVersionGateAgreement reads a value of the 'version_gate_agreement' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalVersionGateAgreement(source interface{}) (object *VersionGateAgreement, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/version_gate_agreements_client.go
+++ b/clustersmgmt/v1/version_gate_agreements_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *VersionGateAgreementsAddRequest) SendContext(ctx context.Context) (resu
 	result = &VersionGateAgreementsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionGateAgreementsAddResponse(result, response.Body)
+	err = readVersionGateAgreementsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -291,15 +299,21 @@ func (r *VersionGateAgreementsListRequest) SendContext(ctx context.Context) (res
 	result = &VersionGateAgreementsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionGateAgreementsListResponse(result, response.Body)
+	err = readVersionGateAgreementsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/version_gate_client.go
+++ b/clustersmgmt/v1/version_gate_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -240,8 +242,14 @@ func (r *VersionGateDeleteRequest) SendContext(ctx context.Context) (result *Ver
 	result = &VersionGateDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -334,15 +342,21 @@ func (r *VersionGateGetRequest) SendContext(ctx context.Context) (result *Versio
 	result = &VersionGateGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionGateGetResponse(result, response.Body)
+	err = readVersionGateGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/version_gate_type_json.go
+++ b/clustersmgmt/v1/version_gate_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -144,9 +143,6 @@ func writeVersionGate(object *VersionGate, stream *jsoniter.Stream) {
 // UnmarshalVersionGate reads a value of the 'version_gate' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalVersionGate(source interface{}) (object *VersionGate, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/version_gates_client.go
+++ b/clustersmgmt/v1/version_gates_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *VersionGatesAddRequest) SendContext(ctx context.Context) (result *Versi
 	result = &VersionGatesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionGatesAddResponse(result, response.Body)
+	err = readVersionGatesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -336,15 +344,21 @@ func (r *VersionGatesListRequest) SendContext(ctx context.Context) (result *Vers
 	result = &VersionGatesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionGatesListResponse(result, response.Body)
+	err = readVersionGatesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/version_type_json.go
+++ b/clustersmgmt/v1/version_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -135,9 +134,6 @@ func writeVersion(object *Version, stream *jsoniter.Stream) {
 // UnmarshalVersion reads a value of the 'version' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalVersion(source interface{}) (object *Version, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/clustersmgmt/v1/versions_client.go
+++ b/clustersmgmt/v1/versions_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -193,15 +195,21 @@ func (r *VersionsListRequest) SendContext(ctx context.Context) (result *Versions
 	result = &VersionsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVersionsListResponse(result, response.Body)
+	err = readVersionsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/clustersmgmt/v1/vpcs_inquiry_client.go
+++ b/clustersmgmt/v1/vpcs_inquiry_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -155,15 +157,21 @@ func (r *VpcsInquirySearchRequest) SendContext(ctx context.Context) (result *Vpc
 	result = &VpcsInquirySearchResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readVpcsInquirySearchResponse(result, response.Body)
+	err = readVpcsInquirySearchResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/jobqueue/v1/job_client.go
+++ b/jobqueue/v1/job_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/jobqueue/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -145,8 +147,14 @@ func (r *JobFailureRequest) SendContext(ctx context.Context) (result *JobFailure
 	result = &JobFailureResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -254,8 +262,14 @@ func (r *JobSuccessRequest) SendContext(ctx context.Context) (result *JobSuccess
 	result = &JobSuccessResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}

--- a/jobqueue/v1/job_type_json.go
+++ b/jobqueue/v1/job_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/jobqueue/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -126,9 +125,6 @@ func writeJob(object *Job, stream *jsoniter.Stream) {
 // UnmarshalJob reads a value of the 'job' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalJob(source interface{}) (object *Job, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/jobqueue/v1/metadata_client.go
+++ b/jobqueue/v1/metadata_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/jobqueue/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -89,15 +91,20 @@ func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResp
 		status: response.StatusCode,
 		header: response.Header,
 	}
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	result.body, err = UnmarshalMetadata(response.Body)
+	result.body, err = UnmarshalMetadata(reader)
 	if err != nil {
 		return
 	}

--- a/jobqueue/v1/queue_client.go
+++ b/jobqueue/v1/queue_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/jobqueue/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -263,15 +265,21 @@ func (r *QueueGetRequest) SendContext(ctx context.Context) (result *QueueGetResp
 	result = &QueueGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readQueueGetResponse(result, response.Body)
+	err = readQueueGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -384,15 +392,21 @@ func (r *QueuePopRequest) SendContext(ctx context.Context) (result *QueuePopResp
 	result = &QueuePopResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readQueuePopResponse(result, response.Body)
+	err = readQueuePopResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -731,15 +745,21 @@ func (r *QueuePushRequest) SendContext(ctx context.Context) (result *QueuePushRe
 	result = &QueuePushResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readQueuePushResponse(result, response.Body)
+	err = readQueuePushResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/jobqueue/v1/queue_type_json.go
+++ b/jobqueue/v1/queue_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/jobqueue/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -117,9 +116,6 @@ func writeQueue(object *Queue, stream *jsoniter.Stream) {
 // UnmarshalQueue reads a value of the 'queue' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalQueue(source interface{}) (object *Queue, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/jobqueue/v1/queues_client.go
+++ b/jobqueue/v1/queues_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/jobqueue/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -144,15 +146,21 @@ func (r *QueuesListRequest) SendContext(ctx context.Context) (result *QueuesList
 	result = &QueuesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readQueuesListResponse(result, response.Body)
+	err = readQueuesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/servicelogs/v1/cluster_logs_client.go
+++ b/servicelogs/v1/cluster_logs_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/servicelogs/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *ClusterLogsAddRequest) SendContext(ctx context.Context) (result *Cluste
 	result = &ClusterLogsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterLogsAddResponse(result, response.Body)
+	err = readClusterLogsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -338,15 +346,21 @@ func (r *ClusterLogsListRequest) SendContext(ctx context.Context) (result *Clust
 	result = &ClusterLogsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readClusterLogsListResponse(result, response.Body)
+	err = readClusterLogsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/servicelogs/v1/log_entry_client.go
+++ b/servicelogs/v1/log_entry_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/servicelogs/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -240,8 +242,14 @@ func (r *LogEntryDeleteRequest) SendContext(ctx context.Context) (result *LogEnt
 	result = &LogEntryDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -334,15 +342,21 @@ func (r *LogEntryGetRequest) SendContext(ctx context.Context) (result *LogEntryG
 	result = &LogEntryGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readLogEntryGetResponse(result, response.Body)
+	err = readLogEntryGetResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/servicelogs/v1/log_entry_type_json.go
+++ b/servicelogs/v1/log_entry_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/servicelogs/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -171,9 +170,6 @@ func writeLogEntry(object *LogEntry, stream *jsoniter.Stream) {
 // UnmarshalLogEntry reads a value of the 'log_entry' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalLogEntry(source interface{}) (object *LogEntry, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/servicelogs/v1/metadata_client.go
+++ b/servicelogs/v1/metadata_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/servicelogs/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -89,15 +91,20 @@ func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResp
 		status: response.StatusCode,
 		header: response.Header,
 	}
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	result.body, err = UnmarshalMetadata(response.Body)
+	result.body, err = UnmarshalMetadata(reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/application_client.go
+++ b/statusboard/v1/application_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -263,8 +265,14 @@ func (r *ApplicationDeleteRequest) SendContext(ctx context.Context) (result *App
 	result = &ApplicationDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -357,15 +365,21 @@ func (r *ApplicationGetRequest) SendContext(ctx context.Context) (result *Applic
 	result = &ApplicationGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationGetResponse(result, response.Body)
+	err = readApplicationGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -493,15 +507,21 @@ func (r *ApplicationUpdateRequest) SendContext(ctx context.Context) (result *App
 	result = &ApplicationUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationUpdateResponse(result, response.Body)
+	err = readApplicationUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/application_dependencies_client.go
+++ b/statusboard/v1/application_dependencies_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *ApplicationDependenciesAddRequest) SendContext(ctx context.Context) (re
 	result = &ApplicationDependenciesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationDependenciesAddResponse(result, response.Body)
+	err = readApplicationDependenciesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -303,15 +311,21 @@ func (r *ApplicationDependenciesListRequest) SendContext(ctx context.Context) (r
 	result = &ApplicationDependenciesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationDependenciesListResponse(result, response.Body)
+	err = readApplicationDependenciesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/application_dependency_client.go
+++ b/statusboard/v1/application_dependency_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *ApplicationDependencyDeleteRequest) SendContext(ctx context.Context) (r
 	result = &ApplicationDependencyDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *ApplicationDependencyGetRequest) SendContext(ctx context.Context) (resu
 	result = &ApplicationDependencyGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationDependencyGetResponse(result, response.Body)
+	err = readApplicationDependencyGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *ApplicationDependencyUpdateRequest) SendContext(ctx context.Context) (r
 	result = &ApplicationDependencyUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationDependencyUpdateResponse(result, response.Body)
+	err = readApplicationDependencyUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/application_dependency_type_json.go
+++ b/statusboard/v1/application_dependency_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -144,9 +143,6 @@ func writeApplicationDependency(object *ApplicationDependency, stream *jsoniter.
 // UnmarshalApplicationDependency reads a value of the 'application_dependency' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalApplicationDependency(source interface{}) (object *ApplicationDependency, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/application_type_json.go
+++ b/statusboard/v1/application_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -135,9 +134,6 @@ func writeApplication(object *Application, stream *jsoniter.Stream) {
 // UnmarshalApplication reads a value of the 'application' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalApplication(source interface{}) (object *Application, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/applications_client.go
+++ b/statusboard/v1/applications_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *ApplicationsAddRequest) SendContext(ctx context.Context) (result *Appli
 	result = &ApplicationsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationsAddResponse(result, response.Body)
+	err = readApplicationsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -315,15 +323,21 @@ func (r *ApplicationsListRequest) SendContext(ctx context.Context) (result *Appl
 	result = &ApplicationsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readApplicationsListResponse(result, response.Body)
+	err = readApplicationsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/metadata_client.go
+++ b/statusboard/v1/metadata_client.go
@@ -20,7 +20,9 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -89,15 +91,20 @@ func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResp
 		status: response.StatusCode,
 		header: response.Header,
 	}
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	result.body, err = UnmarshalMetadata(response.Body)
+	result.body, err = UnmarshalMetadata(reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/owner_type_json.go
+++ b/statusboard/v1/owner_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -89,9 +88,6 @@ func writeOwner(object *Owner, stream *jsoniter.Stream) {
 // UnmarshalOwner reads a value of the 'owner' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalOwner(source interface{}) (object *Owner, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/peer_dependencies_client.go
+++ b/statusboard/v1/peer_dependencies_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *PeerDependenciesAddRequest) SendContext(ctx context.Context) (result *P
 	result = &PeerDependenciesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPeerDependenciesAddResponse(result, response.Body)
+	err = readPeerDependenciesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -303,15 +311,21 @@ func (r *PeerDependenciesListRequest) SendContext(ctx context.Context) (result *
 	result = &PeerDependenciesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPeerDependenciesListResponse(result, response.Body)
+	err = readPeerDependenciesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/peer_dependency_client.go
+++ b/statusboard/v1/peer_dependency_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *PeerDependencyDeleteRequest) SendContext(ctx context.Context) (result *
 	result = &PeerDependencyDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *PeerDependencyGetRequest) SendContext(ctx context.Context) (result *Pee
 	result = &PeerDependencyGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPeerDependencyGetResponse(result, response.Body)
+	err = readPeerDependencyGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *PeerDependencyUpdateRequest) SendContext(ctx context.Context) (result *
 	result = &PeerDependencyUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readPeerDependencyUpdateResponse(result, response.Body)
+	err = readPeerDependencyUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/peer_dependency_type_json.go
+++ b/statusboard/v1/peer_dependency_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -126,9 +125,6 @@ func writePeerDependency(object *PeerDependency, stream *jsoniter.Stream) {
 // UnmarshalPeerDependency reads a value of the 'peer_dependency' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalPeerDependency(source interface{}) (object *PeerDependency, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/product_client.go
+++ b/statusboard/v1/product_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -273,8 +275,14 @@ func (r *ProductDeleteRequest) SendContext(ctx context.Context) (result *Product
 	result = &ProductDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -367,15 +375,21 @@ func (r *ProductGetRequest) SendContext(ctx context.Context) (result *ProductGet
 	result = &ProductGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProductGetResponse(result, response.Body)
+	err = readProductGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -503,15 +517,21 @@ func (r *ProductUpdateRequest) SendContext(ctx context.Context) (result *Product
 	result = &ProductUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProductUpdateResponse(result, response.Body)
+	err = readProductUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/product_type_json.go
+++ b/statusboard/v1/product_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -126,9 +125,6 @@ func writeProduct(object *Product, stream *jsoniter.Stream) {
 // UnmarshalProduct reads a value of the 'product' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalProduct(source interface{}) (object *Product, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/products_client.go
+++ b/statusboard/v1/products_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *ProductsAddRequest) SendContext(ctx context.Context) (result *ProductsA
 	result = &ProductsAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProductsAddResponse(result, response.Body)
+	err = readProductsAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -315,15 +323,21 @@ func (r *ProductsListRequest) SendContext(ctx context.Context) (result *Products
 	result = &ProductsListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readProductsListResponse(result, response.Body)
+	err = readProductsListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/service_client.go
+++ b/statusboard/v1/service_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -263,8 +265,14 @@ func (r *ServiceDeleteRequest) SendContext(ctx context.Context) (result *Service
 	result = &ServiceDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -357,15 +365,21 @@ func (r *ServiceGetRequest) SendContext(ctx context.Context) (result *ServiceGet
 	result = &ServiceGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServiceGetResponse(result, response.Body)
+	err = readServiceGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -493,15 +507,21 @@ func (r *ServiceUpdateRequest) SendContext(ctx context.Context) (result *Service
 	result = &ServiceUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServiceUpdateResponse(result, response.Body)
+	err = readServiceUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/service_dependencies_client.go
+++ b/statusboard/v1/service_dependencies_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *ServiceDependenciesAddRequest) SendContext(ctx context.Context) (result
 	result = &ServiceDependenciesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServiceDependenciesAddResponse(result, response.Body)
+	err = readServiceDependenciesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -303,15 +311,21 @@ func (r *ServiceDependenciesListRequest) SendContext(ctx context.Context) (resul
 	result = &ServiceDependenciesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServiceDependenciesListResponse(result, response.Body)
+	err = readServiceDependenciesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/service_dependency_client.go
+++ b/statusboard/v1/service_dependency_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *ServiceDependencyDeleteRequest) SendContext(ctx context.Context) (resul
 	result = &ServiceDependencyDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *ServiceDependencyGetRequest) SendContext(ctx context.Context) (result *
 	result = &ServiceDependencyGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServiceDependencyGetResponse(result, response.Body)
+	err = readServiceDependencyGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *ServiceDependencyUpdateRequest) SendContext(ctx context.Context) (resul
 	result = &ServiceDependencyUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServiceDependencyUpdateResponse(result, response.Body)
+	err = readServiceDependencyUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/service_dependency_type_json.go
+++ b/statusboard/v1/service_dependency_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -144,9 +143,6 @@ func writeServiceDependency(object *ServiceDependency, stream *jsoniter.Stream) 
 // UnmarshalServiceDependency reads a value of the 'service_dependency' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalServiceDependency(source interface{}) (object *ServiceDependency, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/service_info_type_json.go
+++ b/statusboard/v1/service_info_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openshift-online/ocm-sdk-go/helpers"
@@ -66,9 +65,6 @@ func writeServiceInfo(object *ServiceInfo, stream *jsoniter.Stream) {
 // UnmarshalServiceInfo reads a value of the 'service_info' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalServiceInfo(source interface{}) (object *ServiceInfo, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/service_type_json.go
+++ b/statusboard/v1/service_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -198,9 +197,6 @@ func writeService(object *Service, stream *jsoniter.Stream) {
 // UnmarshalService reads a value of the 'service' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalService(source interface{}) (object *Service, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/services_client.go
+++ b/statusboard/v1/services_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -146,15 +148,21 @@ func (r *ServicesAddRequest) SendContext(ctx context.Context) (result *ServicesA
 	result = &ServicesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServicesAddResponse(result, response.Body)
+	err = readServicesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -327,15 +335,21 @@ func (r *ServicesListRequest) SendContext(ctx context.Context) (result *Services
 	result = &ServicesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readServicesListResponse(result, response.Body)
+	err = readServicesListResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/status_client.go
+++ b/statusboard/v1/status_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -252,8 +254,14 @@ func (r *StatusDeleteRequest) SendContext(ctx context.Context) (result *StatusDe
 	result = &StatusDeleteResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
@@ -346,15 +354,21 @@ func (r *StatusGetRequest) SendContext(ctx context.Context) (result *StatusGetRe
 	result = &StatusGetResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readStatusGetResponse(result, response.Body)
+	err = readStatusGetResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -482,15 +496,21 @@ func (r *StatusUpdateRequest) SendContext(ctx context.Context) (result *StatusUp
 	result = &StatusUpdateResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readStatusUpdateResponse(result, response.Body)
+	err = readStatusUpdateResponse(result, reader)
 	if err != nil {
 		return
 	}

--- a/statusboard/v1/status_type_json.go
+++ b/statusboard/v1/status_type_json.go
@@ -21,7 +21,6 @@ package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
 	"io"
-	"net/http"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -126,9 +125,6 @@ func writeStatus(object *Status, stream *jsoniter.Stream) {
 // UnmarshalStatus reads a value of the 'status' type from the given
 // source, which can be an slice of bytes, a string or a reader.
 func UnmarshalStatus(source interface{}) (object *Status, err error) {
-	if source == http.NoBody {
-		return
-	}
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return

--- a/statusboard/v1/statuses_client.go
+++ b/statusboard/v1/statuses_client.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1 // github.com/openshift-online/ocm-sdk-go/statusboard/v1
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -147,15 +149,21 @@ func (r *StatusesAddRequest) SendContext(ctx context.Context) (result *StatusesA
 	result = &StatusesAddResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readStatusesAddResponse(result, response.Body)
+	err = readStatusesAddResponse(result, reader)
 	if err != nil {
 		return
 	}
@@ -316,15 +324,21 @@ func (r *StatusesListRequest) SendContext(ctx context.Context) (result *Statuses
 	result = &StatusesListResponse{}
 	result.status = response.StatusCode
 	result.header = response.Header
+	reader := bufio.NewReader(response.Body)
+	_, err = reader.Peek(1)
+	if err == io.EOF {
+		err = nil
+		return
+	}
 	if result.status >= 400 {
-		result.err, err = errors.UnmarshalErrorStatus(response.Body, result.status)
+		result.err, err = errors.UnmarshalErrorStatus(reader, result.status)
 		if err != nil {
 			return
 		}
 		err = result.err
 		return
 	}
-	err = readStatusesListResponse(result, response.Body)
+	err = readStatusesListResponse(result, reader)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Check for `io.EOF` before trying to parse response body.