### PR TITLE
Release 0.1.240

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,14 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.240 Feb 4 2022
+
+- Update to model 0.1.172:
+  - Remove deprecated `SKUs` endpoint.
+  - Remove deprecated quota summary resource and type.
+  - Add QuotaVersion to ClusterAuth.
+  - Allow adding/removing operator roles.
+
 ## 0.1.239 Feb 3 2022
 
 - Update to metamodel 0.0.51:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.239"
+const Version = "0.1.240"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Update to model 0.1.172:
  - Remove deprecated `SKUs` endpoint.
  - Remove deprecated quota summary resource and type.
  - Add QuotaVersion to ClusterAuth.
  - Allow adding/removing operator roles.