### PR TITLE
Update to metamodel 0.0.52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ model_version:=v0.0.178
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.51
+metamodel_version:=v0.0.52
 
 .PHONY: examples
 examples:

--- a/accountsmgmt/v1/access_token_client.go
+++ b/accountsmgmt/v1/access_token_client.go
@@ -78,6 +78,13 @@ func (r *AccessTokenPostRequest) Header(name string, value interface{}) *AccessT
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AccessTokenPostRequest) Impersonate(user string) *AccessTokenPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/account_client.go
+++ b/accountsmgmt/v1/account_client.go
@@ -223,6 +223,13 @@ func (r *AccountGetRequest) Header(name string, value interface{}) *AccountGetRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AccountGetRequest) Impersonate(user string) *AccountGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -348,6 +355,13 @@ func (r *AccountUpdateRequest) Parameter(name string, value interface{}) *Accoun
 // Header adds a request header.
 func (r *AccountUpdateRequest) Header(name string, value interface{}) *AccountUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AccountUpdateRequest) Impersonate(user string) *AccountUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/accounts_client.go
+++ b/accountsmgmt/v1/accounts_client.go
@@ -102,6 +102,13 @@ func (r *AccountsAddRequest) Header(name string, value interface{}) *AccountsAdd
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AccountsAddRequest) Impersonate(user string) *AccountsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Account data.
@@ -246,6 +253,13 @@ func (r *AccountsListRequest) Parameter(name string, value interface{}) *Account
 // Header adds a request header.
 func (r *AccountsListRequest) Header(name string, value interface{}) *AccountsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AccountsListRequest) Impersonate(user string) *AccountsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/cluster_authorizations_client.go
+++ b/accountsmgmt/v1/cluster_authorizations_client.go
@@ -81,6 +81,13 @@ func (r *ClusterAuthorizationsPostRequest) Header(name string, value interface{}
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterAuthorizationsPostRequest) Impersonate(user string) *ClusterAuthorizationsPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/accountsmgmt/v1/cluster_registrations_client.go
+++ b/accountsmgmt/v1/cluster_registrations_client.go
@@ -82,6 +82,13 @@ func (r *ClusterRegistrationsPostRequest) Header(name string, value interface{})
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterRegistrationsPostRequest) Impersonate(user string) *ClusterRegistrationsPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/accountsmgmt/v1/current_access_client.go
+++ b/accountsmgmt/v1/current_access_client.go
@@ -80,6 +80,13 @@ func (r *CurrentAccessListRequest) Header(name string, value interface{}) *Curre
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CurrentAccessListRequest) Impersonate(user string) *CurrentAccessListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/accountsmgmt/v1/current_account_client.go
+++ b/accountsmgmt/v1/current_account_client.go
@@ -200,6 +200,13 @@ func (r *CurrentAccountGetRequest) Header(name string, value interface{}) *Curre
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CurrentAccountGetRequest) Impersonate(user string) *CurrentAccountGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/feature_toggle_query_client.go
+++ b/accountsmgmt/v1/feature_toggle_query_client.go
@@ -81,6 +81,13 @@ func (r *FeatureToggleQueryPostRequest) Header(name string, value interface{}) *
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *FeatureToggleQueryPostRequest) Impersonate(user string) *FeatureToggleQueryPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/accountsmgmt/v1/generic_label_client.go
+++ b/accountsmgmt/v1/generic_label_client.go
@@ -222,6 +222,13 @@ func (r *GenericLabelDeleteRequest) Header(name string, value interface{}) *Gene
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *GenericLabelDeleteRequest) Impersonate(user string) *GenericLabelDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *GenericLabelGetRequest) Parameter(name string, value interface{}) *Gene
 // Header adds a request header.
 func (r *GenericLabelGetRequest) Header(name string, value interface{}) *GenericLabelGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *GenericLabelGetRequest) Impersonate(user string) *GenericLabelGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *GenericLabelUpdateRequest) Parameter(name string, value interface{}) *G
 // Header adds a request header.
 func (r *GenericLabelUpdateRequest) Header(name string, value interface{}) *GenericLabelUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *GenericLabelUpdateRequest) Impersonate(user string) *GenericLabelUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/generic_labels_client.go
+++ b/accountsmgmt/v1/generic_labels_client.go
@@ -106,6 +106,13 @@ func (r *GenericLabelsAddRequest) Header(name string, value interface{}) *Generi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *GenericLabelsAddRequest) Impersonate(user string) *GenericLabelsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Label
@@ -246,6 +253,13 @@ func (r *GenericLabelsListRequest) Parameter(name string, value interface{}) *Ge
 // Header adds a request header.
 func (r *GenericLabelsListRequest) Header(name string, value interface{}) *GenericLabelsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *GenericLabelsListRequest) Impersonate(user string) *GenericLabelsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/labels_client.go
+++ b/accountsmgmt/v1/labels_client.go
@@ -81,6 +81,13 @@ func (r *LabelsListRequest) Header(name string, value interface{}) *LabelsListRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LabelsListRequest) Impersonate(user string) *LabelsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/accountsmgmt/v1/notify_client.go
+++ b/accountsmgmt/v1/notify_client.go
@@ -81,6 +81,13 @@ func (r *NotifyAddRequest) Header(name string, value interface{}) *NotifyAddRequ
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *NotifyAddRequest) Impersonate(user string) *NotifyAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //

--- a/accountsmgmt/v1/organization_client.go
+++ b/accountsmgmt/v1/organization_client.go
@@ -255,6 +255,13 @@ func (r *OrganizationGetRequest) Header(name string, value interface{}) *Organiz
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *OrganizationGetRequest) Impersonate(user string) *OrganizationGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -380,6 +387,13 @@ func (r *OrganizationUpdateRequest) Parameter(name string, value interface{}) *O
 // Header adds a request header.
 func (r *OrganizationUpdateRequest) Header(name string, value interface{}) *OrganizationUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *OrganizationUpdateRequest) Impersonate(user string) *OrganizationUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/organizations_client.go
+++ b/accountsmgmt/v1/organizations_client.go
@@ -102,6 +102,13 @@ func (r *OrganizationsAddRequest) Header(name string, value interface{}) *Organi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *OrganizationsAddRequest) Impersonate(user string) *OrganizationsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Organization data.
@@ -245,6 +252,13 @@ func (r *OrganizationsListRequest) Parameter(name string, value interface{}) *Or
 // Header adds a request header.
 func (r *OrganizationsListRequest) Header(name string, value interface{}) *OrganizationsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *OrganizationsListRequest) Impersonate(user string) *OrganizationsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/permission_client.go
+++ b/accountsmgmt/v1/permission_client.go
@@ -210,6 +210,13 @@ func (r *PermissionDeleteRequest) Header(name string, value interface{}) *Permis
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PermissionDeleteRequest) Impersonate(user string) *PermissionDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -307,6 +314,13 @@ func (r *PermissionGetRequest) Parameter(name string, value interface{}) *Permis
 // Header adds a request header.
 func (r *PermissionGetRequest) Header(name string, value interface{}) *PermissionGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PermissionGetRequest) Impersonate(user string) *PermissionGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/permissions_client.go
+++ b/accountsmgmt/v1/permissions_client.go
@@ -102,6 +102,13 @@ func (r *PermissionsAddRequest) Header(name string, value interface{}) *Permissi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PermissionsAddRequest) Impersonate(user string) *PermissionsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Permission data.
@@ -242,6 +249,13 @@ func (r *PermissionsListRequest) Parameter(name string, value interface{}) *Perm
 // Header adds a request header.
 func (r *PermissionsListRequest) Header(name string, value interface{}) *PermissionsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PermissionsListRequest) Impersonate(user string) *PermissionsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/plan_id_type.go
+++ b/accountsmgmt/v1/plan_id_type.go
@@ -24,5 +24,5 @@ type PlanID string
 
 const (
 	//
-	PlanIDOCP PlanID = "OCP"
+	PlanIDOCP PlanID = "ocp"
 )

--- a/accountsmgmt/v1/pull_secret_client.go
+++ b/accountsmgmt/v1/pull_secret_client.go
@@ -78,6 +78,13 @@ func (r *PullSecretDeleteRequest) Header(name string, value interface{}) *PullSe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PullSecretDeleteRequest) Impersonate(user string) *PullSecretDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/pull_secrets_client.go
+++ b/accountsmgmt/v1/pull_secrets_client.go
@@ -92,6 +92,13 @@ func (r *PullSecretsPostRequest) Header(name string, value interface{}) *PullSec
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PullSecretsPostRequest) Impersonate(user string) *PullSecretsPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/accountsmgmt/v1/quota_cost_client.go
+++ b/accountsmgmt/v1/quota_cost_client.go
@@ -81,6 +81,13 @@ func (r *QuotaCostListRequest) Header(name string, value interface{}) *QuotaCost
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *QuotaCostListRequest) Impersonate(user string) *QuotaCostListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/accountsmgmt/v1/registries_client.go
+++ b/accountsmgmt/v1/registries_client.go
@@ -91,6 +91,13 @@ func (r *RegistriesListRequest) Header(name string, value interface{}) *Registri
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RegistriesListRequest) Impersonate(user string) *RegistriesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/accountsmgmt/v1/registry_client.go
+++ b/accountsmgmt/v1/registry_client.go
@@ -200,6 +200,13 @@ func (r *RegistryGetRequest) Header(name string, value interface{}) *RegistryGet
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RegistryGetRequest) Impersonate(user string) *RegistryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/registry_credential_client.go
+++ b/accountsmgmt/v1/registry_credential_client.go
@@ -200,6 +200,13 @@ func (r *RegistryCredentialGetRequest) Header(name string, value interface{}) *R
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RegistryCredentialGetRequest) Impersonate(user string) *RegistryCredentialGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/registry_credentials_client.go
+++ b/accountsmgmt/v1/registry_credentials_client.go
@@ -102,6 +102,13 @@ func (r *RegistryCredentialsAddRequest) Header(name string, value interface{}) *
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RegistryCredentialsAddRequest) Impersonate(user string) *RegistryCredentialsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Registry credential data.
@@ -244,6 +251,13 @@ func (r *RegistryCredentialsListRequest) Parameter(name string, value interface{
 // Header adds a request header.
 func (r *RegistryCredentialsListRequest) Header(name string, value interface{}) *RegistryCredentialsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RegistryCredentialsListRequest) Impersonate(user string) *RegistryCredentialsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/resource_quota_client.go
+++ b/accountsmgmt/v1/resource_quota_client.go
@@ -222,6 +222,13 @@ func (r *ResourceQuotaDeleteRequest) Header(name string, value interface{}) *Res
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ResourceQuotaDeleteRequest) Impersonate(user string) *ResourceQuotaDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *ResourceQuotaGetRequest) Parameter(name string, value interface{}) *Res
 // Header adds a request header.
 func (r *ResourceQuotaGetRequest) Header(name string, value interface{}) *ResourceQuotaGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ResourceQuotaGetRequest) Impersonate(user string) *ResourceQuotaGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *ResourceQuotaUpdateRequest) Parameter(name string, value interface{}) *
 // Header adds a request header.
 func (r *ResourceQuotaUpdateRequest) Header(name string, value interface{}) *ResourceQuotaUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ResourceQuotaUpdateRequest) Impersonate(user string) *ResourceQuotaUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/resource_quotas_client.go
+++ b/accountsmgmt/v1/resource_quotas_client.go
@@ -102,6 +102,13 @@ func (r *ResourceQuotasAddRequest) Header(name string, value interface{}) *Resou
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ResourceQuotasAddRequest) Impersonate(user string) *ResourceQuotasAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Resource quota data.
@@ -243,6 +250,13 @@ func (r *ResourceQuotasListRequest) Parameter(name string, value interface{}) *R
 // Header adds a request header.
 func (r *ResourceQuotasListRequest) Header(name string, value interface{}) *ResourceQuotasListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ResourceQuotasListRequest) Impersonate(user string) *ResourceQuotasListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/role_binding_client.go
+++ b/accountsmgmt/v1/role_binding_client.go
@@ -222,6 +222,13 @@ func (r *RoleBindingDeleteRequest) Header(name string, value interface{}) *RoleB
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleBindingDeleteRequest) Impersonate(user string) *RoleBindingDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *RoleBindingGetRequest) Parameter(name string, value interface{}) *RoleB
 // Header adds a request header.
 func (r *RoleBindingGetRequest) Header(name string, value interface{}) *RoleBindingGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleBindingGetRequest) Impersonate(user string) *RoleBindingGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *RoleBindingUpdateRequest) Parameter(name string, value interface{}) *Ro
 // Header adds a request header.
 func (r *RoleBindingUpdateRequest) Header(name string, value interface{}) *RoleBindingUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleBindingUpdateRequest) Impersonate(user string) *RoleBindingUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/role_bindings_client.go
+++ b/accountsmgmt/v1/role_bindings_client.go
@@ -102,6 +102,13 @@ func (r *RoleBindingsAddRequest) Header(name string, value interface{}) *RoleBin
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleBindingsAddRequest) Impersonate(user string) *RoleBindingsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Role binding data.
@@ -243,6 +250,13 @@ func (r *RoleBindingsListRequest) Parameter(name string, value interface{}) *Rol
 // Header adds a request header.
 func (r *RoleBindingsListRequest) Header(name string, value interface{}) *RoleBindingsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleBindingsListRequest) Impersonate(user string) *RoleBindingsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/role_client.go
+++ b/accountsmgmt/v1/role_client.go
@@ -222,6 +222,13 @@ func (r *RoleDeleteRequest) Header(name string, value interface{}) *RoleDeleteRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleDeleteRequest) Impersonate(user string) *RoleDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *RoleGetRequest) Parameter(name string, value interface{}) *RoleGetReque
 // Header adds a request header.
 func (r *RoleGetRequest) Header(name string, value interface{}) *RoleGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleGetRequest) Impersonate(user string) *RoleGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *RoleUpdateRequest) Parameter(name string, value interface{}) *RoleUpdat
 // Header adds a request header.
 func (r *RoleUpdateRequest) Header(name string, value interface{}) *RoleUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RoleUpdateRequest) Impersonate(user string) *RoleUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/roles_client.go
+++ b/accountsmgmt/v1/roles_client.go
@@ -102,6 +102,13 @@ func (r *RolesAddRequest) Header(name string, value interface{}) *RolesAddReques
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RolesAddRequest) Impersonate(user string) *RolesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Role data.
@@ -243,6 +250,13 @@ func (r *RolesListRequest) Parameter(name string, value interface{}) *RolesListR
 // Header adds a request header.
 func (r *RolesListRequest) Header(name string, value interface{}) *RolesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *RolesListRequest) Impersonate(user string) *RolesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/sku_rule_client.go
+++ b/accountsmgmt/v1/sku_rule_client.go
@@ -200,6 +200,13 @@ func (r *SkuRuleGetRequest) Header(name string, value interface{}) *SkuRuleGetRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SkuRuleGetRequest) Impersonate(user string) *SkuRuleGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/sku_rules_client.go
+++ b/accountsmgmt/v1/sku_rules_client.go
@@ -92,6 +92,13 @@ func (r *SkuRulesListRequest) Header(name string, value interface{}) *SkuRulesLi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SkuRulesListRequest) Impersonate(user string) *SkuRulesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/accountsmgmt/v1/subscription_client.go
+++ b/accountsmgmt/v1/subscription_client.go
@@ -264,6 +264,13 @@ func (r *SubscriptionDeleteRequest) Header(name string, value interface{}) *Subs
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionDeleteRequest) Impersonate(user string) *SubscriptionDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -361,6 +368,13 @@ func (r *SubscriptionGetRequest) Parameter(name string, value interface{}) *Subs
 // Header adds a request header.
 func (r *SubscriptionGetRequest) Header(name string, value interface{}) *SubscriptionGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionGetRequest) Impersonate(user string) *SubscriptionGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -489,6 +503,13 @@ func (r *SubscriptionUpdateRequest) Parameter(name string, value interface{}) *S
 // Header adds a request header.
 func (r *SubscriptionUpdateRequest) Header(name string, value interface{}) *SubscriptionUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionUpdateRequest) Impersonate(user string) *SubscriptionUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/subscription_notify_client.go
+++ b/accountsmgmt/v1/subscription_notify_client.go
@@ -81,6 +81,13 @@ func (r *SubscriptionNotifyAddRequest) Header(name string, value interface{}) *S
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionNotifyAddRequest) Impersonate(user string) *SubscriptionNotifyAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //

--- a/accountsmgmt/v1/subscription_reserved_resource_client.go
+++ b/accountsmgmt/v1/subscription_reserved_resource_client.go
@@ -200,6 +200,13 @@ func (r *SubscriptionReservedResourceGetRequest) Header(name string, value inter
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionReservedResourceGetRequest) Impersonate(user string) *SubscriptionReservedResourceGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/subscription_reserved_resources_client.go
+++ b/accountsmgmt/v1/subscription_reserved_resources_client.go
@@ -92,6 +92,13 @@ func (r *SubscriptionReservedResourcesListRequest) Header(name string, value int
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionReservedResourcesListRequest) Impersonate(user string) *SubscriptionReservedResourcesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/accountsmgmt/v1/subscriptions_client.go
+++ b/accountsmgmt/v1/subscriptions_client.go
@@ -119,6 +119,13 @@ func (r *SubscriptionsListRequest) Header(name string, value interface{}) *Subsc
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionsListRequest) Impersonate(user string) *SubscriptionsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // FetchaccountsAccounts sets the value of the 'fetchaccounts_accounts' parameter.
 //
 // If true, includes the account reference information in the output. Could slow request response time.
@@ -437,6 +444,13 @@ func (r *SubscriptionsPostRequest) Parameter(name string, value interface{}) *Su
 // Header adds a request header.
 func (r *SubscriptionsPostRequest) Header(name string, value interface{}) *SubscriptionsPostRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SubscriptionsPostRequest) Impersonate(user string) *SubscriptionsPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/accountsmgmt/v1/summary_dashboard_client.go
+++ b/accountsmgmt/v1/summary_dashboard_client.go
@@ -200,6 +200,13 @@ func (r *SummaryDashboardGetRequest) Header(name string, value interface{}) *Sum
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SummaryDashboardGetRequest) Impersonate(user string) *SummaryDashboardGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/support_case_client.go
+++ b/accountsmgmt/v1/support_case_client.go
@@ -78,6 +78,13 @@ func (r *SupportCaseDeleteRequest) Header(name string, value interface{}) *Suppo
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SupportCaseDeleteRequest) Impersonate(user string) *SupportCaseDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/accountsmgmt/v1/support_cases_client.go
+++ b/accountsmgmt/v1/support_cases_client.go
@@ -92,6 +92,13 @@ func (r *SupportCasesPostRequest) Header(name string, value interface{}) *Suppor
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SupportCasesPostRequest) Impersonate(user string) *SupportCasesPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/accountsmgmt/v1/token_authorization_client.go
+++ b/accountsmgmt/v1/token_authorization_client.go
@@ -81,6 +81,13 @@ func (r *TokenAuthorizationPostRequest) Header(name string, value interface{}) *
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *TokenAuthorizationPostRequest) Impersonate(user string) *TokenAuthorizationPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/access_review_client.go
+++ b/authorizations/v1/access_review_client.go
@@ -81,6 +81,13 @@ func (r *AccessReviewPostRequest) Header(name string, value interface{}) *Access
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AccessReviewPostRequest) Impersonate(user string) *AccessReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/capability_review_client.go
+++ b/authorizations/v1/capability_review_client.go
@@ -81,6 +81,13 @@ func (r *CapabilityReviewPostRequest) Header(name string, value interface{}) *Ca
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CapabilityReviewPostRequest) Impersonate(user string) *CapabilityReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/export_control_review_client.go
+++ b/authorizations/v1/export_control_review_client.go
@@ -81,6 +81,13 @@ func (r *ExportControlReviewPostRequest) Header(name string, value interface{}) 
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ExportControlReviewPostRequest) Impersonate(user string) *ExportControlReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/feature_review_client.go
+++ b/authorizations/v1/feature_review_client.go
@@ -81,6 +81,13 @@ func (r *FeatureReviewPostRequest) Header(name string, value interface{}) *Featu
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *FeatureReviewPostRequest) Impersonate(user string) *FeatureReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/resource_review_client.go
+++ b/authorizations/v1/resource_review_client.go
@@ -82,6 +82,13 @@ func (r *ResourceReviewPostRequest) Header(name string, value interface{}) *Reso
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ResourceReviewPostRequest) Impersonate(user string) *ResourceReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/self_access_review_client.go
+++ b/authorizations/v1/self_access_review_client.go
@@ -81,6 +81,13 @@ func (r *SelfAccessReviewPostRequest) Header(name string, value interface{}) *Se
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SelfAccessReviewPostRequest) Impersonate(user string) *SelfAccessReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/self_capability_review_client.go
+++ b/authorizations/v1/self_capability_review_client.go
@@ -81,6 +81,13 @@ func (r *SelfCapabilityReviewPostRequest) Header(name string, value interface{})
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SelfCapabilityReviewPostRequest) Impersonate(user string) *SelfCapabilityReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/self_feature_review_client.go
+++ b/authorizations/v1/self_feature_review_client.go
@@ -81,6 +81,13 @@ func (r *SelfFeatureReviewPostRequest) Header(name string, value interface{}) *S
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SelfFeatureReviewPostRequest) Impersonate(user string) *SelfFeatureReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/self_terms_review_client.go
+++ b/authorizations/v1/self_terms_review_client.go
@@ -82,6 +82,13 @@ func (r *SelfTermsReviewPostRequest) Header(name string, value interface{}) *Sel
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SelfTermsReviewPostRequest) Impersonate(user string) *SelfTermsReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/authorizations/v1/terms_review_client.go
+++ b/authorizations/v1/terms_review_client.go
@@ -82,6 +82,13 @@ func (r *TermsReviewPostRequest) Header(name string, value interface{}) *TermsRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *TermsReviewPostRequest) Impersonate(user string) *TermsReviewPostRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Request sets the value of the 'request' parameter.
 //
 //

--- a/clustersmgmt/v1/add_on_client.go
+++ b/clustersmgmt/v1/add_on_client.go
@@ -233,6 +233,13 @@ func (r *AddOnDeleteRequest) Header(name string, value interface{}) *AddOnDelete
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnDeleteRequest) Impersonate(user string) *AddOnDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -330,6 +337,13 @@ func (r *AddOnGetRequest) Parameter(name string, value interface{}) *AddOnGetReq
 // Header adds a request header.
 func (r *AddOnGetRequest) Header(name string, value interface{}) *AddOnGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnGetRequest) Impersonate(user string) *AddOnGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -458,6 +472,13 @@ func (r *AddOnUpdateRequest) Parameter(name string, value interface{}) *AddOnUpd
 // Header adds a request header.
 func (r *AddOnUpdateRequest) Header(name string, value interface{}) *AddOnUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnUpdateRequest) Impersonate(user string) *AddOnUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/add_on_installation_client.go
+++ b/clustersmgmt/v1/add_on_installation_client.go
@@ -222,6 +222,13 @@ func (r *AddOnInstallationDeleteRequest) Header(name string, value interface{}) 
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnInstallationDeleteRequest) Impersonate(user string) *AddOnInstallationDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *AddOnInstallationGetRequest) Parameter(name string, value interface{}) 
 // Header adds a request header.
 func (r *AddOnInstallationGetRequest) Header(name string, value interface{}) *AddOnInstallationGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnInstallationGetRequest) Impersonate(user string) *AddOnInstallationGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *AddOnInstallationUpdateRequest) Parameter(name string, value interface{
 // Header adds a request header.
 func (r *AddOnInstallationUpdateRequest) Header(name string, value interface{}) *AddOnInstallationUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnInstallationUpdateRequest) Impersonate(user string) *AddOnInstallationUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/add_on_installations_client.go
+++ b/clustersmgmt/v1/add_on_installations_client.go
@@ -102,6 +102,13 @@ func (r *AddOnInstallationsAddRequest) Header(name string, value interface{}) *A
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnInstallationsAddRequest) Impersonate(user string) *AddOnInstallationsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the add-on installation.
@@ -244,6 +251,13 @@ func (r *AddOnInstallationsListRequest) Parameter(name string, value interface{}
 // Header adds a request header.
 func (r *AddOnInstallationsListRequest) Header(name string, value interface{}) *AddOnInstallationsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnInstallationsListRequest) Impersonate(user string) *AddOnInstallationsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/add_on_version_client.go
+++ b/clustersmgmt/v1/add_on_version_client.go
@@ -222,6 +222,13 @@ func (r *AddOnVersionDeleteRequest) Header(name string, value interface{}) *AddO
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnVersionDeleteRequest) Impersonate(user string) *AddOnVersionDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *AddOnVersionGetRequest) Parameter(name string, value interface{}) *AddO
 // Header adds a request header.
 func (r *AddOnVersionGetRequest) Header(name string, value interface{}) *AddOnVersionGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnVersionGetRequest) Impersonate(user string) *AddOnVersionGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *AddOnVersionUpdateRequest) Parameter(name string, value interface{}) *A
 // Header adds a request header.
 func (r *AddOnVersionUpdateRequest) Header(name string, value interface{}) *AddOnVersionUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnVersionUpdateRequest) Impersonate(user string) *AddOnVersionUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/add_on_versions_client.go
+++ b/clustersmgmt/v1/add_on_versions_client.go
@@ -102,6 +102,13 @@ func (r *AddOnVersionsAddRequest) Header(name string, value interface{}) *AddOnV
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnVersionsAddRequest) Impersonate(user string) *AddOnVersionsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the add-on version.
@@ -244,6 +251,13 @@ func (r *AddOnVersionsListRequest) Parameter(name string, value interface{}) *Ad
 // Header adds a request header.
 func (r *AddOnVersionsListRequest) Header(name string, value interface{}) *AddOnVersionsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnVersionsListRequest) Impersonate(user string) *AddOnVersionsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/add_ons_client.go
+++ b/clustersmgmt/v1/add_ons_client.go
@@ -102,6 +102,13 @@ func (r *AddOnsAddRequest) Header(name string, value interface{}) *AddOnsAddRequ
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnsAddRequest) Impersonate(user string) *AddOnsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the add-on.
@@ -244,6 +251,13 @@ func (r *AddOnsListRequest) Parameter(name string, value interface{}) *AddOnsLis
 // Header adds a request header.
 func (r *AddOnsListRequest) Header(name string, value interface{}) *AddOnsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddOnsListRequest) Impersonate(user string) *AddOnsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/addon_inquiries_client.go
+++ b/clustersmgmt/v1/addon_inquiries_client.go
@@ -94,6 +94,13 @@ func (r *AddonInquiriesListRequest) Header(name string, value interface{}) *Addo
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddonInquiriesListRequest) Impersonate(user string) *AddonInquiriesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Order sets the value of the 'order' parameter.
 //
 // Order criteria.

--- a/clustersmgmt/v1/addon_inquiry_client.go
+++ b/clustersmgmt/v1/addon_inquiry_client.go
@@ -200,6 +200,13 @@ func (r *AddonInquiryGetRequest) Header(name string, value interface{}) *AddonIn
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AddonInquiryGetRequest) Impersonate(user string) *AddonInquiryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/alerts_metric_query_client.go
+++ b/clustersmgmt/v1/alerts_metric_query_client.go
@@ -200,6 +200,13 @@ func (r *AlertsMetricQueryGetRequest) Header(name string, value interface{}) *Al
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AlertsMetricQueryGetRequest) Impersonate(user string) *AlertsMetricQueryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/available_regions_client.go
+++ b/clustersmgmt/v1/available_regions_client.go
@@ -87,6 +87,13 @@ func (r *AvailableRegionsSearchRequest) Header(name string, value interface{}) *
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AvailableRegionsSearchRequest) Impersonate(user string) *AvailableRegionsSearchRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // AWS account details

--- a/clustersmgmt/v1/available_regions_inquiry_client.go
+++ b/clustersmgmt/v1/available_regions_inquiry_client.go
@@ -86,6 +86,13 @@ func (r *AvailableRegionsInquirySearchRequest) Header(name string, value interfa
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AvailableRegionsInquirySearchRequest) Impersonate(user string) *AvailableRegionsInquirySearchRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Cloud provider data needed for the inquiry

--- a/clustersmgmt/v1/aws_infrastructure_access_role_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_client.go
@@ -200,6 +200,13 @@ func (r *AWSInfrastructureAccessRoleGetRequest) Header(name string, value interf
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AWSInfrastructureAccessRoleGetRequest) Impersonate(user string) *AWSInfrastructureAccessRoleGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grant_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grant_client.go
@@ -210,6 +210,13 @@ func (r *AWSInfrastructureAccessRoleGrantDeleteRequest) Header(name string, valu
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AWSInfrastructureAccessRoleGrantDeleteRequest) Impersonate(user string) *AWSInfrastructureAccessRoleGrantDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -307,6 +314,13 @@ func (r *AWSInfrastructureAccessRoleGrantGetRequest) Parameter(name string, valu
 // Header adds a request header.
 func (r *AWSInfrastructureAccessRoleGrantGetRequest) Header(name string, value interface{}) *AWSInfrastructureAccessRoleGrantGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AWSInfrastructureAccessRoleGrantGetRequest) Impersonate(user string) *AWSInfrastructureAccessRoleGrantGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grants_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grants_client.go
@@ -103,6 +103,13 @@ func (r *AWSInfrastructureAccessRoleGrantsAddRequest) Header(name string, value 
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AWSInfrastructureAccessRoleGrantsAddRequest) Impersonate(user string) *AWSInfrastructureAccessRoleGrantsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the AWS infrastructure access role grant.
@@ -245,6 +252,13 @@ func (r *AWSInfrastructureAccessRoleGrantsListRequest) Parameter(name string, va
 // Header adds a request header.
 func (r *AWSInfrastructureAccessRoleGrantsListRequest) Header(name string, value interface{}) *AWSInfrastructureAccessRoleGrantsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AWSInfrastructureAccessRoleGrantsListRequest) Impersonate(user string) *AWSInfrastructureAccessRoleGrantsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
@@ -93,6 +93,13 @@ func (r *AWSInfrastructureAccessRolesListRequest) Header(name string, value inte
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *AWSInfrastructureAccessRolesListRequest) Impersonate(user string) *AWSInfrastructureAccessRolesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Order sets the value of the 'order' parameter.
 //
 // Order criteria.

--- a/clustersmgmt/v1/cloud_provider_client.go
+++ b/clustersmgmt/v1/cloud_provider_client.go
@@ -223,6 +223,13 @@ func (r *CloudProviderGetRequest) Header(name string, value interface{}) *CloudP
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CloudProviderGetRequest) Impersonate(user string) *CloudProviderGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/cloud_providers_client.go
+++ b/clustersmgmt/v1/cloud_providers_client.go
@@ -93,6 +93,13 @@ func (r *CloudProvidersListRequest) Header(name string, value interface{}) *Clou
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CloudProvidersListRequest) Impersonate(user string) *CloudProvidersListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Order sets the value of the 'order' parameter.
 //
 // Order criteria.

--- a/clustersmgmt/v1/cloud_region_client.go
+++ b/clustersmgmt/v1/cloud_region_client.go
@@ -200,6 +200,13 @@ func (r *CloudRegionGetRequest) Header(name string, value interface{}) *CloudReg
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CloudRegionGetRequest) Impersonate(user string) *CloudRegionGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/cloud_regions_client.go
+++ b/clustersmgmt/v1/cloud_regions_client.go
@@ -95,6 +95,13 @@ func (r *CloudRegionsListRequest) Header(name string, value interface{}) *CloudR
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CloudRegionsListRequest) Impersonate(user string) *CloudRegionsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the returned page, where one corresponds to the first page. As this

--- a/clustersmgmt/v1/cluster_client.go
+++ b/clustersmgmt/v1/cluster_client.go
@@ -446,6 +446,13 @@ func (r *ClusterDeleteRequest) Header(name string, value interface{}) *ClusterDe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterDeleteRequest) Impersonate(user string) *ClusterDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Deprovision sets the value of the 'deprovision' parameter.
 //
 // If false it will only delete from OCM but not the actual cluster resources.
@@ -555,6 +562,13 @@ func (r *ClusterGetRequest) Parameter(name string, value interface{}) *ClusterGe
 // Header adds a request header.
 func (r *ClusterGetRequest) Header(name string, value interface{}) *ClusterGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterGetRequest) Impersonate(user string) *ClusterGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -685,6 +699,13 @@ func (r *ClusterHibernateRequest) Header(name string, value interface{}) *Cluste
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterHibernateRequest) Impersonate(user string) *ClusterHibernateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -782,6 +803,13 @@ func (r *ClusterResumeRequest) Parameter(name string, value interface{}) *Cluste
 // Header adds a request header.
 func (r *ClusterResumeRequest) Header(name string, value interface{}) *ClusterResumeRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterResumeRequest) Impersonate(user string) *ClusterResumeRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -883,6 +911,13 @@ func (r *ClusterUpdateRequest) Parameter(name string, value interface{}) *Cluste
 // Header adds a request header.
 func (r *ClusterUpdateRequest) Header(name string, value interface{}) *ClusterUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterUpdateRequest) Impersonate(user string) *ClusterUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/cluster_operators_metric_query_client.go
+++ b/clustersmgmt/v1/cluster_operators_metric_query_client.go
@@ -200,6 +200,13 @@ func (r *ClusterOperatorsMetricQueryGetRequest) Header(name string, value interf
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterOperatorsMetricQueryGetRequest) Impersonate(user string) *ClusterOperatorsMetricQueryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/cluster_resources_client.go
+++ b/clustersmgmt/v1/cluster_resources_client.go
@@ -200,6 +200,13 @@ func (r *ClusterResourcesGetRequest) Header(name string, value interface{}) *Clu
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterResourcesGetRequest) Impersonate(user string) *ClusterResourcesGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/cluster_status_client.go
+++ b/clustersmgmt/v1/cluster_status_client.go
@@ -200,6 +200,13 @@ func (r *ClusterStatusGetRequest) Header(name string, value interface{}) *Cluste
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterStatusGetRequest) Impersonate(user string) *ClusterStatusGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/clusterdeployment_client.go
+++ b/clustersmgmt/v1/clusterdeployment_client.go
@@ -78,6 +78,13 @@ func (r *ClusterdeploymentDeleteRequest) Header(name string, value interface{}) 
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterdeploymentDeleteRequest) Impersonate(user string) *ClusterdeploymentDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/clusters_client.go
+++ b/clustersmgmt/v1/clusters_client.go
@@ -104,6 +104,13 @@ func (r *ClustersAddRequest) Header(name string, value interface{}) *ClustersAdd
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClustersAddRequest) Impersonate(user string) *ClustersAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the cluster.
@@ -246,6 +253,13 @@ func (r *ClustersListRequest) Parameter(name string, value interface{}) *Cluster
 // Header adds a request header.
 func (r *ClustersListRequest) Header(name string, value interface{}) *ClustersListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClustersListRequest) Impersonate(user string) *ClustersListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_client.go
+++ b/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_client.go
@@ -200,6 +200,13 @@ func (r *CPUTotalByNodeRolesOSMetricQueryGetRequest) Header(name string, value i
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CPUTotalByNodeRolesOSMetricQueryGetRequest) Impersonate(user string) *CPUTotalByNodeRolesOSMetricQueryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/credentials_client.go
+++ b/clustersmgmt/v1/credentials_client.go
@@ -200,6 +200,13 @@ func (r *CredentialsGetRequest) Header(name string, value interface{}) *Credenti
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *CredentialsGetRequest) Impersonate(user string) *CredentialsGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/encryption_keys_inquiry_client.go
+++ b/clustersmgmt/v1/encryption_keys_inquiry_client.go
@@ -86,6 +86,13 @@ func (r *EncryptionKeysInquirySearchRequest) Header(name string, value interface
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *EncryptionKeysInquirySearchRequest) Impersonate(user string) *EncryptionKeysInquirySearchRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Cloud provider data needed for the inquiry

--- a/clustersmgmt/v1/environment_client.go
+++ b/clustersmgmt/v1/environment_client.go
@@ -217,6 +217,13 @@ func (r *EnvironmentGetRequest) Header(name string, value interface{}) *Environm
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *EnvironmentGetRequest) Impersonate(user string) *EnvironmentGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -342,6 +349,13 @@ func (r *EnvironmentUpdateRequest) Parameter(name string, value interface{}) *En
 // Header adds a request header.
 func (r *EnvironmentUpdateRequest) Header(name string, value interface{}) *EnvironmentUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *EnvironmentUpdateRequest) Impersonate(user string) *EnvironmentUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/events_client.go
+++ b/clustersmgmt/v1/events_client.go
@@ -86,6 +86,13 @@ func (r *EventsAddRequest) Header(name string, value interface{}) *EventsAddRequ
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *EventsAddRequest) Impersonate(user string) *EventsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the event.

--- a/clustersmgmt/v1/external_configuration_client.go
+++ b/clustersmgmt/v1/external_configuration_client.go
@@ -221,6 +221,13 @@ func (r *ExternalConfigurationGetRequest) Header(name string, value interface{})
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ExternalConfigurationGetRequest) Impersonate(user string) *ExternalConfigurationGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/flavour_client.go
+++ b/clustersmgmt/v1/flavour_client.go
@@ -218,6 +218,13 @@ func (r *FlavourGetRequest) Header(name string, value interface{}) *FlavourGetRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *FlavourGetRequest) Impersonate(user string) *FlavourGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -343,6 +350,13 @@ func (r *FlavourUpdateRequest) Parameter(name string, value interface{}) *Flavou
 // Header adds a request header.
 func (r *FlavourUpdateRequest) Header(name string, value interface{}) *FlavourUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *FlavourUpdateRequest) Impersonate(user string) *FlavourUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/flavours_client.go
+++ b/clustersmgmt/v1/flavours_client.go
@@ -102,6 +102,13 @@ func (r *FlavoursAddRequest) Header(name string, value interface{}) *FlavoursAdd
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *FlavoursAddRequest) Impersonate(user string) *FlavoursAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Details of the cluster flavour.
@@ -244,6 +251,13 @@ func (r *FlavoursListRequest) Parameter(name string, value interface{}) *Flavour
 // Header adds a request header.
 func (r *FlavoursListRequest) Header(name string, value interface{}) *FlavoursListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *FlavoursListRequest) Impersonate(user string) *FlavoursListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/group_client.go
+++ b/clustersmgmt/v1/group_client.go
@@ -211,6 +211,13 @@ func (r *GroupGetRequest) Header(name string, value interface{}) *GroupGetReques
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *GroupGetRequest) Impersonate(user string) *GroupGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/groups_client.go
+++ b/clustersmgmt/v1/groups_client.go
@@ -91,6 +91,13 @@ func (r *GroupsListRequest) Header(name string, value interface{}) *GroupsListRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *GroupsListRequest) Impersonate(user string) *GroupsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/clustersmgmt/v1/ht_passwd_user_client.go
+++ b/clustersmgmt/v1/ht_passwd_user_client.go
@@ -222,6 +222,13 @@ func (r *HTPasswdUserDeleteRequest) Header(name string, value interface{}) *HTPa
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *HTPasswdUserDeleteRequest) Impersonate(user string) *HTPasswdUserDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *HTPasswdUserGetRequest) Parameter(name string, value interface{}) *HTPa
 // Header adds a request header.
 func (r *HTPasswdUserGetRequest) Header(name string, value interface{}) *HTPasswdUserGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *HTPasswdUserGetRequest) Impersonate(user string) *HTPasswdUserGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *HTPasswdUserUpdateRequest) Parameter(name string, value interface{}) *H
 // Header adds a request header.
 func (r *HTPasswdUserUpdateRequest) Header(name string, value interface{}) *HTPasswdUserUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *HTPasswdUserUpdateRequest) Impersonate(user string) *HTPasswdUserUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/ht_passwd_users_client.go
+++ b/clustersmgmt/v1/ht_passwd_users_client.go
@@ -102,6 +102,13 @@ func (r *HTPasswdUsersAddRequest) Header(name string, value interface{}) *HTPass
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *HTPasswdUsersAddRequest) Impersonate(user string) *HTPasswdUsersAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // New user to be added
@@ -242,6 +249,13 @@ func (r *HTPasswdUsersListRequest) Parameter(name string, value interface{}) *HT
 // Header adds a request header.
 func (r *HTPasswdUsersListRequest) Header(name string, value interface{}) *HTPasswdUsersListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *HTPasswdUsersListRequest) Impersonate(user string) *HTPasswdUsersListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/identity_provider_client.go
+++ b/clustersmgmt/v1/identity_provider_client.go
@@ -233,6 +233,13 @@ func (r *IdentityProviderDeleteRequest) Header(name string, value interface{}) *
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IdentityProviderDeleteRequest) Impersonate(user string) *IdentityProviderDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -330,6 +337,13 @@ func (r *IdentityProviderGetRequest) Parameter(name string, value interface{}) *
 // Header adds a request header.
 func (r *IdentityProviderGetRequest) Header(name string, value interface{}) *IdentityProviderGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IdentityProviderGetRequest) Impersonate(user string) *IdentityProviderGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -458,6 +472,13 @@ func (r *IdentityProviderUpdateRequest) Parameter(name string, value interface{}
 // Header adds a request header.
 func (r *IdentityProviderUpdateRequest) Header(name string, value interface{}) *IdentityProviderUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IdentityProviderUpdateRequest) Impersonate(user string) *IdentityProviderUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/identity_provider_type_type.go
+++ b/clustersmgmt/v1/identity_provider_type_type.go
@@ -24,7 +24,7 @@ type IdentityProviderType string
 
 const (
 	//
-	IdentityProviderTypeLDAP IdentityProviderType = "LDAP"
+	IdentityProviderTypeLDAP IdentityProviderType = "ldap"
 	//
 	IdentityProviderTypeGithub IdentityProviderType = "github"
 	//
@@ -34,5 +34,5 @@ const (
 	//
 	IdentityProviderTypeHtpasswd IdentityProviderType = "htpasswd"
 	//
-	IdentityProviderTypeOpenID IdentityProviderType = "open_ID"
+	IdentityProviderTypeOpenID IdentityProviderType = "open_id"
 )

--- a/clustersmgmt/v1/identity_providers_client.go
+++ b/clustersmgmt/v1/identity_providers_client.go
@@ -102,6 +102,13 @@ func (r *IdentityProvidersAddRequest) Header(name string, value interface{}) *Id
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IdentityProvidersAddRequest) Impersonate(user string) *IdentityProvidersAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the cluster.
@@ -242,6 +249,13 @@ func (r *IdentityProvidersListRequest) Parameter(name string, value interface{})
 // Header adds a request header.
 func (r *IdentityProvidersListRequest) Header(name string, value interface{}) *IdentityProvidersListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IdentityProvidersListRequest) Impersonate(user string) *IdentityProvidersListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/ingress_client.go
+++ b/clustersmgmt/v1/ingress_client.go
@@ -222,6 +222,13 @@ func (r *IngressDeleteRequest) Header(name string, value interface{}) *IngressDe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IngressDeleteRequest) Impersonate(user string) *IngressDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *IngressGetRequest) Parameter(name string, value interface{}) *IngressGe
 // Header adds a request header.
 func (r *IngressGetRequest) Header(name string, value interface{}) *IngressGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IngressGetRequest) Impersonate(user string) *IngressGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *IngressUpdateRequest) Parameter(name string, value interface{}) *Ingres
 // Header adds a request header.
 func (r *IngressUpdateRequest) Header(name string, value interface{}) *IngressUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IngressUpdateRequest) Impersonate(user string) *IngressUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/ingresses_client.go
+++ b/clustersmgmt/v1/ingresses_client.go
@@ -112,6 +112,13 @@ func (r *IngressesAddRequest) Header(name string, value interface{}) *IngressesA
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IngressesAddRequest) Impersonate(user string) *IngressesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the ingress
@@ -252,6 +259,13 @@ func (r *IngressesListRequest) Parameter(name string, value interface{}) *Ingres
 // Header adds a request header.
 func (r *IngressesListRequest) Header(name string, value interface{}) *IngressesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IngressesListRequest) Impersonate(user string) *IngressesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -471,6 +485,13 @@ func (r *IngressesUpdateRequest) Parameter(name string, value interface{}) *Ingr
 // Header adds a request header.
 func (r *IngressesUpdateRequest) Header(name string, value interface{}) *IngressesUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *IngressesUpdateRequest) Impersonate(user string) *IngressesUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/key_rings_inquiry_client.go
+++ b/clustersmgmt/v1/key_rings_inquiry_client.go
@@ -86,6 +86,13 @@ func (r *KeyRingsInquirySearchRequest) Header(name string, value interface{}) *K
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *KeyRingsInquirySearchRequest) Impersonate(user string) *KeyRingsInquirySearchRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Cloud provider data needed for the inquiry

--- a/clustersmgmt/v1/label_client.go
+++ b/clustersmgmt/v1/label_client.go
@@ -222,6 +222,13 @@ func (r *LabelDeleteRequest) Header(name string, value interface{}) *LabelDelete
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LabelDeleteRequest) Impersonate(user string) *LabelDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *LabelGetRequest) Parameter(name string, value interface{}) *LabelGetReq
 // Header adds a request header.
 func (r *LabelGetRequest) Header(name string, value interface{}) *LabelGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LabelGetRequest) Impersonate(user string) *LabelGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *LabelUpdateRequest) Parameter(name string, value interface{}) *LabelUpd
 // Header adds a request header.
 func (r *LabelUpdateRequest) Header(name string, value interface{}) *LabelUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LabelUpdateRequest) Impersonate(user string) *LabelUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/labels_client.go
+++ b/clustersmgmt/v1/labels_client.go
@@ -102,6 +102,13 @@ func (r *LabelsAddRequest) Header(name string, value interface{}) *LabelsAddRequ
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LabelsAddRequest) Impersonate(user string) *LabelsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the label.
@@ -242,6 +249,13 @@ func (r *LabelsListRequest) Parameter(name string, value interface{}) *LabelsLis
 // Header adds a request header.
 func (r *LabelsListRequest) Header(name string, value interface{}) *LabelsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LabelsListRequest) Impersonate(user string) *LabelsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/limited_support_reason_client.go
+++ b/clustersmgmt/v1/limited_support_reason_client.go
@@ -210,6 +210,13 @@ func (r *LimitedSupportReasonDeleteRequest) Header(name string, value interface{
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LimitedSupportReasonDeleteRequest) Impersonate(user string) *LimitedSupportReasonDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -307,6 +314,13 @@ func (r *LimitedSupportReasonGetRequest) Parameter(name string, value interface{
 // Header adds a request header.
 func (r *LimitedSupportReasonGetRequest) Header(name string, value interface{}) *LimitedSupportReasonGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LimitedSupportReasonGetRequest) Impersonate(user string) *LimitedSupportReasonGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/limited_support_reason_template_client.go
+++ b/clustersmgmt/v1/limited_support_reason_template_client.go
@@ -200,6 +200,13 @@ func (r *LimitedSupportReasonTemplateGetRequest) Header(name string, value inter
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LimitedSupportReasonTemplateGetRequest) Impersonate(user string) *LimitedSupportReasonTemplateGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/limited_support_reason_templates_client.go
+++ b/clustersmgmt/v1/limited_support_reason_templates_client.go
@@ -91,6 +91,13 @@ func (r *LimitedSupportReasonTemplatesListRequest) Header(name string, value int
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LimitedSupportReasonTemplatesListRequest) Impersonate(user string) *LimitedSupportReasonTemplatesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/clustersmgmt/v1/limited_support_reasons_client.go
+++ b/clustersmgmt/v1/limited_support_reasons_client.go
@@ -102,6 +102,13 @@ func (r *LimitedSupportReasonsAddRequest) Header(name string, value interface{})
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LimitedSupportReasonsAddRequest) Impersonate(user string) *LimitedSupportReasonsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the reason.
@@ -242,6 +249,13 @@ func (r *LimitedSupportReasonsListRequest) Parameter(name string, value interfac
 // Header adds a request header.
 func (r *LimitedSupportReasonsListRequest) Header(name string, value interface{}) *LimitedSupportReasonsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LimitedSupportReasonsListRequest) Impersonate(user string) *LimitedSupportReasonsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/log_client.go
+++ b/clustersmgmt/v1/log_client.go
@@ -224,6 +224,13 @@ func (r *LogGetRequest) Header(name string, value interface{}) *LogGetRequest {
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LogGetRequest) Impersonate(user string) *LogGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Offset sets the value of the 'offset' parameter.
 //
 // Line offset to start logs from. if 0 retreive entire log.

--- a/clustersmgmt/v1/logs_client.go
+++ b/clustersmgmt/v1/logs_client.go
@@ -101,6 +101,13 @@ func (r *LogsListRequest) Header(name string, value interface{}) *LogsListReques
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LogsListRequest) Impersonate(user string) *LogsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/clustersmgmt/v1/machine_pool_client.go
+++ b/clustersmgmt/v1/machine_pool_client.go
@@ -222,6 +222,13 @@ func (r *MachinePoolDeleteRequest) Header(name string, value interface{}) *Machi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *MachinePoolDeleteRequest) Impersonate(user string) *MachinePoolDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *MachinePoolGetRequest) Parameter(name string, value interface{}) *Machi
 // Header adds a request header.
 func (r *MachinePoolGetRequest) Header(name string, value interface{}) *MachinePoolGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *MachinePoolGetRequest) Impersonate(user string) *MachinePoolGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *MachinePoolUpdateRequest) Parameter(name string, value interface{}) *Ma
 // Header adds a request header.
 func (r *MachinePoolUpdateRequest) Header(name string, value interface{}) *MachinePoolUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *MachinePoolUpdateRequest) Impersonate(user string) *MachinePoolUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/machine_pools_client.go
+++ b/clustersmgmt/v1/machine_pools_client.go
@@ -102,6 +102,13 @@ func (r *MachinePoolsAddRequest) Header(name string, value interface{}) *Machine
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *MachinePoolsAddRequest) Impersonate(user string) *MachinePoolsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the machine pool
@@ -242,6 +249,13 @@ func (r *MachinePoolsListRequest) Parameter(name string, value interface{}) *Mac
 // Header adds a request header.
 func (r *MachinePoolsListRequest) Header(name string, value interface{}) *MachinePoolsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *MachinePoolsListRequest) Impersonate(user string) *MachinePoolsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/machine_type_client.go
+++ b/clustersmgmt/v1/machine_type_client.go
@@ -200,6 +200,13 @@ func (r *MachineTypeGetRequest) Header(name string, value interface{}) *MachineT
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *MachineTypeGetRequest) Impersonate(user string) *MachineTypeGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/machine_types_client.go
+++ b/clustersmgmt/v1/machine_types_client.go
@@ -82,6 +82,13 @@ func (r *MachineTypesListRequest) Header(name string, value interface{}) *Machin
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *MachineTypesListRequest) Impersonate(user string) *MachineTypesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Order sets the value of the 'order' parameter.
 //
 // Order criteria.

--- a/clustersmgmt/v1/nodes_metric_query_client.go
+++ b/clustersmgmt/v1/nodes_metric_query_client.go
@@ -200,6 +200,13 @@ func (r *NodesMetricQueryGetRequest) Header(name string, value interface{}) *Nod
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *NodesMetricQueryGetRequest) Impersonate(user string) *NodesMetricQueryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/operator_iam_role_client.go
+++ b/clustersmgmt/v1/operator_iam_role_client.go
@@ -78,6 +78,13 @@ func (r *OperatorIAMRoleDeleteRequest) Header(name string, value interface{}) *O
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *OperatorIAMRoleDeleteRequest) Impersonate(user string) *OperatorIAMRoleDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/operator_iam_roles_client.go
+++ b/clustersmgmt/v1/operator_iam_roles_client.go
@@ -102,6 +102,13 @@ func (r *OperatorIAMRolesAddRequest) Header(name string, value interface{}) *Ope
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *OperatorIAMRolesAddRequest) Impersonate(user string) *OperatorIAMRolesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the operator role.
@@ -242,6 +249,13 @@ func (r *OperatorIAMRolesListRequest) Parameter(name string, value interface{}) 
 // Header adds a request header.
 func (r *OperatorIAMRolesListRequest) Header(name string, value interface{}) *OperatorIAMRolesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *OperatorIAMRolesListRequest) Impersonate(user string) *OperatorIAMRolesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/product_client.go
+++ b/clustersmgmt/v1/product_client.go
@@ -200,6 +200,13 @@ func (r *ProductGetRequest) Header(name string, value interface{}) *ProductGetRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProductGetRequest) Impersonate(user string) *ProductGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/products_client.go
+++ b/clustersmgmt/v1/products_client.go
@@ -93,6 +93,13 @@ func (r *ProductsListRequest) Header(name string, value interface{}) *ProductsLi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProductsListRequest) Impersonate(user string) *ProductsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Order sets the value of the 'order' parameter.
 //
 // Order criteria.

--- a/clustersmgmt/v1/provision_shard_client.go
+++ b/clustersmgmt/v1/provision_shard_client.go
@@ -200,6 +200,13 @@ func (r *ProvisionShardGetRequest) Header(name string, value interface{}) *Provi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProvisionShardGetRequest) Impersonate(user string) *ProvisionShardGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/provision_shards_client.go
+++ b/clustersmgmt/v1/provision_shards_client.go
@@ -91,6 +91,13 @@ func (r *ProvisionShardsListRequest) Header(name string, value interface{}) *Pro
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProvisionShardsListRequest) Impersonate(user string) *ProvisionShardsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/clustersmgmt/v1/resources_client.go
+++ b/clustersmgmt/v1/resources_client.go
@@ -211,6 +211,13 @@ func (r *ResourcesGetRequest) Header(name string, value interface{}) *ResourcesG
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ResourcesGetRequest) Impersonate(user string) *ResourcesGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_client.go
+++ b/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_client.go
@@ -200,6 +200,13 @@ func (r *SocketTotalByNodeRolesOSMetricQueryGetRequest) Header(name string, valu
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SocketTotalByNodeRolesOSMetricQueryGetRequest) Impersonate(user string) *SocketTotalByNodeRolesOSMetricQueryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/syncset_client.go
+++ b/clustersmgmt/v1/syncset_client.go
@@ -222,6 +222,13 @@ func (r *SyncsetDeleteRequest) Header(name string, value interface{}) *SyncsetDe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SyncsetDeleteRequest) Impersonate(user string) *SyncsetDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *SyncsetGetRequest) Parameter(name string, value interface{}) *SyncsetGe
 // Header adds a request header.
 func (r *SyncsetGetRequest) Header(name string, value interface{}) *SyncsetGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SyncsetGetRequest) Impersonate(user string) *SyncsetGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *SyncsetUpdateRequest) Parameter(name string, value interface{}) *Syncse
 // Header adds a request header.
 func (r *SyncsetUpdateRequest) Header(name string, value interface{}) *SyncsetUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SyncsetUpdateRequest) Impersonate(user string) *SyncsetUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/syncsets_client.go
+++ b/clustersmgmt/v1/syncsets_client.go
@@ -102,6 +102,13 @@ func (r *SyncsetsAddRequest) Header(name string, value interface{}) *SyncsetsAdd
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SyncsetsAddRequest) Impersonate(user string) *SyncsetsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the syncset.
@@ -242,6 +249,13 @@ func (r *SyncsetsListRequest) Parameter(name string, value interface{}) *Syncset
 // Header adds a request header.
 func (r *SyncsetsListRequest) Header(name string, value interface{}) *SyncsetsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *SyncsetsListRequest) Impersonate(user string) *SyncsetsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/upgrade_policies_client.go
+++ b/clustersmgmt/v1/upgrade_policies_client.go
@@ -102,6 +102,13 @@ func (r *UpgradePoliciesAddRequest) Header(name string, value interface{}) *Upgr
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UpgradePoliciesAddRequest) Impersonate(user string) *UpgradePoliciesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the upgrade policy.
@@ -242,6 +249,13 @@ func (r *UpgradePoliciesListRequest) Parameter(name string, value interface{}) *
 // Header adds a request header.
 func (r *UpgradePoliciesListRequest) Header(name string, value interface{}) *UpgradePoliciesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UpgradePoliciesListRequest) Impersonate(user string) *UpgradePoliciesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/upgrade_policy_client.go
+++ b/clustersmgmt/v1/upgrade_policy_client.go
@@ -233,6 +233,13 @@ func (r *UpgradePolicyDeleteRequest) Header(name string, value interface{}) *Upg
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UpgradePolicyDeleteRequest) Impersonate(user string) *UpgradePolicyDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -330,6 +337,13 @@ func (r *UpgradePolicyGetRequest) Parameter(name string, value interface{}) *Upg
 // Header adds a request header.
 func (r *UpgradePolicyGetRequest) Header(name string, value interface{}) *UpgradePolicyGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UpgradePolicyGetRequest) Impersonate(user string) *UpgradePolicyGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -458,6 +472,13 @@ func (r *UpgradePolicyUpdateRequest) Parameter(name string, value interface{}) *
 // Header adds a request header.
 func (r *UpgradePolicyUpdateRequest) Header(name string, value interface{}) *UpgradePolicyUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UpgradePolicyUpdateRequest) Impersonate(user string) *UpgradePolicyUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/upgrade_policy_state_client.go
+++ b/clustersmgmt/v1/upgrade_policy_state_client.go
@@ -212,6 +212,13 @@ func (r *UpgradePolicyStateGetRequest) Header(name string, value interface{}) *U
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UpgradePolicyStateGetRequest) Impersonate(user string) *UpgradePolicyStateGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -337,6 +344,13 @@ func (r *UpgradePolicyStateUpdateRequest) Parameter(name string, value interface
 // Header adds a request header.
 func (r *UpgradePolicyStateUpdateRequest) Header(name string, value interface{}) *UpgradePolicyStateUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UpgradePolicyStateUpdateRequest) Impersonate(user string) *UpgradePolicyStateUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/user_client.go
+++ b/clustersmgmt/v1/user_client.go
@@ -210,6 +210,13 @@ func (r *UserDeleteRequest) Header(name string, value interface{}) *UserDeleteRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UserDeleteRequest) Impersonate(user string) *UserDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -307,6 +314,13 @@ func (r *UserGetRequest) Parameter(name string, value interface{}) *UserGetReque
 // Header adds a request header.
 func (r *UserGetRequest) Header(name string, value interface{}) *UserGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UserGetRequest) Impersonate(user string) *UserGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/users_client.go
+++ b/clustersmgmt/v1/users_client.go
@@ -102,6 +102,13 @@ func (r *UsersAddRequest) Header(name string, value interface{}) *UsersAddReques
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UsersAddRequest) Impersonate(user string) *UsersAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Description of the user.
@@ -242,6 +249,13 @@ func (r *UsersListRequest) Parameter(name string, value interface{}) *UsersListR
 // Header adds a request header.
 func (r *UsersListRequest) Header(name string, value interface{}) *UsersListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *UsersListRequest) Impersonate(user string) *UsersListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/version_client.go
+++ b/clustersmgmt/v1/version_client.go
@@ -200,6 +200,13 @@ func (r *VersionGetRequest) Header(name string, value interface{}) *VersionGetRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGetRequest) Impersonate(user string) *VersionGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.

--- a/clustersmgmt/v1/version_gate_agreement_client.go
+++ b/clustersmgmt/v1/version_gate_agreement_client.go
@@ -210,6 +210,13 @@ func (r *VersionGateAgreementDeleteRequest) Header(name string, value interface{
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGateAgreementDeleteRequest) Impersonate(user string) *VersionGateAgreementDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -307,6 +314,13 @@ func (r *VersionGateAgreementGetRequest) Parameter(name string, value interface{
 // Header adds a request header.
 func (r *VersionGateAgreementGetRequest) Header(name string, value interface{}) *VersionGateAgreementGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGateAgreementGetRequest) Impersonate(user string) *VersionGateAgreementGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/version_gate_agreements_client.go
+++ b/clustersmgmt/v1/version_gate_agreements_client.go
@@ -102,6 +102,13 @@ func (r *VersionGateAgreementsAddRequest) Header(name string, value interface{})
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGateAgreementsAddRequest) Impersonate(user string) *VersionGateAgreementsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Details of the version gate agreement.
@@ -242,6 +249,13 @@ func (r *VersionGateAgreementsListRequest) Parameter(name string, value interfac
 // Header adds a request header.
 func (r *VersionGateAgreementsListRequest) Header(name string, value interface{}) *VersionGateAgreementsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGateAgreementsListRequest) Impersonate(user string) *VersionGateAgreementsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/version_gate_client.go
+++ b/clustersmgmt/v1/version_gate_client.go
@@ -210,6 +210,13 @@ func (r *VersionGateDeleteRequest) Header(name string, value interface{}) *Versi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGateDeleteRequest) Impersonate(user string) *VersionGateDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -307,6 +314,13 @@ func (r *VersionGateGetRequest) Parameter(name string, value interface{}) *Versi
 // Header adds a request header.
 func (r *VersionGateGetRequest) Header(name string, value interface{}) *VersionGateGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGateGetRequest) Impersonate(user string) *VersionGateGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/version_gates_client.go
+++ b/clustersmgmt/v1/version_gates_client.go
@@ -102,6 +102,13 @@ func (r *VersionGatesAddRequest) Header(name string, value interface{}) *Version
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGatesAddRequest) Impersonate(user string) *VersionGatesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Details of the version gate
@@ -244,6 +251,13 @@ func (r *VersionGatesListRequest) Parameter(name string, value interface{}) *Ver
 // Header adds a request header.
 func (r *VersionGatesListRequest) Header(name string, value interface{}) *VersionGatesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionGatesListRequest) Impersonate(user string) *VersionGatesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/clustersmgmt/v1/versions_client.go
+++ b/clustersmgmt/v1/versions_client.go
@@ -93,6 +93,13 @@ func (r *VersionsListRequest) Header(name string, value interface{}) *VersionsLi
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VersionsListRequest) Impersonate(user string) *VersionsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Order sets the value of the 'order' parameter.
 //
 // Order criteria.

--- a/clustersmgmt/v1/vpcs_inquiry_client.go
+++ b/clustersmgmt/v1/vpcs_inquiry_client.go
@@ -86,6 +86,13 @@ func (r *VpcsInquirySearchRequest) Header(name string, value interface{}) *VpcsI
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *VpcsInquirySearchRequest) Impersonate(user string) *VpcsInquirySearchRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Cloud provider data needed for the inquiry

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -74,6 +74,12 @@ func CopyHeader(header http.Header) http.Header {
 	return result
 }
 
+const impersonateUserHeader = "Impersonate-User"
+
+func AddImpersonationHeader(header *http.Header, user string) {
+	AddHeader(header, impersonateUserHeader, user)
+}
+
 // CopyValues copies a slice of strings.
 func CopyValues(values []string) []string {
 	if values == nil {

--- a/jobqueue/v1/job_client.go
+++ b/jobqueue/v1/job_client.go
@@ -93,6 +93,13 @@ func (r *JobFailureRequest) Header(name string, value interface{}) *JobFailureRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *JobFailureRequest) Impersonate(user string) *JobFailureRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // FailureReason sets the value of the 'failure_reason' parameter.
 //
 //
@@ -213,6 +220,13 @@ func (r *JobSuccessRequest) Parameter(name string, value interface{}) *JobSucces
 // Header adds a request header.
 func (r *JobSuccessRequest) Header(name string, value interface{}) *JobSuccessRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *JobSuccessRequest) Impersonate(user string) *JobSuccessRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/jobqueue/v1/queue_client.go
+++ b/jobqueue/v1/queue_client.go
@@ -233,6 +233,13 @@ func (r *QueueGetRequest) Header(name string, value interface{}) *QueueGetReques
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *QueueGetRequest) Impersonate(user string) *QueueGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -357,6 +364,13 @@ func (r *QueuePopRequest) Parameter(name string, value interface{}) *QueuePopReq
 // Header adds a request header.
 func (r *QueuePopRequest) Header(name string, value interface{}) *QueuePopRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *QueuePopRequest) Impersonate(user string) *QueuePopRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -672,6 +686,13 @@ func (r *QueuePushRequest) Parameter(name string, value interface{}) *QueuePushR
 // Header adds a request header.
 func (r *QueuePushRequest) Header(name string, value interface{}) *QueuePushRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *QueuePushRequest) Impersonate(user string) *QueuePushRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/jobqueue/v1/queues_client.go
+++ b/jobqueue/v1/queues_client.go
@@ -91,6 +91,13 @@ func (r *QueuesListRequest) Header(name string, value interface{}) *QueuesListRe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *QueuesListRequest) Impersonate(user string) *QueuesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Page sets the value of the 'page' parameter.
 //
 // Index of the requested page, where one corresponds to the first page.

--- a/servicelogs/v1/cluster_logs_client.go
+++ b/servicelogs/v1/cluster_logs_client.go
@@ -102,6 +102,13 @@ func (r *ClusterLogsAddRequest) Header(name string, value interface{}) *ClusterL
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterLogsAddRequest) Impersonate(user string) *ClusterLogsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 // Log entry data.
@@ -244,6 +251,13 @@ func (r *ClusterLogsListRequest) Parameter(name string, value interface{}) *Clus
 // Header adds a request header.
 func (r *ClusterLogsListRequest) Header(name string, value interface{}) *ClusterLogsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterLogsListRequest) Impersonate(user string) *ClusterLogsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/servicelogs/v1/cluster_logs_uuid_client.go
+++ b/servicelogs/v1/cluster_logs_uuid_client.go
@@ -82,6 +82,13 @@ func (r *ClusterLogsUUIDListRequest) Header(name string, value interface{}) *Clu
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ClusterLogsUUIDListRequest) Impersonate(user string) *ClusterLogsUUIDListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Order sets the value of the 'order' parameter.
 //
 // Order criteria.

--- a/servicelogs/v1/log_entry_client.go
+++ b/servicelogs/v1/log_entry_client.go
@@ -210,6 +210,13 @@ func (r *LogEntryDeleteRequest) Header(name string, value interface{}) *LogEntry
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LogEntryDeleteRequest) Impersonate(user string) *LogEntryDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -307,6 +314,13 @@ func (r *LogEntryGetRequest) Parameter(name string, value interface{}) *LogEntry
 // Header adds a request header.
 func (r *LogEntryGetRequest) Header(name string, value interface{}) *LogEntryGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *LogEntryGetRequest) Impersonate(user string) *LogEntryGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/application_client.go
+++ b/statusboard/v1/application_client.go
@@ -233,6 +233,13 @@ func (r *ApplicationDeleteRequest) Header(name string, value interface{}) *Appli
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationDeleteRequest) Impersonate(user string) *ApplicationDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -330,6 +337,13 @@ func (r *ApplicationGetRequest) Parameter(name string, value interface{}) *Appli
 // Header adds a request header.
 func (r *ApplicationGetRequest) Header(name string, value interface{}) *ApplicationGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationGetRequest) Impersonate(user string) *ApplicationGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -458,6 +472,13 @@ func (r *ApplicationUpdateRequest) Parameter(name string, value interface{}) *Ap
 // Header adds a request header.
 func (r *ApplicationUpdateRequest) Header(name string, value interface{}) *ApplicationUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationUpdateRequest) Impersonate(user string) *ApplicationUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/application_dependencies_client.go
+++ b/statusboard/v1/application_dependencies_client.go
@@ -102,6 +102,13 @@ func (r *ApplicationDependenciesAddRequest) Header(name string, value interface{
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationDependenciesAddRequest) Impersonate(user string) *ApplicationDependenciesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -243,6 +250,13 @@ func (r *ApplicationDependenciesListRequest) Parameter(name string, value interf
 // Header adds a request header.
 func (r *ApplicationDependenciesListRequest) Header(name string, value interface{}) *ApplicationDependenciesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationDependenciesListRequest) Impersonate(user string) *ApplicationDependenciesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/application_dependency_client.go
+++ b/statusboard/v1/application_dependency_client.go
@@ -222,6 +222,13 @@ func (r *ApplicationDependencyDeleteRequest) Header(name string, value interface
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationDependencyDeleteRequest) Impersonate(user string) *ApplicationDependencyDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *ApplicationDependencyGetRequest) Parameter(name string, value interface
 // Header adds a request header.
 func (r *ApplicationDependencyGetRequest) Header(name string, value interface{}) *ApplicationDependencyGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationDependencyGetRequest) Impersonate(user string) *ApplicationDependencyGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *ApplicationDependencyUpdateRequest) Parameter(name string, value interf
 // Header adds a request header.
 func (r *ApplicationDependencyUpdateRequest) Header(name string, value interface{}) *ApplicationDependencyUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationDependencyUpdateRequest) Impersonate(user string) *ApplicationDependencyUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/applications_client.go
+++ b/statusboard/v1/applications_client.go
@@ -102,6 +102,13 @@ func (r *ApplicationsAddRequest) Header(name string, value interface{}) *Applica
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationsAddRequest) Impersonate(user string) *ApplicationsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -244,6 +251,13 @@ func (r *ApplicationsListRequest) Parameter(name string, value interface{}) *App
 // Header adds a request header.
 func (r *ApplicationsListRequest) Header(name string, value interface{}) *ApplicationsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ApplicationsListRequest) Impersonate(user string) *ApplicationsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/peer_dependencies_client.go
+++ b/statusboard/v1/peer_dependencies_client.go
@@ -102,6 +102,13 @@ func (r *PeerDependenciesAddRequest) Header(name string, value interface{}) *Pee
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PeerDependenciesAddRequest) Impersonate(user string) *PeerDependenciesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -243,6 +250,13 @@ func (r *PeerDependenciesListRequest) Parameter(name string, value interface{}) 
 // Header adds a request header.
 func (r *PeerDependenciesListRequest) Header(name string, value interface{}) *PeerDependenciesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PeerDependenciesListRequest) Impersonate(user string) *PeerDependenciesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/peer_dependency_client.go
+++ b/statusboard/v1/peer_dependency_client.go
@@ -222,6 +222,13 @@ func (r *PeerDependencyDeleteRequest) Header(name string, value interface{}) *Pe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PeerDependencyDeleteRequest) Impersonate(user string) *PeerDependencyDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *PeerDependencyGetRequest) Parameter(name string, value interface{}) *Pe
 // Header adds a request header.
 func (r *PeerDependencyGetRequest) Header(name string, value interface{}) *PeerDependencyGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PeerDependencyGetRequest) Impersonate(user string) *PeerDependencyGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *PeerDependencyUpdateRequest) Parameter(name string, value interface{}) 
 // Header adds a request header.
 func (r *PeerDependencyUpdateRequest) Header(name string, value interface{}) *PeerDependencyUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *PeerDependencyUpdateRequest) Impersonate(user string) *PeerDependencyUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/product_client.go
+++ b/statusboard/v1/product_client.go
@@ -243,6 +243,13 @@ func (r *ProductDeleteRequest) Header(name string, value interface{}) *ProductDe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProductDeleteRequest) Impersonate(user string) *ProductDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -340,6 +347,13 @@ func (r *ProductGetRequest) Parameter(name string, value interface{}) *ProductGe
 // Header adds a request header.
 func (r *ProductGetRequest) Header(name string, value interface{}) *ProductGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProductGetRequest) Impersonate(user string) *ProductGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -468,6 +482,13 @@ func (r *ProductUpdateRequest) Parameter(name string, value interface{}) *Produc
 // Header adds a request header.
 func (r *ProductUpdateRequest) Header(name string, value interface{}) *ProductUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProductUpdateRequest) Impersonate(user string) *ProductUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/products_client.go
+++ b/statusboard/v1/products_client.go
@@ -102,6 +102,13 @@ func (r *ProductsAddRequest) Header(name string, value interface{}) *ProductsAdd
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProductsAddRequest) Impersonate(user string) *ProductsAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -244,6 +251,13 @@ func (r *ProductsListRequest) Parameter(name string, value interface{}) *Product
 // Header adds a request header.
 func (r *ProductsListRequest) Header(name string, value interface{}) *ProductsListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ProductsListRequest) Impersonate(user string) *ProductsListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/service_client.go
+++ b/statusboard/v1/service_client.go
@@ -233,6 +233,13 @@ func (r *ServiceDeleteRequest) Header(name string, value interface{}) *ServiceDe
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceDeleteRequest) Impersonate(user string) *ServiceDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -330,6 +337,13 @@ func (r *ServiceGetRequest) Parameter(name string, value interface{}) *ServiceGe
 // Header adds a request header.
 func (r *ServiceGetRequest) Header(name string, value interface{}) *ServiceGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceGetRequest) Impersonate(user string) *ServiceGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -458,6 +472,13 @@ func (r *ServiceUpdateRequest) Parameter(name string, value interface{}) *Servic
 // Header adds a request header.
 func (r *ServiceUpdateRequest) Header(name string, value interface{}) *ServiceUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceUpdateRequest) Impersonate(user string) *ServiceUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/service_dependencies_client.go
+++ b/statusboard/v1/service_dependencies_client.go
@@ -102,6 +102,13 @@ func (r *ServiceDependenciesAddRequest) Header(name string, value interface{}) *
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceDependenciesAddRequest) Impersonate(user string) *ServiceDependenciesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -243,6 +250,13 @@ func (r *ServiceDependenciesListRequest) Parameter(name string, value interface{
 // Header adds a request header.
 func (r *ServiceDependenciesListRequest) Header(name string, value interface{}) *ServiceDependenciesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceDependenciesListRequest) Impersonate(user string) *ServiceDependenciesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/service_dependency_client.go
+++ b/statusboard/v1/service_dependency_client.go
@@ -222,6 +222,13 @@ func (r *ServiceDependencyDeleteRequest) Header(name string, value interface{}) 
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceDependencyDeleteRequest) Impersonate(user string) *ServiceDependencyDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *ServiceDependencyGetRequest) Parameter(name string, value interface{}) 
 // Header adds a request header.
 func (r *ServiceDependencyGetRequest) Header(name string, value interface{}) *ServiceDependencyGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceDependencyGetRequest) Impersonate(user string) *ServiceDependencyGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *ServiceDependencyUpdateRequest) Parameter(name string, value interface{
 // Header adds a request header.
 func (r *ServiceDependencyUpdateRequest) Header(name string, value interface{}) *ServiceDependencyUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServiceDependencyUpdateRequest) Impersonate(user string) *ServiceDependencyUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/services_client.go
+++ b/statusboard/v1/services_client.go
@@ -102,6 +102,13 @@ func (r *ServicesAddRequest) Header(name string, value interface{}) *ServicesAdd
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServicesAddRequest) Impersonate(user string) *ServicesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -245,6 +252,13 @@ func (r *ServicesListRequest) Parameter(name string, value interface{}) *Service
 // Header adds a request header.
 func (r *ServicesListRequest) Header(name string, value interface{}) *ServicesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *ServicesListRequest) Impersonate(user string) *ServicesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/status_client.go
+++ b/statusboard/v1/status_client.go
@@ -222,6 +222,13 @@ func (r *StatusDeleteRequest) Header(name string, value interface{}) *StatusDele
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusDeleteRequest) Impersonate(user string) *StatusDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *StatusGetRequest) Parameter(name string, value interface{}) *StatusGetR
 // Header adds a request header.
 func (r *StatusGetRequest) Header(name string, value interface{}) *StatusGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusGetRequest) Impersonate(user string) *StatusGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *StatusUpdateRequest) Parameter(name string, value interface{}) *StatusU
 // Header adds a request header.
 func (r *StatusUpdateRequest) Header(name string, value interface{}) *StatusUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusUpdateRequest) Impersonate(user string) *StatusUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/status_update_client.go
+++ b/statusboard/v1/status_update_client.go
@@ -222,6 +222,13 @@ func (r *StatusUpdateDeleteRequest) Header(name string, value interface{}) *Stat
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusUpdateDeleteRequest) Impersonate(user string) *StatusUpdateDeleteRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
@@ -319,6 +326,13 @@ func (r *StatusUpdateGetRequest) Parameter(name string, value interface{}) *Stat
 // Header adds a request header.
 func (r *StatusUpdateGetRequest) Header(name string, value interface{}) *StatusUpdateGetRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusUpdateGetRequest) Impersonate(user string) *StatusUpdateGetRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 
@@ -447,6 +461,13 @@ func (r *StatusUpdateUpdateRequest) Parameter(name string, value interface{}) *S
 // Header adds a request header.
 func (r *StatusUpdateUpdateRequest) Header(name string, value interface{}) *StatusUpdateUpdateRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusUpdateUpdateRequest) Impersonate(user string) *StatusUpdateUpdateRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/status_updates_client.go
+++ b/statusboard/v1/status_updates_client.go
@@ -103,6 +103,13 @@ func (r *StatusUpdatesAddRequest) Header(name string, value interface{}) *Status
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusUpdatesAddRequest) Impersonate(user string) *StatusUpdatesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -246,6 +253,13 @@ func (r *StatusUpdatesListRequest) Parameter(name string, value interface{}) *St
 // Header adds a request header.
 func (r *StatusUpdatesListRequest) Header(name string, value interface{}) *StatusUpdatesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusUpdatesListRequest) Impersonate(user string) *StatusUpdatesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 

--- a/statusboard/v1/statuses_client.go
+++ b/statusboard/v1/statuses_client.go
@@ -103,6 +103,13 @@ func (r *StatusesAddRequest) Header(name string, value interface{}) *StatusesAdd
 	return r
 }
 
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusesAddRequest) Impersonate(user string) *StatusesAddRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
+	return r
+}
+
 // Body sets the value of the 'body' parameter.
 //
 //
@@ -246,6 +253,13 @@ func (r *StatusesListRequest) Parameter(name string, value interface{}) *Statuse
 // Header adds a request header.
 func (r *StatusesListRequest) Header(name string, value interface{}) *StatusesListRequest {
 	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Impersonate wraps requests on behalf of another user.
+// Note: Services that do not support this feature may silently ignore this call.
+func (r *StatusesListRequest) Impersonate(user string) *StatusesListRequest {
+	helpers.AddImpersonationHeader(&r.header, user)
 	return r
 }
 


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Add support for annotations.
- Add `@json` and `@http` annotations.
- Add `@go` annotation.
- Add original text to names.
- Add `Impersonate` method to support the `Impersonate-User` header.