### PR TITLE
Test with Go 1.18

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         go:
         - 1.17
+        - 1.18
     steps:
     - name: Checkout the source
       uses: actions/checkout@v2
@@ -72,7 +73,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Setup Goimports
       run: go install golang.org/x/tools/cmd/goimports@v0.0.0-20200518194103-259583f2d8a9


### PR DESCRIPTION
This patch changes the GitHub actions so that tests also run with Go
1.18.