### PR TITLE
Release 0.1.239

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.239 Feb 3 2022
+
+- Update to metamodel 0.0.51:
+  - Check for `io.EOF` before trying to parse response body.
+
 ## 0.1.238 Jan 28 2022
 
 - Update to model 0.0.170:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.238"
+const Version = "0.1.239"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to metamodel 0.0.51:
  - Check for `io.EOF` before trying to parse response body.