### PR TITLE
Revert "Don't crash in debug mode deserializing an empty response"

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -101,13 +101,8 @@ func (d *dumpRoundTripper) RoundTrip(request *http.Request) (response *http.Resp
 		if err != nil {
 			return
 		}
-		if len(body) == 0 {
-			d.dumpResponse(ctx, response, nil)
-			response.Body = http.NoBody // checked by Unmarshal* functions.
-		} else {
-			d.dumpResponse(ctx, response, body)
-			response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-		}
+		d.dumpResponse(ctx, response, body)
+		response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 	} else {
 		d.dumpResponse(ctx, response, nil)
 	}


### PR DESCRIPTION
This reverts commit 4d0806de9d2717bb61e9917240a0839d530a4e0a because the
generated code lo longer requires the empty response bodies to be
`http.NoBody`.