### PR TITLE
Remove send without context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ model_version:=v0.0.183
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=54a2413ff3822a178ae40d7161a69eaa25e37c55
+metamodel_version:=7b30ef5fe95d0d13ca93e1d21a83039f5fca1bc6
 
 .PHONY: examples
 examples:

--- a/accountsmgmt/v1/access_token_client.go
+++ b/accountsmgmt/v1/access_token_client.go
@@ -86,15 +86,7 @@ func (r *AccessTokenPostRequest) Impersonate(user string) *AccessTokenPostReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AccessTokenPostRequest) Send() (result *AccessTokenPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AccessTokenPostRequest) SendContext(ctx context.Context) (result *AccessTokenPostResponse, err error) {
+func (r *AccessTokenPostRequest) Send(ctx context.Context) (result *AccessTokenPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/account_client.go
+++ b/accountsmgmt/v1/account_client.go
@@ -125,13 +125,13 @@ func (r *AccountPollRequest) Predicate(value func(*AccountGetResponse) bool) *Ac
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AccountPollRequest) StartContext(ctx context.Context) (response *AccountPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AccountPollRequest) Start(ctx context.Context) (response *AccountPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AccountPollResponse{
 			response: result.(*AccountGetResponse),
@@ -143,7 +143,7 @@ func (r *AccountPollRequest) StartContext(ctx context.Context) (response *Accoun
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AccountPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -231,15 +231,7 @@ func (r *AccountGetRequest) Impersonate(user string) *AccountGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AccountGetRequest) Send() (result *AccountGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AccountGetRequest) SendContext(ctx context.Context) (result *AccountGetResponse, err error) {
+func (r *AccountGetRequest) Send(ctx context.Context) (result *AccountGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -374,15 +366,7 @@ func (r *AccountUpdateRequest) Body(value *Account) *AccountUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AccountUpdateRequest) Send() (result *AccountUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AccountUpdateRequest) SendContext(ctx context.Context) (result *AccountUpdateResponse, err error) {
+func (r *AccountUpdateRequest) Send(ctx context.Context) (result *AccountUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/accounts_client.go
+++ b/accountsmgmt/v1/accounts_client.go
@@ -118,15 +118,7 @@ func (r *AccountsAddRequest) Body(value *Account) *AccountsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AccountsAddRequest) Send() (result *AccountsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AccountsAddRequest) SendContext(ctx context.Context) (result *AccountsAddResponse, err error) {
+func (r *AccountsAddRequest) Send(ctx context.Context) (result *AccountsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -340,15 +332,7 @@ func (r *AccountsListRequest) Size(value int) *AccountsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AccountsListRequest) Send() (result *AccountsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AccountsListRequest) SendContext(ctx context.Context) (result *AccountsListResponse, err error) {
+func (r *AccountsListRequest) Send(ctx context.Context) (result *AccountsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.fetchlabelsLabels != nil {
 		helpers.AddValue(&query, "fetchlabels_labels", *r.fetchlabelsLabels)

--- a/accountsmgmt/v1/cluster_authorizations_client.go
+++ b/accountsmgmt/v1/cluster_authorizations_client.go
@@ -97,15 +97,7 @@ func (r *ClusterAuthorizationsPostRequest) Request(value *ClusterAuthorizationRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterAuthorizationsPostRequest) Send() (result *ClusterAuthorizationsPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterAuthorizationsPostRequest) SendContext(ctx context.Context) (result *ClusterAuthorizationsPostResponse, err error) {
+func (r *ClusterAuthorizationsPostRequest) Send(ctx context.Context) (result *ClusterAuthorizationsPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/cluster_registrations_client.go
+++ b/accountsmgmt/v1/cluster_registrations_client.go
@@ -98,15 +98,7 @@ func (r *ClusterRegistrationsPostRequest) Request(value *ClusterRegistrationRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterRegistrationsPostRequest) Send() (result *ClusterRegistrationsPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterRegistrationsPostRequest) SendContext(ctx context.Context) (result *ClusterRegistrationsPostResponse, err error) {
+func (r *ClusterRegistrationsPostRequest) Send(ctx context.Context) (result *ClusterRegistrationsPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/current_access_client.go
+++ b/accountsmgmt/v1/current_access_client.go
@@ -104,15 +104,7 @@ func (r *CurrentAccessListRequest) Size(value int) *CurrentAccessListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CurrentAccessListRequest) Send() (result *CurrentAccessListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CurrentAccessListRequest) SendContext(ctx context.Context) (result *CurrentAccessListResponse, err error) {
+func (r *CurrentAccessListRequest) Send(ctx context.Context) (result *CurrentAccessListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/current_account_client.go
+++ b/accountsmgmt/v1/current_account_client.go
@@ -102,13 +102,13 @@ func (r *CurrentAccountPollRequest) Predicate(value func(*CurrentAccountGetRespo
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *CurrentAccountPollRequest) StartContext(ctx context.Context) (response *CurrentAccountPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *CurrentAccountPollRequest) Start(ctx context.Context) (response *CurrentAccountPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &CurrentAccountPollResponse{
 			response: result.(*CurrentAccountGetResponse),
@@ -120,7 +120,7 @@ func (r *CurrentAccountPollRequest) StartContext(ctx context.Context) (response 
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *CurrentAccountPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *CurrentAccountGetRequest) Impersonate(user string) *CurrentAccountGetRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CurrentAccountGetRequest) Send() (result *CurrentAccountGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CurrentAccountGetRequest) SendContext(ctx context.Context) (result *CurrentAccountGetResponse, err error) {
+func (r *CurrentAccountGetRequest) Send(ctx context.Context) (result *CurrentAccountGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/feature_toggle_query_client.go
+++ b/accountsmgmt/v1/feature_toggle_query_client.go
@@ -97,15 +97,7 @@ func (r *FeatureToggleQueryPostRequest) Request(value *FeatureToggleQueryRequest
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *FeatureToggleQueryPostRequest) Send() (result *FeatureToggleQueryPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *FeatureToggleQueryPostRequest) SendContext(ctx context.Context) (result *FeatureToggleQueryPostResponse, err error) {
+func (r *FeatureToggleQueryPostRequest) Send(ctx context.Context) (result *FeatureToggleQueryPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/generic_label_client.go
+++ b/accountsmgmt/v1/generic_label_client.go
@@ -124,13 +124,13 @@ func (r *GenericLabelPollRequest) Predicate(value func(*GenericLabelGetResponse)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *GenericLabelPollRequest) StartContext(ctx context.Context) (response *GenericLabelPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *GenericLabelPollRequest) Start(ctx context.Context) (response *GenericLabelPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &GenericLabelPollResponse{
 			response: result.(*GenericLabelGetResponse),
@@ -142,7 +142,7 @@ func (r *GenericLabelPollRequest) StartContext(ctx context.Context) (response *G
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *GenericLabelPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *GenericLabelDeleteRequest) Impersonate(user string) *GenericLabelDelete
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *GenericLabelDeleteRequest) Send() (result *GenericLabelDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *GenericLabelDeleteRequest) SendContext(ctx context.Context) (result *GenericLabelDeleteResponse, err error) {
+func (r *GenericLabelDeleteRequest) Send(ctx context.Context) (result *GenericLabelDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *GenericLabelGetRequest) Impersonate(user string) *GenericLabelGetReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *GenericLabelGetRequest) Send() (result *GenericLabelGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *GenericLabelGetRequest) SendContext(ctx context.Context) (result *GenericLabelGetResponse, err error) {
+func (r *GenericLabelGetRequest) Send(ctx context.Context) (result *GenericLabelGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *GenericLabelUpdateRequest) Body(value *Label) *GenericLabelUpdateReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *GenericLabelUpdateRequest) Send() (result *GenericLabelUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *GenericLabelUpdateRequest) SendContext(ctx context.Context) (result *GenericLabelUpdateResponse, err error) {
+func (r *GenericLabelUpdateRequest) Send(ctx context.Context) (result *GenericLabelUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/generic_labels_client.go
+++ b/accountsmgmt/v1/generic_labels_client.go
@@ -122,15 +122,7 @@ func (r *GenericLabelsAddRequest) Body(value *Label) *GenericLabelsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *GenericLabelsAddRequest) Send() (result *GenericLabelsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *GenericLabelsAddRequest) SendContext(ctx context.Context) (result *GenericLabelsAddResponse, err error) {
+func (r *GenericLabelsAddRequest) Send(ctx context.Context) (result *GenericLabelsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -283,15 +275,7 @@ func (r *GenericLabelsListRequest) Size(value int) *GenericLabelsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *GenericLabelsListRequest) Send() (result *GenericLabelsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *GenericLabelsListRequest) SendContext(ctx context.Context) (result *GenericLabelsListResponse, err error) {
+func (r *GenericLabelsListRequest) Send(ctx context.Context) (result *GenericLabelsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/labels_client.go
+++ b/accountsmgmt/v1/labels_client.go
@@ -125,15 +125,7 @@ func (r *LabelsListRequest) Size(value int) *LabelsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LabelsListRequest) Send() (result *LabelsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LabelsListRequest) SendContext(ctx context.Context) (result *LabelsListResponse, err error) {
+func (r *LabelsListRequest) Send(ctx context.Context) (result *LabelsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/metadata_client.go
+++ b/accountsmgmt/v1/metadata_client.go
@@ -59,15 +59,7 @@ func (r *MetadataRequest) Header(name string, value interface{}) *MetadataReques
 }
 
 // Send sends the metadata request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends the metadata request, waits for the response, and returns it.
-func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/notify_client.go
+++ b/accountsmgmt/v1/notify_client.go
@@ -97,15 +97,7 @@ func (r *NotifyAddRequest) Body(value *SubscriptionNotify) *NotifyAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *NotifyAddRequest) Send() (result *NotifyAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *NotifyAddRequest) SendContext(ctx context.Context) (result *NotifyAddResponse, err error) {
+func (r *NotifyAddRequest) Send(ctx context.Context) (result *NotifyAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/organization_client.go
+++ b/accountsmgmt/v1/organization_client.go
@@ -157,13 +157,13 @@ func (r *OrganizationPollRequest) Predicate(value func(*OrganizationGetResponse)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *OrganizationPollRequest) StartContext(ctx context.Context) (response *OrganizationPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *OrganizationPollRequest) Start(ctx context.Context) (response *OrganizationPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &OrganizationPollResponse{
 			response: result.(*OrganizationGetResponse),
@@ -175,7 +175,7 @@ func (r *OrganizationPollRequest) StartContext(ctx context.Context) (response *O
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *OrganizationPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -263,15 +263,7 @@ func (r *OrganizationGetRequest) Impersonate(user string) *OrganizationGetReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *OrganizationGetRequest) Send() (result *OrganizationGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *OrganizationGetRequest) SendContext(ctx context.Context) (result *OrganizationGetResponse, err error) {
+func (r *OrganizationGetRequest) Send(ctx context.Context) (result *OrganizationGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -406,15 +398,7 @@ func (r *OrganizationUpdateRequest) Body(value *Organization) *OrganizationUpdat
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *OrganizationUpdateRequest) Send() (result *OrganizationUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *OrganizationUpdateRequest) SendContext(ctx context.Context) (result *OrganizationUpdateResponse, err error) {
+func (r *OrganizationUpdateRequest) Send(ctx context.Context) (result *OrganizationUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/organizations_client.go
+++ b/accountsmgmt/v1/organizations_client.go
@@ -118,15 +118,7 @@ func (r *OrganizationsAddRequest) Body(value *Organization) *OrganizationsAddReq
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *OrganizationsAddRequest) Send() (result *OrganizationsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *OrganizationsAddRequest) SendContext(ctx context.Context) (result *OrganizationsAddResponse, err error) {
+func (r *OrganizationsAddRequest) Send(ctx context.Context) (result *OrganizationsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -320,15 +312,7 @@ func (r *OrganizationsListRequest) Size(value int) *OrganizationsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *OrganizationsListRequest) Send() (result *OrganizationsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *OrganizationsListRequest) SendContext(ctx context.Context) (result *OrganizationsListResponse, err error) {
+func (r *OrganizationsListRequest) Send(ctx context.Context) (result *OrganizationsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.fetchlabelsLabels != nil {
 		helpers.AddValue(&query, "fetchlabels_labels", *r.fetchlabelsLabels)

--- a/accountsmgmt/v1/permission_client.go
+++ b/accountsmgmt/v1/permission_client.go
@@ -112,13 +112,13 @@ func (r *PermissionPollRequest) Predicate(value func(*PermissionGetResponse) boo
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *PermissionPollRequest) StartContext(ctx context.Context) (response *PermissionPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *PermissionPollRequest) Start(ctx context.Context) (response *PermissionPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &PermissionPollResponse{
 			response: result.(*PermissionGetResponse),
@@ -130,7 +130,7 @@ func (r *PermissionPollRequest) StartContext(ctx context.Context) (response *Per
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *PermissionPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *PermissionDeleteRequest) Impersonate(user string) *PermissionDeleteRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PermissionDeleteRequest) Send() (result *PermissionDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PermissionDeleteRequest) SendContext(ctx context.Context) (result *PermissionDeleteResponse, err error) {
+func (r *PermissionDeleteRequest) Send(ctx context.Context) (result *PermissionDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *PermissionGetRequest) Impersonate(user string) *PermissionGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PermissionGetRequest) Send() (result *PermissionGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PermissionGetRequest) SendContext(ctx context.Context) (result *PermissionGetResponse, err error) {
+func (r *PermissionGetRequest) Send(ctx context.Context) (result *PermissionGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/permissions_client.go
+++ b/accountsmgmt/v1/permissions_client.go
@@ -118,15 +118,7 @@ func (r *PermissionsAddRequest) Body(value *Permission) *PermissionsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PermissionsAddRequest) Send() (result *PermissionsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PermissionsAddRequest) SendContext(ctx context.Context) (result *PermissionsAddResponse, err error) {
+func (r *PermissionsAddRequest) Send(ctx context.Context) (result *PermissionsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *PermissionsListRequest) Size(value int) *PermissionsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PermissionsListRequest) Send() (result *PermissionsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PermissionsListRequest) SendContext(ctx context.Context) (result *PermissionsListResponse, err error) {
+func (r *PermissionsListRequest) Send(ctx context.Context) (result *PermissionsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/pull_secret_client.go
+++ b/accountsmgmt/v1/pull_secret_client.go
@@ -86,15 +86,7 @@ func (r *PullSecretDeleteRequest) Impersonate(user string) *PullSecretDeleteRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PullSecretDeleteRequest) Send() (result *PullSecretDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PullSecretDeleteRequest) SendContext(ctx context.Context) (result *PullSecretDeleteResponse, err error) {
+func (r *PullSecretDeleteRequest) Send(ctx context.Context) (result *PullSecretDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/pull_secrets_client.go
+++ b/accountsmgmt/v1/pull_secrets_client.go
@@ -108,15 +108,7 @@ func (r *PullSecretsPostRequest) Request(value *PullSecretsRequest) *PullSecrets
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PullSecretsPostRequest) Send() (result *PullSecretsPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PullSecretsPostRequest) SendContext(ctx context.Context) (result *PullSecretsPostResponse, err error) {
+func (r *PullSecretsPostRequest) Send(ctx context.Context) (result *PullSecretsPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/quota_cost_client.go
+++ b/accountsmgmt/v1/quota_cost_client.go
@@ -125,15 +125,7 @@ func (r *QuotaCostListRequest) Size(value int) *QuotaCostListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *QuotaCostListRequest) Send() (result *QuotaCostListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *QuotaCostListRequest) SendContext(ctx context.Context) (result *QuotaCostListResponse, err error) {
+func (r *QuotaCostListRequest) Send(ctx context.Context) (result *QuotaCostListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/registries_client.go
+++ b/accountsmgmt/v1/registries_client.go
@@ -115,15 +115,7 @@ func (r *RegistriesListRequest) Size(value int) *RegistriesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RegistriesListRequest) Send() (result *RegistriesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RegistriesListRequest) SendContext(ctx context.Context) (result *RegistriesListResponse, err error) {
+func (r *RegistriesListRequest) Send(ctx context.Context) (result *RegistriesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/registry_client.go
+++ b/accountsmgmt/v1/registry_client.go
@@ -102,13 +102,13 @@ func (r *RegistryPollRequest) Predicate(value func(*RegistryGetResponse) bool) *
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *RegistryPollRequest) StartContext(ctx context.Context) (response *RegistryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *RegistryPollRequest) Start(ctx context.Context) (response *RegistryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &RegistryPollResponse{
 			response: result.(*RegistryGetResponse),
@@ -120,7 +120,7 @@ func (r *RegistryPollRequest) StartContext(ctx context.Context) (response *Regis
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *RegistryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *RegistryGetRequest) Impersonate(user string) *RegistryGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RegistryGetRequest) Send() (result *RegistryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RegistryGetRequest) SendContext(ctx context.Context) (result *RegistryGetResponse, err error) {
+func (r *RegistryGetRequest) Send(ctx context.Context) (result *RegistryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/registry_credential_client.go
+++ b/accountsmgmt/v1/registry_credential_client.go
@@ -102,13 +102,13 @@ func (r *RegistryCredentialPollRequest) Predicate(value func(*RegistryCredential
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *RegistryCredentialPollRequest) StartContext(ctx context.Context) (response *RegistryCredentialPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *RegistryCredentialPollRequest) Start(ctx context.Context) (response *RegistryCredentialPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &RegistryCredentialPollResponse{
 			response: result.(*RegistryCredentialGetResponse),
@@ -120,7 +120,7 @@ func (r *RegistryCredentialPollRequest) StartContext(ctx context.Context) (respo
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *RegistryCredentialPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *RegistryCredentialGetRequest) Impersonate(user string) *RegistryCredent
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RegistryCredentialGetRequest) Send() (result *RegistryCredentialGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RegistryCredentialGetRequest) SendContext(ctx context.Context) (result *RegistryCredentialGetResponse, err error) {
+func (r *RegistryCredentialGetRequest) Send(ctx context.Context) (result *RegistryCredentialGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/registry_credentials_client.go
+++ b/accountsmgmt/v1/registry_credentials_client.go
@@ -118,15 +118,7 @@ func (r *RegistryCredentialsAddRequest) Body(value *RegistryCredential) *Registr
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RegistryCredentialsAddRequest) Send() (result *RegistryCredentialsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RegistryCredentialsAddRequest) SendContext(ctx context.Context) (result *RegistryCredentialsAddResponse, err error) {
+func (r *RegistryCredentialsAddRequest) Send(ctx context.Context) (result *RegistryCredentialsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -317,15 +309,7 @@ func (r *RegistryCredentialsListRequest) Size(value int) *RegistryCredentialsLis
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RegistryCredentialsListRequest) Send() (result *RegistryCredentialsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RegistryCredentialsListRequest) SendContext(ctx context.Context) (result *RegistryCredentialsListResponse, err error) {
+func (r *RegistryCredentialsListRequest) Send(ctx context.Context) (result *RegistryCredentialsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/accountsmgmt/v1/resource_quota_client.go
+++ b/accountsmgmt/v1/resource_quota_client.go
@@ -124,13 +124,13 @@ func (r *ResourceQuotaPollRequest) Predicate(value func(*ResourceQuotaGetRespons
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ResourceQuotaPollRequest) StartContext(ctx context.Context) (response *ResourceQuotaPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ResourceQuotaPollRequest) Start(ctx context.Context) (response *ResourceQuotaPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ResourceQuotaPollResponse{
 			response: result.(*ResourceQuotaGetResponse),
@@ -142,7 +142,7 @@ func (r *ResourceQuotaPollRequest) StartContext(ctx context.Context) (response *
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ResourceQuotaPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *ResourceQuotaDeleteRequest) Impersonate(user string) *ResourceQuotaDele
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ResourceQuotaDeleteRequest) Send() (result *ResourceQuotaDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ResourceQuotaDeleteRequest) SendContext(ctx context.Context) (result *ResourceQuotaDeleteResponse, err error) {
+func (r *ResourceQuotaDeleteRequest) Send(ctx context.Context) (result *ResourceQuotaDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *ResourceQuotaGetRequest) Impersonate(user string) *ResourceQuotaGetRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ResourceQuotaGetRequest) Send() (result *ResourceQuotaGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ResourceQuotaGetRequest) SendContext(ctx context.Context) (result *ResourceQuotaGetResponse, err error) {
+func (r *ResourceQuotaGetRequest) Send(ctx context.Context) (result *ResourceQuotaGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *ResourceQuotaUpdateRequest) Body(value *ResourceQuota) *ResourceQuotaUp
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ResourceQuotaUpdateRequest) Send() (result *ResourceQuotaUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ResourceQuotaUpdateRequest) SendContext(ctx context.Context) (result *ResourceQuotaUpdateResponse, err error) {
+func (r *ResourceQuotaUpdateRequest) Send(ctx context.Context) (result *ResourceQuotaUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/resource_quotas_client.go
+++ b/accountsmgmt/v1/resource_quotas_client.go
@@ -118,15 +118,7 @@ func (r *ResourceQuotasAddRequest) Body(value *ResourceQuota) *ResourceQuotasAdd
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ResourceQuotasAddRequest) Send() (result *ResourceQuotasAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ResourceQuotasAddRequest) SendContext(ctx context.Context) (result *ResourceQuotasAddResponse, err error) {
+func (r *ResourceQuotasAddRequest) Send(ctx context.Context) (result *ResourceQuotasAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -297,15 +289,7 @@ func (r *ResourceQuotasListRequest) Size(value int) *ResourceQuotasListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ResourceQuotasListRequest) Send() (result *ResourceQuotasListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ResourceQuotasListRequest) SendContext(ctx context.Context) (result *ResourceQuotasListResponse, err error) {
+func (r *ResourceQuotasListRequest) Send(ctx context.Context) (result *ResourceQuotasListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/role_binding_client.go
+++ b/accountsmgmt/v1/role_binding_client.go
@@ -124,13 +124,13 @@ func (r *RoleBindingPollRequest) Predicate(value func(*RoleBindingGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *RoleBindingPollRequest) StartContext(ctx context.Context) (response *RoleBindingPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *RoleBindingPollRequest) Start(ctx context.Context) (response *RoleBindingPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &RoleBindingPollResponse{
 			response: result.(*RoleBindingGetResponse),
@@ -142,7 +142,7 @@ func (r *RoleBindingPollRequest) StartContext(ctx context.Context) (response *Ro
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *RoleBindingPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *RoleBindingDeleteRequest) Impersonate(user string) *RoleBindingDeleteRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleBindingDeleteRequest) Send() (result *RoleBindingDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleBindingDeleteRequest) SendContext(ctx context.Context) (result *RoleBindingDeleteResponse, err error) {
+func (r *RoleBindingDeleteRequest) Send(ctx context.Context) (result *RoleBindingDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *RoleBindingGetRequest) Impersonate(user string) *RoleBindingGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleBindingGetRequest) Send() (result *RoleBindingGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleBindingGetRequest) SendContext(ctx context.Context) (result *RoleBindingGetResponse, err error) {
+func (r *RoleBindingGetRequest) Send(ctx context.Context) (result *RoleBindingGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *RoleBindingUpdateRequest) Body(value *RoleBinding) *RoleBindingUpdateRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleBindingUpdateRequest) Send() (result *RoleBindingUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleBindingUpdateRequest) SendContext(ctx context.Context) (result *RoleBindingUpdateResponse, err error) {
+func (r *RoleBindingUpdateRequest) Send(ctx context.Context) (result *RoleBindingUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/role_bindings_client.go
+++ b/accountsmgmt/v1/role_bindings_client.go
@@ -118,15 +118,7 @@ func (r *RoleBindingsAddRequest) Body(value *RoleBinding) *RoleBindingsAddReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleBindingsAddRequest) Send() (result *RoleBindingsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleBindingsAddRequest) SendContext(ctx context.Context) (result *RoleBindingsAddResponse, err error) {
+func (r *RoleBindingsAddRequest) Send(ctx context.Context) (result *RoleBindingsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -297,15 +289,7 @@ func (r *RoleBindingsListRequest) Size(value int) *RoleBindingsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleBindingsListRequest) Send() (result *RoleBindingsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleBindingsListRequest) SendContext(ctx context.Context) (result *RoleBindingsListResponse, err error) {
+func (r *RoleBindingsListRequest) Send(ctx context.Context) (result *RoleBindingsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/role_client.go
+++ b/accountsmgmt/v1/role_client.go
@@ -124,13 +124,13 @@ func (r *RolePollRequest) Predicate(value func(*RoleGetResponse) bool) *RolePoll
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *RolePollRequest) StartContext(ctx context.Context) (response *RolePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *RolePollRequest) Start(ctx context.Context) (response *RolePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &RolePollResponse{
 			response: result.(*RoleGetResponse),
@@ -142,7 +142,7 @@ func (r *RolePollRequest) StartContext(ctx context.Context) (response *RolePollR
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *RolePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *RoleDeleteRequest) Impersonate(user string) *RoleDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleDeleteRequest) Send() (result *RoleDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleDeleteRequest) SendContext(ctx context.Context) (result *RoleDeleteResponse, err error) {
+func (r *RoleDeleteRequest) Send(ctx context.Context) (result *RoleDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *RoleGetRequest) Impersonate(user string) *RoleGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleGetRequest) Send() (result *RoleGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleGetRequest) SendContext(ctx context.Context) (result *RoleGetResponse, err error) {
+func (r *RoleGetRequest) Send(ctx context.Context) (result *RoleGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *RoleUpdateRequest) Body(value *Role) *RoleUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RoleUpdateRequest) Send() (result *RoleUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RoleUpdateRequest) SendContext(ctx context.Context) (result *RoleUpdateResponse, err error) {
+func (r *RoleUpdateRequest) Send(ctx context.Context) (result *RoleUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/roles_client.go
+++ b/accountsmgmt/v1/roles_client.go
@@ -118,15 +118,7 @@ func (r *RolesAddRequest) Body(value *Role) *RolesAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RolesAddRequest) Send() (result *RolesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RolesAddRequest) SendContext(ctx context.Context) (result *RolesAddResponse, err error) {
+func (r *RolesAddRequest) Send(ctx context.Context) (result *RolesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -297,15 +289,7 @@ func (r *RolesListRequest) Size(value int) *RolesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *RolesListRequest) Send() (result *RolesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *RolesListRequest) SendContext(ctx context.Context) (result *RolesListResponse, err error) {
+func (r *RolesListRequest) Send(ctx context.Context) (result *RolesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/sku_rule_client.go
+++ b/accountsmgmt/v1/sku_rule_client.go
@@ -102,13 +102,13 @@ func (r *SkuRulePollRequest) Predicate(value func(*SkuRuleGetResponse) bool) *Sk
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *SkuRulePollRequest) StartContext(ctx context.Context) (response *SkuRulePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *SkuRulePollRequest) Start(ctx context.Context) (response *SkuRulePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &SkuRulePollResponse{
 			response: result.(*SkuRuleGetResponse),
@@ -120,7 +120,7 @@ func (r *SkuRulePollRequest) StartContext(ctx context.Context) (response *SkuRul
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *SkuRulePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *SkuRuleGetRequest) Impersonate(user string) *SkuRuleGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SkuRuleGetRequest) Send() (result *SkuRuleGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SkuRuleGetRequest) SendContext(ctx context.Context) (result *SkuRuleGetResponse, err error) {
+func (r *SkuRuleGetRequest) Send(ctx context.Context) (result *SkuRuleGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/sku_rules_client.go
+++ b/accountsmgmt/v1/sku_rules_client.go
@@ -136,15 +136,7 @@ func (r *SkuRulesListRequest) Size(value int) *SkuRulesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SkuRulesListRequest) Send() (result *SkuRulesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SkuRulesListRequest) SendContext(ctx context.Context) (result *SkuRulesListResponse, err error) {
+func (r *SkuRulesListRequest) Send(ctx context.Context) (result *SkuRulesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/subscription_client.go
+++ b/accountsmgmt/v1/subscription_client.go
@@ -166,13 +166,13 @@ func (r *SubscriptionPollRequest) Predicate(value func(*SubscriptionGetResponse)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *SubscriptionPollRequest) StartContext(ctx context.Context) (response *SubscriptionPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *SubscriptionPollRequest) Start(ctx context.Context) (response *SubscriptionPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &SubscriptionPollResponse{
 			response: result.(*SubscriptionGetResponse),
@@ -184,7 +184,7 @@ func (r *SubscriptionPollRequest) StartContext(ctx context.Context) (response *S
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *SubscriptionPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -272,15 +272,7 @@ func (r *SubscriptionDeleteRequest) Impersonate(user string) *SubscriptionDelete
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionDeleteRequest) Send() (result *SubscriptionDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionDeleteRequest) SendContext(ctx context.Context) (result *SubscriptionDeleteResponse, err error) {
+func (r *SubscriptionDeleteRequest) Send(ctx context.Context) (result *SubscriptionDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -379,15 +371,7 @@ func (r *SubscriptionGetRequest) Impersonate(user string) *SubscriptionGetReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionGetRequest) Send() (result *SubscriptionGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionGetRequest) SendContext(ctx context.Context) (result *SubscriptionGetResponse, err error) {
+func (r *SubscriptionGetRequest) Send(ctx context.Context) (result *SubscriptionGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -522,15 +506,7 @@ func (r *SubscriptionUpdateRequest) Body(value *Subscription) *SubscriptionUpdat
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionUpdateRequest) Send() (result *SubscriptionUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionUpdateRequest) SendContext(ctx context.Context) (result *SubscriptionUpdateResponse, err error) {
+func (r *SubscriptionUpdateRequest) Send(ctx context.Context) (result *SubscriptionUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/subscription_notify_client.go
+++ b/accountsmgmt/v1/subscription_notify_client.go
@@ -97,15 +97,7 @@ func (r *SubscriptionNotifyAddRequest) Body(value *SubscriptionNotify) *Subscrip
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionNotifyAddRequest) Send() (result *SubscriptionNotifyAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionNotifyAddRequest) SendContext(ctx context.Context) (result *SubscriptionNotifyAddResponse, err error) {
+func (r *SubscriptionNotifyAddRequest) Send(ctx context.Context) (result *SubscriptionNotifyAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/subscription_reserved_resource_client.go
+++ b/accountsmgmt/v1/subscription_reserved_resource_client.go
@@ -102,13 +102,13 @@ func (r *SubscriptionReservedResourcePollRequest) Predicate(value func(*Subscrip
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *SubscriptionReservedResourcePollRequest) StartContext(ctx context.Context) (response *SubscriptionReservedResourcePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *SubscriptionReservedResourcePollRequest) Start(ctx context.Context) (response *SubscriptionReservedResourcePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &SubscriptionReservedResourcePollResponse{
 			response: result.(*SubscriptionReservedResourceGetResponse),
@@ -120,7 +120,7 @@ func (r *SubscriptionReservedResourcePollRequest) StartContext(ctx context.Conte
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *SubscriptionReservedResourcePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *SubscriptionReservedResourceGetRequest) Impersonate(user string) *Subsc
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionReservedResourceGetRequest) Send() (result *SubscriptionReservedResourceGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionReservedResourceGetRequest) SendContext(ctx context.Context) (result *SubscriptionReservedResourceGetResponse, err error) {
+func (r *SubscriptionReservedResourceGetRequest) Send(ctx context.Context) (result *SubscriptionReservedResourceGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/subscription_reserved_resources_client.go
+++ b/accountsmgmt/v1/subscription_reserved_resources_client.go
@@ -116,15 +116,7 @@ func (r *SubscriptionReservedResourcesListRequest) Size(value int) *Subscription
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionReservedResourcesListRequest) Send() (result *SubscriptionReservedResourcesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionReservedResourcesListRequest) SendContext(ctx context.Context) (result *SubscriptionReservedResourcesListResponse, err error) {
+func (r *SubscriptionReservedResourcesListRequest) Send(ctx context.Context) (result *SubscriptionReservedResourcesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/accountsmgmt/v1/subscriptions_client.go
+++ b/accountsmgmt/v1/subscriptions_client.go
@@ -225,15 +225,7 @@ func (r *SubscriptionsListRequest) Size(value int) *SubscriptionsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionsListRequest) Send() (result *SubscriptionsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionsListRequest) SendContext(ctx context.Context) (result *SubscriptionsListResponse, err error) {
+func (r *SubscriptionsListRequest) Send(ctx context.Context) (result *SubscriptionsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.fetchaccountsAccounts != nil {
 		helpers.AddValue(&query, "fetchaccounts_accounts", *r.fetchaccountsAccounts)
@@ -463,15 +455,7 @@ func (r *SubscriptionsPostRequest) Request(value *SubscriptionRegistration) *Sub
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SubscriptionsPostRequest) Send() (result *SubscriptionsPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SubscriptionsPostRequest) SendContext(ctx context.Context) (result *SubscriptionsPostResponse, err error) {
+func (r *SubscriptionsPostRequest) Send(ctx context.Context) (result *SubscriptionsPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/summary_dashboard_client.go
+++ b/accountsmgmt/v1/summary_dashboard_client.go
@@ -102,13 +102,13 @@ func (r *SummaryDashboardPollRequest) Predicate(value func(*SummaryDashboardGetR
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *SummaryDashboardPollRequest) StartContext(ctx context.Context) (response *SummaryDashboardPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *SummaryDashboardPollRequest) Start(ctx context.Context) (response *SummaryDashboardPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &SummaryDashboardPollResponse{
 			response: result.(*SummaryDashboardGetResponse),
@@ -120,7 +120,7 @@ func (r *SummaryDashboardPollRequest) StartContext(ctx context.Context) (respons
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *SummaryDashboardPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *SummaryDashboardGetRequest) Impersonate(user string) *SummaryDashboardG
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SummaryDashboardGetRequest) Send() (result *SummaryDashboardGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SummaryDashboardGetRequest) SendContext(ctx context.Context) (result *SummaryDashboardGetResponse, err error) {
+func (r *SummaryDashboardGetRequest) Send(ctx context.Context) (result *SummaryDashboardGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/support_case_client.go
+++ b/accountsmgmt/v1/support_case_client.go
@@ -86,15 +86,7 @@ func (r *SupportCaseDeleteRequest) Impersonate(user string) *SupportCaseDeleteRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SupportCaseDeleteRequest) Send() (result *SupportCaseDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SupportCaseDeleteRequest) SendContext(ctx context.Context) (result *SupportCaseDeleteResponse, err error) {
+func (r *SupportCaseDeleteRequest) Send(ctx context.Context) (result *SupportCaseDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/accountsmgmt/v1/support_cases_client.go
+++ b/accountsmgmt/v1/support_cases_client.go
@@ -108,15 +108,7 @@ func (r *SupportCasesPostRequest) Request(value *SupportCaseRequest) *SupportCas
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SupportCasesPostRequest) Send() (result *SupportCasesPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SupportCasesPostRequest) SendContext(ctx context.Context) (result *SupportCasesPostResponse, err error) {
+func (r *SupportCasesPostRequest) Send(ctx context.Context) (result *SupportCasesPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/accountsmgmt/v1/token_authorization_client.go
+++ b/accountsmgmt/v1/token_authorization_client.go
@@ -97,15 +97,7 @@ func (r *TokenAuthorizationPostRequest) Request(value *TokenAuthorizationRequest
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *TokenAuthorizationPostRequest) Send() (result *TokenAuthorizationPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *TokenAuthorizationPostRequest) SendContext(ctx context.Context) (result *TokenAuthorizationPostResponse, err error) {
+func (r *TokenAuthorizationPostRequest) Send(ctx context.Context) (result *TokenAuthorizationPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/alternative_url_test.go
+++ b/alternative_url_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package sdk
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"time"
@@ -32,6 +33,9 @@ import (
 )
 
 var _ = Describe("Alternative URLs", func() {
+	// Context used during the tests:
+	var ctx context.Context
+
 	// Tokens used during the tests:
 	var accessToken string
 	var refreshToken string
@@ -52,6 +56,9 @@ var _ = Describe("Alternative URLs", func() {
 	var alternativeURL string
 
 	BeforeEach(func() {
+		// Create the context:
+		ctx = context.Background()
+
 		// Create the tokens:
 		accessToken = MakeTokenString("Bearer", 5*time.Minute)
 		refreshToken = MakeTokenString("Refresh", 10*time.Hour)
@@ -221,7 +228,7 @@ var _ = Describe("Alternative URLs", func() {
 			}()
 
 			// Send the request:
-			_, err = connection.ClustersMgmt().V1().Get().Send()
+			_, err = connection.ClustersMgmt().V1().Get().Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -253,7 +260,7 @@ var _ = Describe("Alternative URLs", func() {
 			}()
 
 			// Send the request:
-			_, err = connection.ClustersMgmt().V1().Get().Send()
+			_, err = connection.ClustersMgmt().V1().Get().Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -286,7 +293,7 @@ var _ = Describe("Alternative URLs", func() {
 			}()
 
 			// Send the request:
-			_, err = connection.ClustersMgmt().V1().Get().Send()
+			_, err = connection.ClustersMgmt().V1().Get().Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/authorizations/v1/access_review_client.go
+++ b/authorizations/v1/access_review_client.go
@@ -97,15 +97,7 @@ func (r *AccessReviewPostRequest) Request(value *AccessReviewRequest) *AccessRev
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AccessReviewPostRequest) Send() (result *AccessReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AccessReviewPostRequest) SendContext(ctx context.Context) (result *AccessReviewPostResponse, err error) {
+func (r *AccessReviewPostRequest) Send(ctx context.Context) (result *AccessReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/capability_review_client.go
+++ b/authorizations/v1/capability_review_client.go
@@ -97,15 +97,7 @@ func (r *CapabilityReviewPostRequest) Request(value *CapabilityReviewRequest) *C
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CapabilityReviewPostRequest) Send() (result *CapabilityReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CapabilityReviewPostRequest) SendContext(ctx context.Context) (result *CapabilityReviewPostResponse, err error) {
+func (r *CapabilityReviewPostRequest) Send(ctx context.Context) (result *CapabilityReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/export_control_review_client.go
+++ b/authorizations/v1/export_control_review_client.go
@@ -97,15 +97,7 @@ func (r *ExportControlReviewPostRequest) Request(value *ExportControlReviewReque
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ExportControlReviewPostRequest) Send() (result *ExportControlReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ExportControlReviewPostRequest) SendContext(ctx context.Context) (result *ExportControlReviewPostResponse, err error) {
+func (r *ExportControlReviewPostRequest) Send(ctx context.Context) (result *ExportControlReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/feature_review_client.go
+++ b/authorizations/v1/feature_review_client.go
@@ -97,15 +97,7 @@ func (r *FeatureReviewPostRequest) Request(value *FeatureReviewRequest) *Feature
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *FeatureReviewPostRequest) Send() (result *FeatureReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *FeatureReviewPostRequest) SendContext(ctx context.Context) (result *FeatureReviewPostResponse, err error) {
+func (r *FeatureReviewPostRequest) Send(ctx context.Context) (result *FeatureReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/metadata_client.go
+++ b/authorizations/v1/metadata_client.go
@@ -59,15 +59,7 @@ func (r *MetadataRequest) Header(name string, value interface{}) *MetadataReques
 }
 
 // Send sends the metadata request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends the metadata request, waits for the response, and returns it.
-func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/authorizations/v1/resource_review_client.go
+++ b/authorizations/v1/resource_review_client.go
@@ -98,15 +98,7 @@ func (r *ResourceReviewPostRequest) Request(value *ResourceReviewRequest) *Resou
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ResourceReviewPostRequest) Send() (result *ResourceReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ResourceReviewPostRequest) SendContext(ctx context.Context) (result *ResourceReviewPostResponse, err error) {
+func (r *ResourceReviewPostRequest) Send(ctx context.Context) (result *ResourceReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/self_access_review_client.go
+++ b/authorizations/v1/self_access_review_client.go
@@ -97,15 +97,7 @@ func (r *SelfAccessReviewPostRequest) Request(value *SelfAccessReviewRequest) *S
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SelfAccessReviewPostRequest) Send() (result *SelfAccessReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SelfAccessReviewPostRequest) SendContext(ctx context.Context) (result *SelfAccessReviewPostResponse, err error) {
+func (r *SelfAccessReviewPostRequest) Send(ctx context.Context) (result *SelfAccessReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/self_capability_review_client.go
+++ b/authorizations/v1/self_capability_review_client.go
@@ -97,15 +97,7 @@ func (r *SelfCapabilityReviewPostRequest) Request(value *SelfCapabilityReviewReq
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SelfCapabilityReviewPostRequest) Send() (result *SelfCapabilityReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SelfCapabilityReviewPostRequest) SendContext(ctx context.Context) (result *SelfCapabilityReviewPostResponse, err error) {
+func (r *SelfCapabilityReviewPostRequest) Send(ctx context.Context) (result *SelfCapabilityReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/self_feature_review_client.go
+++ b/authorizations/v1/self_feature_review_client.go
@@ -97,15 +97,7 @@ func (r *SelfFeatureReviewPostRequest) Request(value *SelfFeatureReviewRequest) 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SelfFeatureReviewPostRequest) Send() (result *SelfFeatureReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SelfFeatureReviewPostRequest) SendContext(ctx context.Context) (result *SelfFeatureReviewPostResponse, err error) {
+func (r *SelfFeatureReviewPostRequest) Send(ctx context.Context) (result *SelfFeatureReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/self_terms_review_client.go
+++ b/authorizations/v1/self_terms_review_client.go
@@ -98,15 +98,7 @@ func (r *SelfTermsReviewPostRequest) Request(value *SelfTermsReviewRequest) *Sel
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SelfTermsReviewPostRequest) Send() (result *SelfTermsReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SelfTermsReviewPostRequest) SendContext(ctx context.Context) (result *SelfTermsReviewPostResponse, err error) {
+func (r *SelfTermsReviewPostRequest) Send(ctx context.Context) (result *SelfTermsReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/authorizations/v1/terms_review_client.go
+++ b/authorizations/v1/terms_review_client.go
@@ -98,15 +98,7 @@ func (r *TermsReviewPostRequest) Request(value *TermsReviewRequest) *TermsReview
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *TermsReviewPostRequest) Send() (result *TermsReviewPostResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *TermsReviewPostRequest) SendContext(ctx context.Context) (result *TermsReviewPostResponse, err error) {
+func (r *TermsReviewPostRequest) Send(ctx context.Context) (result *TermsReviewPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/add_on_client.go
+++ b/clustersmgmt/v1/add_on_client.go
@@ -135,13 +135,13 @@ func (r *AddOnPollRequest) Predicate(value func(*AddOnGetResponse) bool) *AddOnP
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AddOnPollRequest) StartContext(ctx context.Context) (response *AddOnPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AddOnPollRequest) Start(ctx context.Context) (response *AddOnPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AddOnPollResponse{
 			response: result.(*AddOnGetResponse),
@@ -153,7 +153,7 @@ func (r *AddOnPollRequest) StartContext(ctx context.Context) (response *AddOnPol
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AddOnPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -241,15 +241,7 @@ func (r *AddOnDeleteRequest) Impersonate(user string) *AddOnDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnDeleteRequest) Send() (result *AddOnDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnDeleteRequest) SendContext(ctx context.Context) (result *AddOnDeleteResponse, err error) {
+func (r *AddOnDeleteRequest) Send(ctx context.Context) (result *AddOnDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -348,15 +340,7 @@ func (r *AddOnGetRequest) Impersonate(user string) *AddOnGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnGetRequest) Send() (result *AddOnGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnGetRequest) SendContext(ctx context.Context) (result *AddOnGetResponse, err error) {
+func (r *AddOnGetRequest) Send(ctx context.Context) (result *AddOnGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -491,15 +475,7 @@ func (r *AddOnUpdateRequest) Body(value *AddOn) *AddOnUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnUpdateRequest) Send() (result *AddOnUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnUpdateRequest) SendContext(ctx context.Context) (result *AddOnUpdateResponse, err error) {
+func (r *AddOnUpdateRequest) Send(ctx context.Context) (result *AddOnUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/add_on_installation_client.go
+++ b/clustersmgmt/v1/add_on_installation_client.go
@@ -124,13 +124,13 @@ func (r *AddOnInstallationPollRequest) Predicate(value func(*AddOnInstallationGe
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AddOnInstallationPollRequest) StartContext(ctx context.Context) (response *AddOnInstallationPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AddOnInstallationPollRequest) Start(ctx context.Context) (response *AddOnInstallationPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AddOnInstallationPollResponse{
 			response: result.(*AddOnInstallationGetResponse),
@@ -142,7 +142,7 @@ func (r *AddOnInstallationPollRequest) StartContext(ctx context.Context) (respon
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AddOnInstallationPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *AddOnInstallationDeleteRequest) Impersonate(user string) *AddOnInstalla
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnInstallationDeleteRequest) Send() (result *AddOnInstallationDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnInstallationDeleteRequest) SendContext(ctx context.Context) (result *AddOnInstallationDeleteResponse, err error) {
+func (r *AddOnInstallationDeleteRequest) Send(ctx context.Context) (result *AddOnInstallationDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *AddOnInstallationGetRequest) Impersonate(user string) *AddOnInstallatio
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnInstallationGetRequest) Send() (result *AddOnInstallationGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnInstallationGetRequest) SendContext(ctx context.Context) (result *AddOnInstallationGetResponse, err error) {
+func (r *AddOnInstallationGetRequest) Send(ctx context.Context) (result *AddOnInstallationGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *AddOnInstallationUpdateRequest) Body(value *AddOnInstallation) *AddOnIn
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnInstallationUpdateRequest) Send() (result *AddOnInstallationUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnInstallationUpdateRequest) SendContext(ctx context.Context) (result *AddOnInstallationUpdateResponse, err error) {
+func (r *AddOnInstallationUpdateRequest) Send(ctx context.Context) (result *AddOnInstallationUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/add_on_installations_client.go
+++ b/clustersmgmt/v1/add_on_installations_client.go
@@ -118,15 +118,7 @@ func (r *AddOnInstallationsAddRequest) Body(value *AddOnInstallation) *AddOnInst
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnInstallationsAddRequest) Send() (result *AddOnInstallationsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnInstallationsAddRequest) SendContext(ctx context.Context) (result *AddOnInstallationsAddResponse, err error) {
+func (r *AddOnInstallationsAddRequest) Send(ctx context.Context) (result *AddOnInstallationsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -318,15 +310,7 @@ func (r *AddOnInstallationsListRequest) Size(value int) *AddOnInstallationsListR
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnInstallationsListRequest) Send() (result *AddOnInstallationsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnInstallationsListRequest) SendContext(ctx context.Context) (result *AddOnInstallationsListResponse, err error) {
+func (r *AddOnInstallationsListRequest) Send(ctx context.Context) (result *AddOnInstallationsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/add_on_version_client.go
+++ b/clustersmgmt/v1/add_on_version_client.go
@@ -124,13 +124,13 @@ func (r *AddOnVersionPollRequest) Predicate(value func(*AddOnVersionGetResponse)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AddOnVersionPollRequest) StartContext(ctx context.Context) (response *AddOnVersionPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AddOnVersionPollRequest) Start(ctx context.Context) (response *AddOnVersionPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AddOnVersionPollResponse{
 			response: result.(*AddOnVersionGetResponse),
@@ -142,7 +142,7 @@ func (r *AddOnVersionPollRequest) StartContext(ctx context.Context) (response *A
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AddOnVersionPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *AddOnVersionDeleteRequest) Impersonate(user string) *AddOnVersionDelete
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnVersionDeleteRequest) Send() (result *AddOnVersionDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnVersionDeleteRequest) SendContext(ctx context.Context) (result *AddOnVersionDeleteResponse, err error) {
+func (r *AddOnVersionDeleteRequest) Send(ctx context.Context) (result *AddOnVersionDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *AddOnVersionGetRequest) Impersonate(user string) *AddOnVersionGetReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnVersionGetRequest) Send() (result *AddOnVersionGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnVersionGetRequest) SendContext(ctx context.Context) (result *AddOnVersionGetResponse, err error) {
+func (r *AddOnVersionGetRequest) Send(ctx context.Context) (result *AddOnVersionGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *AddOnVersionUpdateRequest) Body(value *AddOnVersion) *AddOnVersionUpdat
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnVersionUpdateRequest) Send() (result *AddOnVersionUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnVersionUpdateRequest) SendContext(ctx context.Context) (result *AddOnVersionUpdateResponse, err error) {
+func (r *AddOnVersionUpdateRequest) Send(ctx context.Context) (result *AddOnVersionUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/add_on_versions_client.go
+++ b/clustersmgmt/v1/add_on_versions_client.go
@@ -118,15 +118,7 @@ func (r *AddOnVersionsAddRequest) Body(value *AddOnVersion) *AddOnVersionsAddReq
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnVersionsAddRequest) Send() (result *AddOnVersionsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnVersionsAddRequest) SendContext(ctx context.Context) (result *AddOnVersionsAddResponse, err error) {
+func (r *AddOnVersionsAddRequest) Send(ctx context.Context) (result *AddOnVersionsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -318,15 +310,7 @@ func (r *AddOnVersionsListRequest) Size(value int) *AddOnVersionsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnVersionsListRequest) Send() (result *AddOnVersionsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnVersionsListRequest) SendContext(ctx context.Context) (result *AddOnVersionsListResponse, err error) {
+func (r *AddOnVersionsListRequest) Send(ctx context.Context) (result *AddOnVersionsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/add_ons_client.go
+++ b/clustersmgmt/v1/add_ons_client.go
@@ -118,15 +118,7 @@ func (r *AddOnsAddRequest) Body(value *AddOn) *AddOnsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnsAddRequest) Send() (result *AddOnsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnsAddRequest) SendContext(ctx context.Context) (result *AddOnsAddResponse, err error) {
+func (r *AddOnsAddRequest) Send(ctx context.Context) (result *AddOnsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -318,15 +310,7 @@ func (r *AddOnsListRequest) Size(value int) *AddOnsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddOnsListRequest) Send() (result *AddOnsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddOnsListRequest) SendContext(ctx context.Context) (result *AddOnsListResponse, err error) {
+func (r *AddOnsListRequest) Send(ctx context.Context) (result *AddOnsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/addon_inquiries_client.go
+++ b/clustersmgmt/v1/addon_inquiries_client.go
@@ -158,15 +158,7 @@ func (r *AddonInquiriesListRequest) Size(value int) *AddonInquiriesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddonInquiriesListRequest) Send() (result *AddonInquiriesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddonInquiriesListRequest) SendContext(ctx context.Context) (result *AddonInquiriesListResponse, err error) {
+func (r *AddonInquiriesListRequest) Send(ctx context.Context) (result *AddonInquiriesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/addon_inquiry_client.go
+++ b/clustersmgmt/v1/addon_inquiry_client.go
@@ -102,13 +102,13 @@ func (r *AddonInquiryPollRequest) Predicate(value func(*AddonInquiryGetResponse)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AddonInquiryPollRequest) StartContext(ctx context.Context) (response *AddonInquiryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AddonInquiryPollRequest) Start(ctx context.Context) (response *AddonInquiryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AddonInquiryPollResponse{
 			response: result.(*AddonInquiryGetResponse),
@@ -120,7 +120,7 @@ func (r *AddonInquiryPollRequest) StartContext(ctx context.Context) (response *A
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AddonInquiryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *AddonInquiryGetRequest) Impersonate(user string) *AddonInquiryGetReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AddonInquiryGetRequest) Send() (result *AddonInquiryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AddonInquiryGetRequest) SendContext(ctx context.Context) (result *AddonInquiryGetResponse, err error) {
+func (r *AddonInquiryGetRequest) Send(ctx context.Context) (result *AddonInquiryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/alerts_metric_query_client.go
+++ b/clustersmgmt/v1/alerts_metric_query_client.go
@@ -102,13 +102,13 @@ func (r *AlertsMetricQueryPollRequest) Predicate(value func(*AlertsMetricQueryGe
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AlertsMetricQueryPollRequest) StartContext(ctx context.Context) (response *AlertsMetricQueryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AlertsMetricQueryPollRequest) Start(ctx context.Context) (response *AlertsMetricQueryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AlertsMetricQueryPollResponse{
 			response: result.(*AlertsMetricQueryGetResponse),
@@ -120,7 +120,7 @@ func (r *AlertsMetricQueryPollRequest) StartContext(ctx context.Context) (respon
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AlertsMetricQueryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *AlertsMetricQueryGetRequest) Impersonate(user string) *AlertsMetricQuer
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AlertsMetricQueryGetRequest) Send() (result *AlertsMetricQueryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AlertsMetricQueryGetRequest) SendContext(ctx context.Context) (result *AlertsMetricQueryGetResponse, err error) {
+func (r *AlertsMetricQueryGetRequest) Send(ctx context.Context) (result *AlertsMetricQueryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/available_regions_client.go
+++ b/clustersmgmt/v1/available_regions_client.go
@@ -122,15 +122,7 @@ func (r *AvailableRegionsSearchRequest) Size(value int) *AvailableRegionsSearchR
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AvailableRegionsSearchRequest) Send() (result *AvailableRegionsSearchResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AvailableRegionsSearchRequest) SendContext(ctx context.Context) (result *AvailableRegionsSearchResponse, err error) {
+func (r *AvailableRegionsSearchRequest) Send(ctx context.Context) (result *AvailableRegionsSearchResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/available_regions_inquiry_client.go
+++ b/clustersmgmt/v1/available_regions_inquiry_client.go
@@ -121,15 +121,7 @@ func (r *AvailableRegionsInquirySearchRequest) Size(value int) *AvailableRegions
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AvailableRegionsInquirySearchRequest) Send() (result *AvailableRegionsInquirySearchResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AvailableRegionsInquirySearchRequest) SendContext(ctx context.Context) (result *AvailableRegionsInquirySearchResponse, err error) {
+func (r *AvailableRegionsInquirySearchRequest) Send(ctx context.Context) (result *AvailableRegionsInquirySearchResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/aws_infrastructure_access_role_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_client.go
@@ -102,13 +102,13 @@ func (r *AWSInfrastructureAccessRolePollRequest) Predicate(value func(*AWSInfras
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AWSInfrastructureAccessRolePollRequest) StartContext(ctx context.Context) (response *AWSInfrastructureAccessRolePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AWSInfrastructureAccessRolePollRequest) Start(ctx context.Context) (response *AWSInfrastructureAccessRolePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AWSInfrastructureAccessRolePollResponse{
 			response: result.(*AWSInfrastructureAccessRoleGetResponse),
@@ -120,7 +120,7 @@ func (r *AWSInfrastructureAccessRolePollRequest) StartContext(ctx context.Contex
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AWSInfrastructureAccessRolePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *AWSInfrastructureAccessRoleGetRequest) Impersonate(user string) *AWSInf
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AWSInfrastructureAccessRoleGetRequest) Send() (result *AWSInfrastructureAccessRoleGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AWSInfrastructureAccessRoleGetRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRoleGetResponse, err error) {
+func (r *AWSInfrastructureAccessRoleGetRequest) Send(ctx context.Context) (result *AWSInfrastructureAccessRoleGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grant_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grant_client.go
@@ -112,13 +112,13 @@ func (r *AWSInfrastructureAccessRoleGrantPollRequest) Predicate(value func(*AWSI
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *AWSInfrastructureAccessRoleGrantPollRequest) StartContext(ctx context.Context) (response *AWSInfrastructureAccessRoleGrantPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *AWSInfrastructureAccessRoleGrantPollRequest) Start(ctx context.Context) (response *AWSInfrastructureAccessRoleGrantPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &AWSInfrastructureAccessRoleGrantPollResponse{
 			response: result.(*AWSInfrastructureAccessRoleGrantGetResponse),
@@ -130,7 +130,7 @@ func (r *AWSInfrastructureAccessRoleGrantPollRequest) StartContext(ctx context.C
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *AWSInfrastructureAccessRoleGrantPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *AWSInfrastructureAccessRoleGrantDeleteRequest) Impersonate(user string)
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AWSInfrastructureAccessRoleGrantDeleteRequest) Send() (result *AWSInfrastructureAccessRoleGrantDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AWSInfrastructureAccessRoleGrantDeleteRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantDeleteResponse, err error) {
+func (r *AWSInfrastructureAccessRoleGrantDeleteRequest) Send(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *AWSInfrastructureAccessRoleGrantGetRequest) Impersonate(user string) *A
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AWSInfrastructureAccessRoleGrantGetRequest) Send() (result *AWSInfrastructureAccessRoleGrantGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AWSInfrastructureAccessRoleGrantGetRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantGetResponse, err error) {
+func (r *AWSInfrastructureAccessRoleGrantGetRequest) Send(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/aws_infrastructure_access_role_grants_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_role_grants_client.go
@@ -119,15 +119,7 @@ func (r *AWSInfrastructureAccessRoleGrantsAddRequest) Body(value *AWSInfrastruct
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AWSInfrastructureAccessRoleGrantsAddRequest) Send() (result *AWSInfrastructureAccessRoleGrantsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AWSInfrastructureAccessRoleGrantsAddRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantsAddResponse, err error) {
+func (r *AWSInfrastructureAccessRoleGrantsAddRequest) Send(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -319,15 +311,7 @@ func (r *AWSInfrastructureAccessRoleGrantsListRequest) Size(value int) *AWSInfra
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AWSInfrastructureAccessRoleGrantsListRequest) Send() (result *AWSInfrastructureAccessRoleGrantsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AWSInfrastructureAccessRoleGrantsListRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantsListResponse, err error) {
+func (r *AWSInfrastructureAccessRoleGrantsListRequest) Send(ctx context.Context) (result *AWSInfrastructureAccessRoleGrantsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
+++ b/clustersmgmt/v1/aws_infrastructure_access_roles_client.go
@@ -157,15 +157,7 @@ func (r *AWSInfrastructureAccessRolesListRequest) Size(value int) *AWSInfrastruc
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AWSInfrastructureAccessRolesListRequest) Send() (result *AWSInfrastructureAccessRolesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AWSInfrastructureAccessRolesListRequest) SendContext(ctx context.Context) (result *AWSInfrastructureAccessRolesListResponse, err error) {
+func (r *AWSInfrastructureAccessRolesListRequest) Send(ctx context.Context) (result *AWSInfrastructureAccessRolesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/awssts_policies_inquiry_client.go
+++ b/clustersmgmt/v1/awssts_policies_inquiry_client.go
@@ -147,15 +147,7 @@ func (r *AWSSTSPoliciesInquiryListRequest) Size(value int) *AWSSTSPoliciesInquir
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *AWSSTSPoliciesInquiryListRequest) Send() (result *AWSSTSPoliciesInquiryListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *AWSSTSPoliciesInquiryListRequest) SendContext(ctx context.Context) (result *AWSSTSPoliciesInquiryListResponse, err error) {
+func (r *AWSSTSPoliciesInquiryListRequest) Send(ctx context.Context) (result *AWSSTSPoliciesInquiryListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/cloud_provider_client.go
+++ b/clustersmgmt/v1/cloud_provider_client.go
@@ -125,13 +125,13 @@ func (r *CloudProviderPollRequest) Predicate(value func(*CloudProviderGetRespons
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *CloudProviderPollRequest) StartContext(ctx context.Context) (response *CloudProviderPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *CloudProviderPollRequest) Start(ctx context.Context) (response *CloudProviderPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &CloudProviderPollResponse{
 			response: result.(*CloudProviderGetResponse),
@@ -143,7 +143,7 @@ func (r *CloudProviderPollRequest) StartContext(ctx context.Context) (response *
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *CloudProviderPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -231,15 +231,7 @@ func (r *CloudProviderGetRequest) Impersonate(user string) *CloudProviderGetRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CloudProviderGetRequest) Send() (result *CloudProviderGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CloudProviderGetRequest) SendContext(ctx context.Context) (result *CloudProviderGetResponse, err error) {
+func (r *CloudProviderGetRequest) Send(ctx context.Context) (result *CloudProviderGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/cloud_providers_client.go
+++ b/clustersmgmt/v1/cloud_providers_client.go
@@ -157,15 +157,7 @@ func (r *CloudProvidersListRequest) Size(value int) *CloudProvidersListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CloudProvidersListRequest) Send() (result *CloudProvidersListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CloudProvidersListRequest) SendContext(ctx context.Context) (result *CloudProvidersListResponse, err error) {
+func (r *CloudProvidersListRequest) Send(ctx context.Context) (result *CloudProvidersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/cloud_region_client.go
+++ b/clustersmgmt/v1/cloud_region_client.go
@@ -102,13 +102,13 @@ func (r *CloudRegionPollRequest) Predicate(value func(*CloudRegionGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *CloudRegionPollRequest) StartContext(ctx context.Context) (response *CloudRegionPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *CloudRegionPollRequest) Start(ctx context.Context) (response *CloudRegionPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &CloudRegionPollResponse{
 			response: result.(*CloudRegionGetResponse),
@@ -120,7 +120,7 @@ func (r *CloudRegionPollRequest) StartContext(ctx context.Context) (response *Cl
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *CloudRegionPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *CloudRegionGetRequest) Impersonate(user string) *CloudRegionGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CloudRegionGetRequest) Send() (result *CloudRegionGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CloudRegionGetRequest) SendContext(ctx context.Context) (result *CloudRegionGetResponse, err error) {
+func (r *CloudRegionGetRequest) Send(ctx context.Context) (result *CloudRegionGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/cloud_regions_client.go
+++ b/clustersmgmt/v1/cloud_regions_client.go
@@ -122,15 +122,7 @@ func (r *CloudRegionsListRequest) Size(value int) *CloudRegionsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CloudRegionsListRequest) Send() (result *CloudRegionsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CloudRegionsListRequest) SendContext(ctx context.Context) (result *CloudRegionsListResponse, err error) {
+func (r *CloudRegionsListRequest) Send(ctx context.Context) (result *CloudRegionsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/cluster_client.go
+++ b/clustersmgmt/v1/cluster_client.go
@@ -347,13 +347,13 @@ func (r *ClusterPollRequest) Predicate(value func(*ClusterGetResponse) bool) *Cl
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ClusterPollRequest) StartContext(ctx context.Context) (response *ClusterPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ClusterPollRequest) Start(ctx context.Context) (response *ClusterPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ClusterPollResponse{
 			response: result.(*ClusterGetResponse),
@@ -365,7 +365,7 @@ func (r *ClusterPollRequest) StartContext(ctx context.Context) (response *Cluste
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ClusterPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -463,15 +463,7 @@ func (r *ClusterDeleteRequest) Deprovision(value bool) *ClusterDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterDeleteRequest) Send() (result *ClusterDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterDeleteRequest) SendContext(ctx context.Context) (result *ClusterDeleteResponse, err error) {
+func (r *ClusterDeleteRequest) Send(ctx context.Context) (result *ClusterDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.deprovision != nil {
 		helpers.AddValue(&query, "deprovision", *r.deprovision)
@@ -573,15 +565,7 @@ func (r *ClusterGetRequest) Impersonate(user string) *ClusterGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterGetRequest) Send() (result *ClusterGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterGetRequest) SendContext(ctx context.Context) (result *ClusterGetResponse, err error) {
+func (r *ClusterGetRequest) Send(ctx context.Context) (result *ClusterGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -707,15 +691,7 @@ func (r *ClusterHibernateRequest) Impersonate(user string) *ClusterHibernateRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterHibernateRequest) Send() (result *ClusterHibernateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterHibernateRequest) SendContext(ctx context.Context) (result *ClusterHibernateResponse, err error) {
+func (r *ClusterHibernateRequest) Send(ctx context.Context) (result *ClusterHibernateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -814,15 +790,7 @@ func (r *ClusterResumeRequest) Impersonate(user string) *ClusterResumeRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterResumeRequest) Send() (result *ClusterResumeResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterResumeRequest) SendContext(ctx context.Context) (result *ClusterResumeResponse, err error) {
+func (r *ClusterResumeRequest) Send(ctx context.Context) (result *ClusterResumeResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -930,15 +898,7 @@ func (r *ClusterUpdateRequest) Body(value *Cluster) *ClusterUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterUpdateRequest) Send() (result *ClusterUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterUpdateRequest) SendContext(ctx context.Context) (result *ClusterUpdateResponse, err error) {
+func (r *ClusterUpdateRequest) Send(ctx context.Context) (result *ClusterUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/cluster_operators_metric_query_client.go
+++ b/clustersmgmt/v1/cluster_operators_metric_query_client.go
@@ -102,13 +102,13 @@ func (r *ClusterOperatorsMetricQueryPollRequest) Predicate(value func(*ClusterOp
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ClusterOperatorsMetricQueryPollRequest) StartContext(ctx context.Context) (response *ClusterOperatorsMetricQueryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ClusterOperatorsMetricQueryPollRequest) Start(ctx context.Context) (response *ClusterOperatorsMetricQueryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ClusterOperatorsMetricQueryPollResponse{
 			response: result.(*ClusterOperatorsMetricQueryGetResponse),
@@ -120,7 +120,7 @@ func (r *ClusterOperatorsMetricQueryPollRequest) StartContext(ctx context.Contex
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ClusterOperatorsMetricQueryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *ClusterOperatorsMetricQueryGetRequest) Impersonate(user string) *Cluste
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterOperatorsMetricQueryGetRequest) Send() (result *ClusterOperatorsMetricQueryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterOperatorsMetricQueryGetRequest) SendContext(ctx context.Context) (result *ClusterOperatorsMetricQueryGetResponse, err error) {
+func (r *ClusterOperatorsMetricQueryGetRequest) Send(ctx context.Context) (result *ClusterOperatorsMetricQueryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/cluster_resources_client.go
+++ b/clustersmgmt/v1/cluster_resources_client.go
@@ -102,13 +102,13 @@ func (r *ClusterResourcesPollRequest) Predicate(value func(*ClusterResourcesGetR
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ClusterResourcesPollRequest) StartContext(ctx context.Context) (response *ClusterResourcesPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ClusterResourcesPollRequest) Start(ctx context.Context) (response *ClusterResourcesPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ClusterResourcesPollResponse{
 			response: result.(*ClusterResourcesGetResponse),
@@ -120,7 +120,7 @@ func (r *ClusterResourcesPollRequest) StartContext(ctx context.Context) (respons
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ClusterResourcesPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *ClusterResourcesGetRequest) Impersonate(user string) *ClusterResourcesG
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterResourcesGetRequest) Send() (result *ClusterResourcesGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterResourcesGetRequest) SendContext(ctx context.Context) (result *ClusterResourcesGetResponse, err error) {
+func (r *ClusterResourcesGetRequest) Send(ctx context.Context) (result *ClusterResourcesGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/cluster_status_client.go
+++ b/clustersmgmt/v1/cluster_status_client.go
@@ -102,13 +102,13 @@ func (r *ClusterStatusPollRequest) Predicate(value func(*ClusterStatusGetRespons
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ClusterStatusPollRequest) StartContext(ctx context.Context) (response *ClusterStatusPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ClusterStatusPollRequest) Start(ctx context.Context) (response *ClusterStatusPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ClusterStatusPollResponse{
 			response: result.(*ClusterStatusGetResponse),
@@ -120,7 +120,7 @@ func (r *ClusterStatusPollRequest) StartContext(ctx context.Context) (response *
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ClusterStatusPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *ClusterStatusGetRequest) Impersonate(user string) *ClusterStatusGetRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterStatusGetRequest) Send() (result *ClusterStatusGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterStatusGetRequest) SendContext(ctx context.Context) (result *ClusterStatusGetResponse, err error) {
+func (r *ClusterStatusGetRequest) Send(ctx context.Context) (result *ClusterStatusGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/clusterdeployment_client.go
+++ b/clustersmgmt/v1/clusterdeployment_client.go
@@ -86,15 +86,7 @@ func (r *ClusterdeploymentDeleteRequest) Impersonate(user string) *Clusterdeploy
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterdeploymentDeleteRequest) Send() (result *ClusterdeploymentDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterdeploymentDeleteRequest) SendContext(ctx context.Context) (result *ClusterdeploymentDeleteResponse, err error) {
+func (r *ClusterdeploymentDeleteRequest) Send(ctx context.Context) (result *ClusterdeploymentDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/clusters_client.go
+++ b/clustersmgmt/v1/clusters_client.go
@@ -120,15 +120,7 @@ func (r *ClustersAddRequest) Body(value *Cluster) *ClustersAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClustersAddRequest) Send() (result *ClustersAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClustersAddRequest) SendContext(ctx context.Context) (result *ClustersAddResponse, err error) {
+func (r *ClustersAddRequest) Send(ctx context.Context) (result *ClustersAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -321,15 +313,7 @@ func (r *ClustersListRequest) Size(value int) *ClustersListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClustersListRequest) Send() (result *ClustersListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClustersListRequest) SendContext(ctx context.Context) (result *ClustersListResponse, err error) {
+func (r *ClustersListRequest) Send(ctx context.Context) (result *ClustersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_client.go
+++ b/clustersmgmt/v1/cpu_total_by_node_roles_os_metric_query_client.go
@@ -102,13 +102,13 @@ func (r *CPUTotalByNodeRolesOSMetricQueryPollRequest) Predicate(value func(*CPUT
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *CPUTotalByNodeRolesOSMetricQueryPollRequest) StartContext(ctx context.Context) (response *CPUTotalByNodeRolesOSMetricQueryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *CPUTotalByNodeRolesOSMetricQueryPollRequest) Start(ctx context.Context) (response *CPUTotalByNodeRolesOSMetricQueryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &CPUTotalByNodeRolesOSMetricQueryPollResponse{
 			response: result.(*CPUTotalByNodeRolesOSMetricQueryGetResponse),
@@ -120,7 +120,7 @@ func (r *CPUTotalByNodeRolesOSMetricQueryPollRequest) StartContext(ctx context.C
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *CPUTotalByNodeRolesOSMetricQueryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *CPUTotalByNodeRolesOSMetricQueryGetRequest) Impersonate(user string) *C
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CPUTotalByNodeRolesOSMetricQueryGetRequest) Send() (result *CPUTotalByNodeRolesOSMetricQueryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CPUTotalByNodeRolesOSMetricQueryGetRequest) SendContext(ctx context.Context) (result *CPUTotalByNodeRolesOSMetricQueryGetResponse, err error) {
+func (r *CPUTotalByNodeRolesOSMetricQueryGetRequest) Send(ctx context.Context) (result *CPUTotalByNodeRolesOSMetricQueryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/credentials_client.go
+++ b/clustersmgmt/v1/credentials_client.go
@@ -102,13 +102,13 @@ func (r *CredentialsPollRequest) Predicate(value func(*CredentialsGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *CredentialsPollRequest) StartContext(ctx context.Context) (response *CredentialsPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *CredentialsPollRequest) Start(ctx context.Context) (response *CredentialsPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &CredentialsPollResponse{
 			response: result.(*CredentialsGetResponse),
@@ -120,7 +120,7 @@ func (r *CredentialsPollRequest) StartContext(ctx context.Context) (response *Cr
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *CredentialsPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *CredentialsGetRequest) Impersonate(user string) *CredentialsGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *CredentialsGetRequest) Send() (result *CredentialsGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *CredentialsGetRequest) SendContext(ctx context.Context) (result *CredentialsGetResponse, err error) {
+func (r *CredentialsGetRequest) Send(ctx context.Context) (result *CredentialsGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/encryption_keys_inquiry_client.go
+++ b/clustersmgmt/v1/encryption_keys_inquiry_client.go
@@ -121,15 +121,7 @@ func (r *EncryptionKeysInquirySearchRequest) Size(value int) *EncryptionKeysInqu
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *EncryptionKeysInquirySearchRequest) Send() (result *EncryptionKeysInquirySearchResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *EncryptionKeysInquirySearchRequest) SendContext(ctx context.Context) (result *EncryptionKeysInquirySearchResponse, err error) {
+func (r *EncryptionKeysInquirySearchRequest) Send(ctx context.Context) (result *EncryptionKeysInquirySearchResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/environment_client.go
+++ b/clustersmgmt/v1/environment_client.go
@@ -119,13 +119,13 @@ func (r *EnvironmentPollRequest) Predicate(value func(*EnvironmentGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *EnvironmentPollRequest) StartContext(ctx context.Context) (response *EnvironmentPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *EnvironmentPollRequest) Start(ctx context.Context) (response *EnvironmentPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &EnvironmentPollResponse{
 			response: result.(*EnvironmentGetResponse),
@@ -137,7 +137,7 @@ func (r *EnvironmentPollRequest) StartContext(ctx context.Context) (response *En
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *EnvironmentPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -225,15 +225,7 @@ func (r *EnvironmentGetRequest) Impersonate(user string) *EnvironmentGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *EnvironmentGetRequest) Send() (result *EnvironmentGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *EnvironmentGetRequest) SendContext(ctx context.Context) (result *EnvironmentGetResponse, err error) {
+func (r *EnvironmentGetRequest) Send(ctx context.Context) (result *EnvironmentGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -368,15 +360,7 @@ func (r *EnvironmentUpdateRequest) Body(value *Environment) *EnvironmentUpdateRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *EnvironmentUpdateRequest) Send() (result *EnvironmentUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *EnvironmentUpdateRequest) SendContext(ctx context.Context) (result *EnvironmentUpdateResponse, err error) {
+func (r *EnvironmentUpdateRequest) Send(ctx context.Context) (result *EnvironmentUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/events_client.go
+++ b/clustersmgmt/v1/events_client.go
@@ -102,15 +102,7 @@ func (r *EventsAddRequest) Body(value *Event) *EventsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *EventsAddRequest) Send() (result *EventsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *EventsAddRequest) SendContext(ctx context.Context) (result *EventsAddResponse, err error) {
+func (r *EventsAddRequest) Send(ctx context.Context) (result *EventsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/external_configuration_client.go
+++ b/clustersmgmt/v1/external_configuration_client.go
@@ -123,13 +123,13 @@ func (r *ExternalConfigurationPollRequest) Predicate(value func(*ExternalConfigu
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ExternalConfigurationPollRequest) StartContext(ctx context.Context) (response *ExternalConfigurationPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ExternalConfigurationPollRequest) Start(ctx context.Context) (response *ExternalConfigurationPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ExternalConfigurationPollResponse{
 			response: result.(*ExternalConfigurationGetResponse),
@@ -141,7 +141,7 @@ func (r *ExternalConfigurationPollRequest) StartContext(ctx context.Context) (re
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ExternalConfigurationPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -229,15 +229,7 @@ func (r *ExternalConfigurationGetRequest) Impersonate(user string) *ExternalConf
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ExternalConfigurationGetRequest) Send() (result *ExternalConfigurationGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ExternalConfigurationGetRequest) SendContext(ctx context.Context) (result *ExternalConfigurationGetResponse, err error) {
+func (r *ExternalConfigurationGetRequest) Send(ctx context.Context) (result *ExternalConfigurationGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/flavour_client.go
+++ b/clustersmgmt/v1/flavour_client.go
@@ -120,13 +120,13 @@ func (r *FlavourPollRequest) Predicate(value func(*FlavourGetResponse) bool) *Fl
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *FlavourPollRequest) StartContext(ctx context.Context) (response *FlavourPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *FlavourPollRequest) Start(ctx context.Context) (response *FlavourPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &FlavourPollResponse{
 			response: result.(*FlavourGetResponse),
@@ -138,7 +138,7 @@ func (r *FlavourPollRequest) StartContext(ctx context.Context) (response *Flavou
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *FlavourPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -226,15 +226,7 @@ func (r *FlavourGetRequest) Impersonate(user string) *FlavourGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *FlavourGetRequest) Send() (result *FlavourGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *FlavourGetRequest) SendContext(ctx context.Context) (result *FlavourGetResponse, err error) {
+func (r *FlavourGetRequest) Send(ctx context.Context) (result *FlavourGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -369,15 +361,7 @@ func (r *FlavourUpdateRequest) Body(value *Flavour) *FlavourUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *FlavourUpdateRequest) Send() (result *FlavourUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *FlavourUpdateRequest) SendContext(ctx context.Context) (result *FlavourUpdateResponse, err error) {
+func (r *FlavourUpdateRequest) Send(ctx context.Context) (result *FlavourUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/flavours_client.go
+++ b/clustersmgmt/v1/flavours_client.go
@@ -118,15 +118,7 @@ func (r *FlavoursAddRequest) Body(value *Flavour) *FlavoursAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *FlavoursAddRequest) Send() (result *FlavoursAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *FlavoursAddRequest) SendContext(ctx context.Context) (result *FlavoursAddResponse, err error) {
+func (r *FlavoursAddRequest) Send(ctx context.Context) (result *FlavoursAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -318,15 +310,7 @@ func (r *FlavoursListRequest) Size(value int) *FlavoursListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *FlavoursListRequest) Send() (result *FlavoursListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *FlavoursListRequest) SendContext(ctx context.Context) (result *FlavoursListResponse, err error) {
+func (r *FlavoursListRequest) Send(ctx context.Context) (result *FlavoursListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/group_client.go
+++ b/clustersmgmt/v1/group_client.go
@@ -113,13 +113,13 @@ func (r *GroupPollRequest) Predicate(value func(*GroupGetResponse) bool) *GroupP
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *GroupPollRequest) StartContext(ctx context.Context) (response *GroupPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *GroupPollRequest) Start(ctx context.Context) (response *GroupPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &GroupPollResponse{
 			response: result.(*GroupGetResponse),
@@ -131,7 +131,7 @@ func (r *GroupPollRequest) StartContext(ctx context.Context) (response *GroupPol
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *GroupPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -219,15 +219,7 @@ func (r *GroupGetRequest) Impersonate(user string) *GroupGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *GroupGetRequest) Send() (result *GroupGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *GroupGetRequest) SendContext(ctx context.Context) (result *GroupGetResponse, err error) {
+func (r *GroupGetRequest) Send(ctx context.Context) (result *GroupGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/groups_client.go
+++ b/clustersmgmt/v1/groups_client.go
@@ -115,15 +115,7 @@ func (r *GroupsListRequest) Size(value int) *GroupsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *GroupsListRequest) Send() (result *GroupsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *GroupsListRequest) SendContext(ctx context.Context) (result *GroupsListResponse, err error) {
+func (r *GroupsListRequest) Send(ctx context.Context) (result *GroupsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/ht_passwd_user_client.go
+++ b/clustersmgmt/v1/ht_passwd_user_client.go
@@ -124,13 +124,13 @@ func (r *HTPasswdUserPollRequest) Predicate(value func(*HTPasswdUserGetResponse)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *HTPasswdUserPollRequest) StartContext(ctx context.Context) (response *HTPasswdUserPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *HTPasswdUserPollRequest) Start(ctx context.Context) (response *HTPasswdUserPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &HTPasswdUserPollResponse{
 			response: result.(*HTPasswdUserGetResponse),
@@ -142,7 +142,7 @@ func (r *HTPasswdUserPollRequest) StartContext(ctx context.Context) (response *H
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *HTPasswdUserPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *HTPasswdUserDeleteRequest) Impersonate(user string) *HTPasswdUserDelete
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *HTPasswdUserDeleteRequest) Send() (result *HTPasswdUserDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *HTPasswdUserDeleteRequest) SendContext(ctx context.Context) (result *HTPasswdUserDeleteResponse, err error) {
+func (r *HTPasswdUserDeleteRequest) Send(ctx context.Context) (result *HTPasswdUserDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *HTPasswdUserGetRequest) Impersonate(user string) *HTPasswdUserGetReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *HTPasswdUserGetRequest) Send() (result *HTPasswdUserGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *HTPasswdUserGetRequest) SendContext(ctx context.Context) (result *HTPasswdUserGetResponse, err error) {
+func (r *HTPasswdUserGetRequest) Send(ctx context.Context) (result *HTPasswdUserGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *HTPasswdUserUpdateRequest) Body(value *HTPasswdUser) *HTPasswdUserUpdat
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *HTPasswdUserUpdateRequest) Send() (result *HTPasswdUserUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *HTPasswdUserUpdateRequest) SendContext(ctx context.Context) (result *HTPasswdUserUpdateResponse, err error) {
+func (r *HTPasswdUserUpdateRequest) Send(ctx context.Context) (result *HTPasswdUserUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/ht_passwd_users_client.go
+++ b/clustersmgmt/v1/ht_passwd_users_client.go
@@ -118,15 +118,7 @@ func (r *HTPasswdUsersAddRequest) Body(value *HTPasswdUser) *HTPasswdUsersAddReq
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *HTPasswdUsersAddRequest) Send() (result *HTPasswdUsersAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *HTPasswdUsersAddRequest) SendContext(ctx context.Context) (result *HTPasswdUsersAddResponse, err error) {
+func (r *HTPasswdUsersAddRequest) Send(ctx context.Context) (result *HTPasswdUsersAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *HTPasswdUsersListRequest) Size(value int) *HTPasswdUsersListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *HTPasswdUsersListRequest) Send() (result *HTPasswdUsersListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *HTPasswdUsersListRequest) SendContext(ctx context.Context) (result *HTPasswdUsersListResponse, err error) {
+func (r *HTPasswdUsersListRequest) Send(ctx context.Context) (result *HTPasswdUsersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/identity_provider_client.go
+++ b/clustersmgmt/v1/identity_provider_client.go
@@ -135,13 +135,13 @@ func (r *IdentityProviderPollRequest) Predicate(value func(*IdentityProviderGetR
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *IdentityProviderPollRequest) StartContext(ctx context.Context) (response *IdentityProviderPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *IdentityProviderPollRequest) Start(ctx context.Context) (response *IdentityProviderPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &IdentityProviderPollResponse{
 			response: result.(*IdentityProviderGetResponse),
@@ -153,7 +153,7 @@ func (r *IdentityProviderPollRequest) StartContext(ctx context.Context) (respons
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *IdentityProviderPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -241,15 +241,7 @@ func (r *IdentityProviderDeleteRequest) Impersonate(user string) *IdentityProvid
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IdentityProviderDeleteRequest) Send() (result *IdentityProviderDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IdentityProviderDeleteRequest) SendContext(ctx context.Context) (result *IdentityProviderDeleteResponse, err error) {
+func (r *IdentityProviderDeleteRequest) Send(ctx context.Context) (result *IdentityProviderDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -348,15 +340,7 @@ func (r *IdentityProviderGetRequest) Impersonate(user string) *IdentityProviderG
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IdentityProviderGetRequest) Send() (result *IdentityProviderGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IdentityProviderGetRequest) SendContext(ctx context.Context) (result *IdentityProviderGetResponse, err error) {
+func (r *IdentityProviderGetRequest) Send(ctx context.Context) (result *IdentityProviderGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -491,15 +475,7 @@ func (r *IdentityProviderUpdateRequest) Body(value *IdentityProvider) *IdentityP
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IdentityProviderUpdateRequest) Send() (result *IdentityProviderUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IdentityProviderUpdateRequest) SendContext(ctx context.Context) (result *IdentityProviderUpdateResponse, err error) {
+func (r *IdentityProviderUpdateRequest) Send(ctx context.Context) (result *IdentityProviderUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/identity_providers_client.go
+++ b/clustersmgmt/v1/identity_providers_client.go
@@ -118,15 +118,7 @@ func (r *IdentityProvidersAddRequest) Body(value *IdentityProvider) *IdentityPro
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IdentityProvidersAddRequest) Send() (result *IdentityProvidersAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IdentityProvidersAddRequest) SendContext(ctx context.Context) (result *IdentityProvidersAddResponse, err error) {
+func (r *IdentityProvidersAddRequest) Send(ctx context.Context) (result *IdentityProvidersAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *IdentityProvidersListRequest) Size(value int) *IdentityProvidersListReq
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IdentityProvidersListRequest) Send() (result *IdentityProvidersListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IdentityProvidersListRequest) SendContext(ctx context.Context) (result *IdentityProvidersListResponse, err error) {
+func (r *IdentityProvidersListRequest) Send(ctx context.Context) (result *IdentityProvidersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/ingress_client.go
+++ b/clustersmgmt/v1/ingress_client.go
@@ -124,13 +124,13 @@ func (r *IngressPollRequest) Predicate(value func(*IngressGetResponse) bool) *In
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *IngressPollRequest) StartContext(ctx context.Context) (response *IngressPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *IngressPollRequest) Start(ctx context.Context) (response *IngressPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &IngressPollResponse{
 			response: result.(*IngressGetResponse),
@@ -142,7 +142,7 @@ func (r *IngressPollRequest) StartContext(ctx context.Context) (response *Ingres
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *IngressPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *IngressDeleteRequest) Impersonate(user string) *IngressDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IngressDeleteRequest) Send() (result *IngressDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IngressDeleteRequest) SendContext(ctx context.Context) (result *IngressDeleteResponse, err error) {
+func (r *IngressDeleteRequest) Send(ctx context.Context) (result *IngressDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *IngressGetRequest) Impersonate(user string) *IngressGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IngressGetRequest) Send() (result *IngressGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IngressGetRequest) SendContext(ctx context.Context) (result *IngressGetResponse, err error) {
+func (r *IngressGetRequest) Send(ctx context.Context) (result *IngressGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *IngressUpdateRequest) Body(value *Ingress) *IngressUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IngressUpdateRequest) Send() (result *IngressUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IngressUpdateRequest) SendContext(ctx context.Context) (result *IngressUpdateResponse, err error) {
+func (r *IngressUpdateRequest) Send(ctx context.Context) (result *IngressUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/ingresses_client.go
+++ b/clustersmgmt/v1/ingresses_client.go
@@ -128,15 +128,7 @@ func (r *IngressesAddRequest) Body(value *Ingress) *IngressesAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IngressesAddRequest) Send() (result *IngressesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IngressesAddRequest) SendContext(ctx context.Context) (result *IngressesAddResponse, err error) {
+func (r *IngressesAddRequest) Send(ctx context.Context) (result *IngressesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -286,15 +278,7 @@ func (r *IngressesListRequest) Size(value int) *IngressesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IngressesListRequest) Send() (result *IngressesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IngressesListRequest) SendContext(ctx context.Context) (result *IngressesListResponse, err error) {
+func (r *IngressesListRequest) Send(ctx context.Context) (result *IngressesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)
@@ -504,15 +488,7 @@ func (r *IngressesUpdateRequest) Body(value []*Ingress) *IngressesUpdateRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *IngressesUpdateRequest) Send() (result *IngressesUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *IngressesUpdateRequest) SendContext(ctx context.Context) (result *IngressesUpdateResponse, err error) {
+func (r *IngressesUpdateRequest) Send(ctx context.Context) (result *IngressesUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/key_rings_inquiry_client.go
+++ b/clustersmgmt/v1/key_rings_inquiry_client.go
@@ -121,15 +121,7 @@ func (r *KeyRingsInquirySearchRequest) Size(value int) *KeyRingsInquirySearchReq
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *KeyRingsInquirySearchRequest) Send() (result *KeyRingsInquirySearchResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *KeyRingsInquirySearchRequest) SendContext(ctx context.Context) (result *KeyRingsInquirySearchResponse, err error) {
+func (r *KeyRingsInquirySearchRequest) Send(ctx context.Context) (result *KeyRingsInquirySearchResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/label_client.go
+++ b/clustersmgmt/v1/label_client.go
@@ -124,13 +124,13 @@ func (r *LabelPollRequest) Predicate(value func(*LabelGetResponse) bool) *LabelP
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *LabelPollRequest) StartContext(ctx context.Context) (response *LabelPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *LabelPollRequest) Start(ctx context.Context) (response *LabelPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &LabelPollResponse{
 			response: result.(*LabelGetResponse),
@@ -142,7 +142,7 @@ func (r *LabelPollRequest) StartContext(ctx context.Context) (response *LabelPol
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *LabelPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *LabelDeleteRequest) Impersonate(user string) *LabelDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LabelDeleteRequest) Send() (result *LabelDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LabelDeleteRequest) SendContext(ctx context.Context) (result *LabelDeleteResponse, err error) {
+func (r *LabelDeleteRequest) Send(ctx context.Context) (result *LabelDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *LabelGetRequest) Impersonate(user string) *LabelGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LabelGetRequest) Send() (result *LabelGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LabelGetRequest) SendContext(ctx context.Context) (result *LabelGetResponse, err error) {
+func (r *LabelGetRequest) Send(ctx context.Context) (result *LabelGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *LabelUpdateRequest) Body(value *Label) *LabelUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LabelUpdateRequest) Send() (result *LabelUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LabelUpdateRequest) SendContext(ctx context.Context) (result *LabelUpdateResponse, err error) {
+func (r *LabelUpdateRequest) Send(ctx context.Context) (result *LabelUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/labels_client.go
+++ b/clustersmgmt/v1/labels_client.go
@@ -118,15 +118,7 @@ func (r *LabelsAddRequest) Body(value *Label) *LabelsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LabelsAddRequest) Send() (result *LabelsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LabelsAddRequest) SendContext(ctx context.Context) (result *LabelsAddResponse, err error) {
+func (r *LabelsAddRequest) Send(ctx context.Context) (result *LabelsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *LabelsListRequest) Size(value int) *LabelsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LabelsListRequest) Send() (result *LabelsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LabelsListRequest) SendContext(ctx context.Context) (result *LabelsListResponse, err error) {
+func (r *LabelsListRequest) Send(ctx context.Context) (result *LabelsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/limited_support_reason_client.go
+++ b/clustersmgmt/v1/limited_support_reason_client.go
@@ -112,13 +112,13 @@ func (r *LimitedSupportReasonPollRequest) Predicate(value func(*LimitedSupportRe
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *LimitedSupportReasonPollRequest) StartContext(ctx context.Context) (response *LimitedSupportReasonPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *LimitedSupportReasonPollRequest) Start(ctx context.Context) (response *LimitedSupportReasonPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &LimitedSupportReasonPollResponse{
 			response: result.(*LimitedSupportReasonGetResponse),
@@ -130,7 +130,7 @@ func (r *LimitedSupportReasonPollRequest) StartContext(ctx context.Context) (res
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *LimitedSupportReasonPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *LimitedSupportReasonDeleteRequest) Impersonate(user string) *LimitedSup
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LimitedSupportReasonDeleteRequest) Send() (result *LimitedSupportReasonDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LimitedSupportReasonDeleteRequest) SendContext(ctx context.Context) (result *LimitedSupportReasonDeleteResponse, err error) {
+func (r *LimitedSupportReasonDeleteRequest) Send(ctx context.Context) (result *LimitedSupportReasonDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *LimitedSupportReasonGetRequest) Impersonate(user string) *LimitedSuppor
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LimitedSupportReasonGetRequest) Send() (result *LimitedSupportReasonGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LimitedSupportReasonGetRequest) SendContext(ctx context.Context) (result *LimitedSupportReasonGetResponse, err error) {
+func (r *LimitedSupportReasonGetRequest) Send(ctx context.Context) (result *LimitedSupportReasonGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/limited_support_reason_template_client.go
+++ b/clustersmgmt/v1/limited_support_reason_template_client.go
@@ -102,13 +102,13 @@ func (r *LimitedSupportReasonTemplatePollRequest) Predicate(value func(*LimitedS
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *LimitedSupportReasonTemplatePollRequest) StartContext(ctx context.Context) (response *LimitedSupportReasonTemplatePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *LimitedSupportReasonTemplatePollRequest) Start(ctx context.Context) (response *LimitedSupportReasonTemplatePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &LimitedSupportReasonTemplatePollResponse{
 			response: result.(*LimitedSupportReasonTemplateGetResponse),
@@ -120,7 +120,7 @@ func (r *LimitedSupportReasonTemplatePollRequest) StartContext(ctx context.Conte
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *LimitedSupportReasonTemplatePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *LimitedSupportReasonTemplateGetRequest) Impersonate(user string) *Limit
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LimitedSupportReasonTemplateGetRequest) Send() (result *LimitedSupportReasonTemplateGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LimitedSupportReasonTemplateGetRequest) SendContext(ctx context.Context) (result *LimitedSupportReasonTemplateGetResponse, err error) {
+func (r *LimitedSupportReasonTemplateGetRequest) Send(ctx context.Context) (result *LimitedSupportReasonTemplateGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/limited_support_reason_templates_client.go
+++ b/clustersmgmt/v1/limited_support_reason_templates_client.go
@@ -115,15 +115,7 @@ func (r *LimitedSupportReasonTemplatesListRequest) Size(value int) *LimitedSuppo
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LimitedSupportReasonTemplatesListRequest) Send() (result *LimitedSupportReasonTemplatesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LimitedSupportReasonTemplatesListRequest) SendContext(ctx context.Context) (result *LimitedSupportReasonTemplatesListResponse, err error) {
+func (r *LimitedSupportReasonTemplatesListRequest) Send(ctx context.Context) (result *LimitedSupportReasonTemplatesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/limited_support_reasons_client.go
+++ b/clustersmgmt/v1/limited_support_reasons_client.go
@@ -118,15 +118,7 @@ func (r *LimitedSupportReasonsAddRequest) Body(value *LimitedSupportReason) *Lim
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LimitedSupportReasonsAddRequest) Send() (result *LimitedSupportReasonsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LimitedSupportReasonsAddRequest) SendContext(ctx context.Context) (result *LimitedSupportReasonsAddResponse, err error) {
+func (r *LimitedSupportReasonsAddRequest) Send(ctx context.Context) (result *LimitedSupportReasonsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *LimitedSupportReasonsListRequest) Size(value int) *LimitedSupportReason
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LimitedSupportReasonsListRequest) Send() (result *LimitedSupportReasonsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LimitedSupportReasonsListRequest) SendContext(ctx context.Context) (result *LimitedSupportReasonsListResponse, err error) {
+func (r *LimitedSupportReasonsListRequest) Send(ctx context.Context) (result *LimitedSupportReasonsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/log_client.go
+++ b/clustersmgmt/v1/log_client.go
@@ -124,13 +124,13 @@ func (r *LogPollRequest) Predicate(value func(*LogGetResponse) bool) *LogPollReq
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *LogPollRequest) StartContext(ctx context.Context) (response *LogPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *LogPollRequest) Start(ctx context.Context) (response *LogPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &LogPollResponse{
 			response: result.(*LogGetResponse),
@@ -142,7 +142,7 @@ func (r *LogPollRequest) StartContext(ctx context.Context) (response *LogPollRes
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *LogPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -252,15 +252,7 @@ func (r *LogGetRequest) Tail(value int) *LogGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LogGetRequest) Send() (result *LogGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LogGetRequest) SendContext(ctx context.Context) (result *LogGetResponse, err error) {
+func (r *LogGetRequest) Send(ctx context.Context) (result *LogGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.offset != nil {
 		helpers.AddValue(&query, "offset", *r.offset)

--- a/clustersmgmt/v1/logs_client.go
+++ b/clustersmgmt/v1/logs_client.go
@@ -125,15 +125,7 @@ func (r *LogsListRequest) Size(value int) *LogsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LogsListRequest) Send() (result *LogsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LogsListRequest) SendContext(ctx context.Context) (result *LogsListResponse, err error) {
+func (r *LogsListRequest) Send(ctx context.Context) (result *LogsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/machine_pool_client.go
+++ b/clustersmgmt/v1/machine_pool_client.go
@@ -124,13 +124,13 @@ func (r *MachinePoolPollRequest) Predicate(value func(*MachinePoolGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *MachinePoolPollRequest) StartContext(ctx context.Context) (response *MachinePoolPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *MachinePoolPollRequest) Start(ctx context.Context) (response *MachinePoolPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &MachinePoolPollResponse{
 			response: result.(*MachinePoolGetResponse),
@@ -142,7 +142,7 @@ func (r *MachinePoolPollRequest) StartContext(ctx context.Context) (response *Ma
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *MachinePoolPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *MachinePoolDeleteRequest) Impersonate(user string) *MachinePoolDeleteRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MachinePoolDeleteRequest) Send() (result *MachinePoolDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *MachinePoolDeleteRequest) SendContext(ctx context.Context) (result *MachinePoolDeleteResponse, err error) {
+func (r *MachinePoolDeleteRequest) Send(ctx context.Context) (result *MachinePoolDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *MachinePoolGetRequest) Impersonate(user string) *MachinePoolGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MachinePoolGetRequest) Send() (result *MachinePoolGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *MachinePoolGetRequest) SendContext(ctx context.Context) (result *MachinePoolGetResponse, err error) {
+func (r *MachinePoolGetRequest) Send(ctx context.Context) (result *MachinePoolGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *MachinePoolUpdateRequest) Body(value *MachinePool) *MachinePoolUpdateRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MachinePoolUpdateRequest) Send() (result *MachinePoolUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *MachinePoolUpdateRequest) SendContext(ctx context.Context) (result *MachinePoolUpdateResponse, err error) {
+func (r *MachinePoolUpdateRequest) Send(ctx context.Context) (result *MachinePoolUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/machine_pools_client.go
+++ b/clustersmgmt/v1/machine_pools_client.go
@@ -118,15 +118,7 @@ func (r *MachinePoolsAddRequest) Body(value *MachinePool) *MachinePoolsAddReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MachinePoolsAddRequest) Send() (result *MachinePoolsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *MachinePoolsAddRequest) SendContext(ctx context.Context) (result *MachinePoolsAddResponse, err error) {
+func (r *MachinePoolsAddRequest) Send(ctx context.Context) (result *MachinePoolsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *MachinePoolsListRequest) Size(value int) *MachinePoolsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MachinePoolsListRequest) Send() (result *MachinePoolsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *MachinePoolsListRequest) SendContext(ctx context.Context) (result *MachinePoolsListResponse, err error) {
+func (r *MachinePoolsListRequest) Send(ctx context.Context) (result *MachinePoolsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/machine_type_client.go
+++ b/clustersmgmt/v1/machine_type_client.go
@@ -102,13 +102,13 @@ func (r *MachineTypePollRequest) Predicate(value func(*MachineTypeGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *MachineTypePollRequest) StartContext(ctx context.Context) (response *MachineTypePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *MachineTypePollRequest) Start(ctx context.Context) (response *MachineTypePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &MachineTypePollResponse{
 			response: result.(*MachineTypeGetResponse),
@@ -120,7 +120,7 @@ func (r *MachineTypePollRequest) StartContext(ctx context.Context) (response *Ma
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *MachineTypePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *MachineTypeGetRequest) Impersonate(user string) *MachineTypeGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MachineTypeGetRequest) Send() (result *MachineTypeGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *MachineTypeGetRequest) SendContext(ctx context.Context) (result *MachineTypeGetResponse, err error) {
+func (r *MachineTypeGetRequest) Send(ctx context.Context) (result *MachineTypeGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/machine_types_client.go
+++ b/clustersmgmt/v1/machine_types_client.go
@@ -146,15 +146,7 @@ func (r *MachineTypesListRequest) Size(value int) *MachineTypesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MachineTypesListRequest) Send() (result *MachineTypesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *MachineTypesListRequest) SendContext(ctx context.Context) (result *MachineTypesListResponse, err error) {
+func (r *MachineTypesListRequest) Send(ctx context.Context) (result *MachineTypesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/metadata_client.go
+++ b/clustersmgmt/v1/metadata_client.go
@@ -59,15 +59,7 @@ func (r *MetadataRequest) Header(name string, value interface{}) *MetadataReques
 }
 
 // Send sends the metadata request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends the metadata request, waits for the response, and returns it.
-func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/nodes_metric_query_client.go
+++ b/clustersmgmt/v1/nodes_metric_query_client.go
@@ -102,13 +102,13 @@ func (r *NodesMetricQueryPollRequest) Predicate(value func(*NodesMetricQueryGetR
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *NodesMetricQueryPollRequest) StartContext(ctx context.Context) (response *NodesMetricQueryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *NodesMetricQueryPollRequest) Start(ctx context.Context) (response *NodesMetricQueryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &NodesMetricQueryPollResponse{
 			response: result.(*NodesMetricQueryGetResponse),
@@ -120,7 +120,7 @@ func (r *NodesMetricQueryPollRequest) StartContext(ctx context.Context) (respons
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *NodesMetricQueryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *NodesMetricQueryGetRequest) Impersonate(user string) *NodesMetricQueryG
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *NodesMetricQueryGetRequest) Send() (result *NodesMetricQueryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *NodesMetricQueryGetRequest) SendContext(ctx context.Context) (result *NodesMetricQueryGetResponse, err error) {
+func (r *NodesMetricQueryGetRequest) Send(ctx context.Context) (result *NodesMetricQueryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/operator_iam_role_client.go
+++ b/clustersmgmt/v1/operator_iam_role_client.go
@@ -86,15 +86,7 @@ func (r *OperatorIAMRoleDeleteRequest) Impersonate(user string) *OperatorIAMRole
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *OperatorIAMRoleDeleteRequest) Send() (result *OperatorIAMRoleDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *OperatorIAMRoleDeleteRequest) SendContext(ctx context.Context) (result *OperatorIAMRoleDeleteResponse, err error) {
+func (r *OperatorIAMRoleDeleteRequest) Send(ctx context.Context) (result *OperatorIAMRoleDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/operator_iam_roles_client.go
+++ b/clustersmgmt/v1/operator_iam_roles_client.go
@@ -118,15 +118,7 @@ func (r *OperatorIAMRolesAddRequest) Body(value *OperatorIAMRole) *OperatorIAMRo
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *OperatorIAMRolesAddRequest) Send() (result *OperatorIAMRolesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *OperatorIAMRolesAddRequest) SendContext(ctx context.Context) (result *OperatorIAMRolesAddResponse, err error) {
+func (r *OperatorIAMRolesAddRequest) Send(ctx context.Context) (result *OperatorIAMRolesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *OperatorIAMRolesListRequest) Size(value int) *OperatorIAMRolesListReque
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *OperatorIAMRolesListRequest) Send() (result *OperatorIAMRolesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *OperatorIAMRolesListRequest) SendContext(ctx context.Context) (result *OperatorIAMRolesListResponse, err error) {
+func (r *OperatorIAMRolesListRequest) Send(ctx context.Context) (result *OperatorIAMRolesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/product_client.go
+++ b/clustersmgmt/v1/product_client.go
@@ -102,13 +102,13 @@ func (r *ProductPollRequest) Predicate(value func(*ProductGetResponse) bool) *Pr
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ProductPollRequest) StartContext(ctx context.Context) (response *ProductPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ProductPollRequest) Start(ctx context.Context) (response *ProductPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ProductPollResponse{
 			response: result.(*ProductGetResponse),
@@ -120,7 +120,7 @@ func (r *ProductPollRequest) StartContext(ctx context.Context) (response *Produc
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ProductPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *ProductGetRequest) Impersonate(user string) *ProductGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProductGetRequest) Send() (result *ProductGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProductGetRequest) SendContext(ctx context.Context) (result *ProductGetResponse, err error) {
+func (r *ProductGetRequest) Send(ctx context.Context) (result *ProductGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/products_client.go
+++ b/clustersmgmt/v1/products_client.go
@@ -157,15 +157,7 @@ func (r *ProductsListRequest) Size(value int) *ProductsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProductsListRequest) Send() (result *ProductsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProductsListRequest) SendContext(ctx context.Context) (result *ProductsListResponse, err error) {
+func (r *ProductsListRequest) Send(ctx context.Context) (result *ProductsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/provision_shard_client.go
+++ b/clustersmgmt/v1/provision_shard_client.go
@@ -102,13 +102,13 @@ func (r *ProvisionShardPollRequest) Predicate(value func(*ProvisionShardGetRespo
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ProvisionShardPollRequest) StartContext(ctx context.Context) (response *ProvisionShardPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ProvisionShardPollRequest) Start(ctx context.Context) (response *ProvisionShardPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ProvisionShardPollResponse{
 			response: result.(*ProvisionShardGetResponse),
@@ -120,7 +120,7 @@ func (r *ProvisionShardPollRequest) StartContext(ctx context.Context) (response 
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ProvisionShardPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *ProvisionShardGetRequest) Impersonate(user string) *ProvisionShardGetRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProvisionShardGetRequest) Send() (result *ProvisionShardGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProvisionShardGetRequest) SendContext(ctx context.Context) (result *ProvisionShardGetResponse, err error) {
+func (r *ProvisionShardGetRequest) Send(ctx context.Context) (result *ProvisionShardGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/provision_shards_client.go
+++ b/clustersmgmt/v1/provision_shards_client.go
@@ -115,15 +115,7 @@ func (r *ProvisionShardsListRequest) Size(value int) *ProvisionShardsListRequest
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProvisionShardsListRequest) Send() (result *ProvisionShardsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProvisionShardsListRequest) SendContext(ctx context.Context) (result *ProvisionShardsListResponse, err error) {
+func (r *ProvisionShardsListRequest) Send(ctx context.Context) (result *ProvisionShardsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/resources_client.go
+++ b/clustersmgmt/v1/resources_client.go
@@ -113,13 +113,13 @@ func (r *ResourcesPollRequest) Predicate(value func(*ResourcesGetResponse) bool)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ResourcesPollRequest) StartContext(ctx context.Context) (response *ResourcesPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ResourcesPollRequest) Start(ctx context.Context) (response *ResourcesPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ResourcesPollResponse{
 			response: result.(*ResourcesGetResponse),
@@ -131,7 +131,7 @@ func (r *ResourcesPollRequest) StartContext(ctx context.Context) (response *Reso
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ResourcesPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -219,15 +219,7 @@ func (r *ResourcesGetRequest) Impersonate(user string) *ResourcesGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ResourcesGetRequest) Send() (result *ResourcesGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ResourcesGetRequest) SendContext(ctx context.Context) (result *ResourcesGetResponse, err error) {
+func (r *ResourcesGetRequest) Send(ctx context.Context) (result *ResourcesGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_client.go
+++ b/clustersmgmt/v1/socket_total_by_node_roles_os_metric_query_client.go
@@ -102,13 +102,13 @@ func (r *SocketTotalByNodeRolesOSMetricQueryPollRequest) Predicate(value func(*S
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *SocketTotalByNodeRolesOSMetricQueryPollRequest) StartContext(ctx context.Context) (response *SocketTotalByNodeRolesOSMetricQueryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *SocketTotalByNodeRolesOSMetricQueryPollRequest) Start(ctx context.Context) (response *SocketTotalByNodeRolesOSMetricQueryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &SocketTotalByNodeRolesOSMetricQueryPollResponse{
 			response: result.(*SocketTotalByNodeRolesOSMetricQueryGetResponse),
@@ -120,7 +120,7 @@ func (r *SocketTotalByNodeRolesOSMetricQueryPollRequest) StartContext(ctx contex
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *SocketTotalByNodeRolesOSMetricQueryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *SocketTotalByNodeRolesOSMetricQueryGetRequest) Impersonate(user string)
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SocketTotalByNodeRolesOSMetricQueryGetRequest) Send() (result *SocketTotalByNodeRolesOSMetricQueryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SocketTotalByNodeRolesOSMetricQueryGetRequest) SendContext(ctx context.Context) (result *SocketTotalByNodeRolesOSMetricQueryGetResponse, err error) {
+func (r *SocketTotalByNodeRolesOSMetricQueryGetRequest) Send(ctx context.Context) (result *SocketTotalByNodeRolesOSMetricQueryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/syncset_client.go
+++ b/clustersmgmt/v1/syncset_client.go
@@ -124,13 +124,13 @@ func (r *SyncsetPollRequest) Predicate(value func(*SyncsetGetResponse) bool) *Sy
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *SyncsetPollRequest) StartContext(ctx context.Context) (response *SyncsetPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *SyncsetPollRequest) Start(ctx context.Context) (response *SyncsetPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &SyncsetPollResponse{
 			response: result.(*SyncsetGetResponse),
@@ -142,7 +142,7 @@ func (r *SyncsetPollRequest) StartContext(ctx context.Context) (response *Syncse
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *SyncsetPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *SyncsetDeleteRequest) Impersonate(user string) *SyncsetDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SyncsetDeleteRequest) Send() (result *SyncsetDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SyncsetDeleteRequest) SendContext(ctx context.Context) (result *SyncsetDeleteResponse, err error) {
+func (r *SyncsetDeleteRequest) Send(ctx context.Context) (result *SyncsetDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *SyncsetGetRequest) Impersonate(user string) *SyncsetGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SyncsetGetRequest) Send() (result *SyncsetGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SyncsetGetRequest) SendContext(ctx context.Context) (result *SyncsetGetResponse, err error) {
+func (r *SyncsetGetRequest) Send(ctx context.Context) (result *SyncsetGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *SyncsetUpdateRequest) Body(value *Syncset) *SyncsetUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SyncsetUpdateRequest) Send() (result *SyncsetUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SyncsetUpdateRequest) SendContext(ctx context.Context) (result *SyncsetUpdateResponse, err error) {
+func (r *SyncsetUpdateRequest) Send(ctx context.Context) (result *SyncsetUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/syncsets_client.go
+++ b/clustersmgmt/v1/syncsets_client.go
@@ -118,15 +118,7 @@ func (r *SyncsetsAddRequest) Body(value *Syncset) *SyncsetsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SyncsetsAddRequest) Send() (result *SyncsetsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SyncsetsAddRequest) SendContext(ctx context.Context) (result *SyncsetsAddResponse, err error) {
+func (r *SyncsetsAddRequest) Send(ctx context.Context) (result *SyncsetsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *SyncsetsListRequest) Size(value int) *SyncsetsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *SyncsetsListRequest) Send() (result *SyncsetsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *SyncsetsListRequest) SendContext(ctx context.Context) (result *SyncsetsListResponse, err error) {
+func (r *SyncsetsListRequest) Send(ctx context.Context) (result *SyncsetsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/upgrade_policies_client.go
+++ b/clustersmgmt/v1/upgrade_policies_client.go
@@ -118,15 +118,7 @@ func (r *UpgradePoliciesAddRequest) Body(value *UpgradePolicy) *UpgradePoliciesA
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UpgradePoliciesAddRequest) Send() (result *UpgradePoliciesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UpgradePoliciesAddRequest) SendContext(ctx context.Context) (result *UpgradePoliciesAddResponse, err error) {
+func (r *UpgradePoliciesAddRequest) Send(ctx context.Context) (result *UpgradePoliciesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *UpgradePoliciesListRequest) Size(value int) *UpgradePoliciesListRequest
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UpgradePoliciesListRequest) Send() (result *UpgradePoliciesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UpgradePoliciesListRequest) SendContext(ctx context.Context) (result *UpgradePoliciesListResponse, err error) {
+func (r *UpgradePoliciesListRequest) Send(ctx context.Context) (result *UpgradePoliciesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/upgrade_policy_client.go
+++ b/clustersmgmt/v1/upgrade_policy_client.go
@@ -135,13 +135,13 @@ func (r *UpgradePolicyPollRequest) Predicate(value func(*UpgradePolicyGetRespons
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *UpgradePolicyPollRequest) StartContext(ctx context.Context) (response *UpgradePolicyPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *UpgradePolicyPollRequest) Start(ctx context.Context) (response *UpgradePolicyPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &UpgradePolicyPollResponse{
 			response: result.(*UpgradePolicyGetResponse),
@@ -153,7 +153,7 @@ func (r *UpgradePolicyPollRequest) StartContext(ctx context.Context) (response *
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *UpgradePolicyPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -241,15 +241,7 @@ func (r *UpgradePolicyDeleteRequest) Impersonate(user string) *UpgradePolicyDele
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UpgradePolicyDeleteRequest) Send() (result *UpgradePolicyDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UpgradePolicyDeleteRequest) SendContext(ctx context.Context) (result *UpgradePolicyDeleteResponse, err error) {
+func (r *UpgradePolicyDeleteRequest) Send(ctx context.Context) (result *UpgradePolicyDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -348,15 +340,7 @@ func (r *UpgradePolicyGetRequest) Impersonate(user string) *UpgradePolicyGetRequ
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UpgradePolicyGetRequest) Send() (result *UpgradePolicyGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UpgradePolicyGetRequest) SendContext(ctx context.Context) (result *UpgradePolicyGetResponse, err error) {
+func (r *UpgradePolicyGetRequest) Send(ctx context.Context) (result *UpgradePolicyGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -491,15 +475,7 @@ func (r *UpgradePolicyUpdateRequest) Body(value *UpgradePolicy) *UpgradePolicyUp
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UpgradePolicyUpdateRequest) Send() (result *UpgradePolicyUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UpgradePolicyUpdateRequest) SendContext(ctx context.Context) (result *UpgradePolicyUpdateResponse, err error) {
+func (r *UpgradePolicyUpdateRequest) Send(ctx context.Context) (result *UpgradePolicyUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/upgrade_policy_state_client.go
+++ b/clustersmgmt/v1/upgrade_policy_state_client.go
@@ -114,13 +114,13 @@ func (r *UpgradePolicyStatePollRequest) Predicate(value func(*UpgradePolicyState
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *UpgradePolicyStatePollRequest) StartContext(ctx context.Context) (response *UpgradePolicyStatePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *UpgradePolicyStatePollRequest) Start(ctx context.Context) (response *UpgradePolicyStatePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &UpgradePolicyStatePollResponse{
 			response: result.(*UpgradePolicyStateGetResponse),
@@ -132,7 +132,7 @@ func (r *UpgradePolicyStatePollRequest) StartContext(ctx context.Context) (respo
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *UpgradePolicyStatePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -220,15 +220,7 @@ func (r *UpgradePolicyStateGetRequest) Impersonate(user string) *UpgradePolicySt
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UpgradePolicyStateGetRequest) Send() (result *UpgradePolicyStateGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UpgradePolicyStateGetRequest) SendContext(ctx context.Context) (result *UpgradePolicyStateGetResponse, err error) {
+func (r *UpgradePolicyStateGetRequest) Send(ctx context.Context) (result *UpgradePolicyStateGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -363,15 +355,7 @@ func (r *UpgradePolicyStateUpdateRequest) Body(value *UpgradePolicyState) *Upgra
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UpgradePolicyStateUpdateRequest) Send() (result *UpgradePolicyStateUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UpgradePolicyStateUpdateRequest) SendContext(ctx context.Context) (result *UpgradePolicyStateUpdateResponse, err error) {
+func (r *UpgradePolicyStateUpdateRequest) Send(ctx context.Context) (result *UpgradePolicyStateUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/clustersmgmt/v1/user_client.go
+++ b/clustersmgmt/v1/user_client.go
@@ -112,13 +112,13 @@ func (r *UserPollRequest) Predicate(value func(*UserGetResponse) bool) *UserPoll
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *UserPollRequest) StartContext(ctx context.Context) (response *UserPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *UserPollRequest) Start(ctx context.Context) (response *UserPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &UserPollResponse{
 			response: result.(*UserGetResponse),
@@ -130,7 +130,7 @@ func (r *UserPollRequest) StartContext(ctx context.Context) (response *UserPollR
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *UserPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *UserDeleteRequest) Impersonate(user string) *UserDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UserDeleteRequest) Send() (result *UserDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UserDeleteRequest) SendContext(ctx context.Context) (result *UserDeleteResponse, err error) {
+func (r *UserDeleteRequest) Send(ctx context.Context) (result *UserDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *UserGetRequest) Impersonate(user string) *UserGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UserGetRequest) Send() (result *UserGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UserGetRequest) SendContext(ctx context.Context) (result *UserGetResponse, err error) {
+func (r *UserGetRequest) Send(ctx context.Context) (result *UserGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/users_client.go
+++ b/clustersmgmt/v1/users_client.go
@@ -118,15 +118,7 @@ func (r *UsersAddRequest) Body(value *User) *UsersAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UsersAddRequest) Send() (result *UsersAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UsersAddRequest) SendContext(ctx context.Context) (result *UsersAddResponse, err error) {
+func (r *UsersAddRequest) Send(ctx context.Context) (result *UsersAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *UsersListRequest) Size(value int) *UsersListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *UsersListRequest) Send() (result *UsersListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *UsersListRequest) SendContext(ctx context.Context) (result *UsersListResponse, err error) {
+func (r *UsersListRequest) Send(ctx context.Context) (result *UsersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/version_client.go
+++ b/clustersmgmt/v1/version_client.go
@@ -102,13 +102,13 @@ func (r *VersionPollRequest) Predicate(value func(*VersionGetResponse) bool) *Ve
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *VersionPollRequest) StartContext(ctx context.Context) (response *VersionPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *VersionPollRequest) Start(ctx context.Context) (response *VersionPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &VersionPollResponse{
 			response: result.(*VersionGetResponse),
@@ -120,7 +120,7 @@ func (r *VersionPollRequest) StartContext(ctx context.Context) (response *Versio
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *VersionPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -208,15 +208,7 @@ func (r *VersionGetRequest) Impersonate(user string) *VersionGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGetRequest) Send() (result *VersionGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGetRequest) SendContext(ctx context.Context) (result *VersionGetResponse, err error) {
+func (r *VersionGetRequest) Send(ctx context.Context) (result *VersionGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/version_gate_agreement_client.go
+++ b/clustersmgmt/v1/version_gate_agreement_client.go
@@ -112,13 +112,13 @@ func (r *VersionGateAgreementPollRequest) Predicate(value func(*VersionGateAgree
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *VersionGateAgreementPollRequest) StartContext(ctx context.Context) (response *VersionGateAgreementPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *VersionGateAgreementPollRequest) Start(ctx context.Context) (response *VersionGateAgreementPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &VersionGateAgreementPollResponse{
 			response: result.(*VersionGateAgreementGetResponse),
@@ -130,7 +130,7 @@ func (r *VersionGateAgreementPollRequest) StartContext(ctx context.Context) (res
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *VersionGateAgreementPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *VersionGateAgreementDeleteRequest) Impersonate(user string) *VersionGat
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGateAgreementDeleteRequest) Send() (result *VersionGateAgreementDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGateAgreementDeleteRequest) SendContext(ctx context.Context) (result *VersionGateAgreementDeleteResponse, err error) {
+func (r *VersionGateAgreementDeleteRequest) Send(ctx context.Context) (result *VersionGateAgreementDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *VersionGateAgreementGetRequest) Impersonate(user string) *VersionGateAg
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGateAgreementGetRequest) Send() (result *VersionGateAgreementGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGateAgreementGetRequest) SendContext(ctx context.Context) (result *VersionGateAgreementGetResponse, err error) {
+func (r *VersionGateAgreementGetRequest) Send(ctx context.Context) (result *VersionGateAgreementGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/version_gate_agreements_client.go
+++ b/clustersmgmt/v1/version_gate_agreements_client.go
@@ -118,15 +118,7 @@ func (r *VersionGateAgreementsAddRequest) Body(value *VersionGateAgreement) *Ver
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGateAgreementsAddRequest) Send() (result *VersionGateAgreementsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGateAgreementsAddRequest) SendContext(ctx context.Context) (result *VersionGateAgreementsAddResponse, err error) {
+func (r *VersionGateAgreementsAddRequest) Send(ctx context.Context) (result *VersionGateAgreementsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *VersionGateAgreementsListRequest) Size(value int) *VersionGateAgreement
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGateAgreementsListRequest) Send() (result *VersionGateAgreementsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGateAgreementsListRequest) SendContext(ctx context.Context) (result *VersionGateAgreementsListResponse, err error) {
+func (r *VersionGateAgreementsListRequest) Send(ctx context.Context) (result *VersionGateAgreementsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/clustersmgmt/v1/version_gate_client.go
+++ b/clustersmgmt/v1/version_gate_client.go
@@ -112,13 +112,13 @@ func (r *VersionGatePollRequest) Predicate(value func(*VersionGateGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *VersionGatePollRequest) StartContext(ctx context.Context) (response *VersionGatePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *VersionGatePollRequest) Start(ctx context.Context) (response *VersionGatePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &VersionGatePollResponse{
 			response: result.(*VersionGateGetResponse),
@@ -130,7 +130,7 @@ func (r *VersionGatePollRequest) StartContext(ctx context.Context) (response *Ve
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *VersionGatePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *VersionGateDeleteRequest) Impersonate(user string) *VersionGateDeleteRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGateDeleteRequest) Send() (result *VersionGateDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGateDeleteRequest) SendContext(ctx context.Context) (result *VersionGateDeleteResponse, err error) {
+func (r *VersionGateDeleteRequest) Send(ctx context.Context) (result *VersionGateDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *VersionGateGetRequest) Impersonate(user string) *VersionGateGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGateGetRequest) Send() (result *VersionGateGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGateGetRequest) SendContext(ctx context.Context) (result *VersionGateGetResponse, err error) {
+func (r *VersionGateGetRequest) Send(ctx context.Context) (result *VersionGateGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/clustersmgmt/v1/version_gates_client.go
+++ b/clustersmgmt/v1/version_gates_client.go
@@ -118,15 +118,7 @@ func (r *VersionGatesAddRequest) Body(value *VersionGate) *VersionGatesAddReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGatesAddRequest) Send() (result *VersionGatesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGatesAddRequest) SendContext(ctx context.Context) (result *VersionGatesAddResponse, err error) {
+func (r *VersionGatesAddRequest) Send(ctx context.Context) (result *VersionGatesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -315,15 +307,7 @@ func (r *VersionGatesListRequest) Size(value int) *VersionGatesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionGatesListRequest) Send() (result *VersionGatesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionGatesListRequest) SendContext(ctx context.Context) (result *VersionGatesListResponse, err error) {
+func (r *VersionGatesListRequest) Send(ctx context.Context) (result *VersionGatesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/versions_client.go
+++ b/clustersmgmt/v1/versions_client.go
@@ -159,15 +159,7 @@ func (r *VersionsListRequest) Size(value int) *VersionsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VersionsListRequest) Send() (result *VersionsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VersionsListRequest) SendContext(ctx context.Context) (result *VersionsListResponse, err error) {
+func (r *VersionsListRequest) Send(ctx context.Context) (result *VersionsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/clustersmgmt/v1/vpcs_inquiry_client.go
+++ b/clustersmgmt/v1/vpcs_inquiry_client.go
@@ -121,15 +121,7 @@ func (r *VpcsInquirySearchRequest) Size(value int) *VpcsInquirySearchRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *VpcsInquirySearchRequest) Send() (result *VpcsInquirySearchResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *VpcsInquirySearchRequest) SendContext(ctx context.Context) (result *VpcsInquirySearchResponse, err error) {
+func (r *VpcsInquirySearchRequest) Send(ctx context.Context) (result *VpcsInquirySearchResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/compression_test.go
+++ b/compression_test.go
@@ -20,6 +20,7 @@ package sdk
 
 import (
 	"compress/gzip"
+	"context"
 	"net/http"
 	"time"
 
@@ -33,12 +34,16 @@ import (
 
 var _ = Describe("Compression", func() {
 	var (
+		ctx        context.Context
 		server     *ghttp.Server
 		connection *Connection
 	)
 
 	BeforeEach(func() {
 		var err error
+
+		// Create the context:
+		ctx = context.Background()
 
 		// Create the tokens:
 		token := MakeTokenString("Bearer", 5*time.Minute)
@@ -89,7 +94,7 @@ var _ = Describe("Compression", func() {
 
 		// Send the request:
 		response, err := connection.ClustersMgmt().V1().Clusters().Cluster("123").Get().
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 		result := response.Body()

--- a/examples/client_credentials_grant.go
+++ b/examples/client_credentials_grant.go
@@ -46,7 +46,7 @@ func clientCredentialsGrant(ctx context.Context, args []string) error {
 		Search("name like 'my%'").
 		Page(1).
 		Size(10).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/create_cluster.go
+++ b/examples/create_cluster.go
@@ -72,7 +72,7 @@ func createCluster(ctx context.Context, args []string) error {
 	// Send a request to create the cluster:
 	response, err := collection.Add().
 		Body(cluster).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/create_product.go
+++ b/examples/create_product.go
@@ -53,7 +53,7 @@ func createProduct(ctx context.Context, args []string) error {
 	// Send a request to create the product:
 	response, err := collection.Add().
 		Body(product).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/create_syncset.go
+++ b/examples/create_syncset.go
@@ -75,7 +75,7 @@ func createSyncset(ctx context.Context, args []string) error {
 		Syncsets().
 		Add().
 		Body(syncset).
-		Send()
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/delete_cluster.go
+++ b/examples/delete_cluster.go
@@ -46,7 +46,7 @@ func deleteCluster(ctx context.Context, args []string) error {
 	resource := collection.Cluster("1BDFg66jv2kDfBh6bBog3IsZWVH")
 
 	// Send the request to delete the cluster:
-	_, err = resource.Delete().SendContext(ctx)
+	_, err = resource.Delete().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/delete_product.go
+++ b/examples/delete_product.go
@@ -47,7 +47,7 @@ func deleteProduct(ctx context.Context, args []string) error {
 	resource := collection.Product("ea7ee64f-978d-4705-a271-85b072bc5241")
 
 	// Send the request to delete the product:
-	_, err = resource.Delete().SendContext(ctx)
+	_, err = resource.Delete().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/delete_subscription.go
+++ b/examples/delete_subscription.go
@@ -46,7 +46,7 @@ func deleteSubscription(ctx context.Context, args []string) error {
 	resource := collection.Subscription("1BDFg66jv2kDfBh6bBog3IsZWVH")
 
 	// Send the request to delete the subscription:
-	_, err = resource.Delete().SendContext(ctx)
+	_, err = resource.Delete().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/existing_token.go
+++ b/examples/existing_token.go
@@ -60,7 +60,7 @@ func existingToken(ctx context.Context, args []string) error {
 		Search("name like 'my%'").
 		Page(1).
 		Size(10).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/export_control_review.go
+++ b/examples/export_control_review.go
@@ -53,7 +53,7 @@ func exportControlReview(ctx context.Context, args []string) error {
 	// Send the request:
 	postResponse, err := resource.Post().
 		Request(reviewRequest).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/get_cluster.go
+++ b/examples/get_cluster.go
@@ -47,7 +47,7 @@ func getCluster(ctx context.Context, args []string) error {
 	resource := collection.Cluster("1BDFg66jv2kDfBh6bBog3IsZWVH")
 
 	// Send the request to retrieve the cluster:
-	response, err := resource.Get().SendContext(ctx)
+	response, err := resource.Get().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/get_cluster_credentials.go
+++ b/examples/get_cluster_credentials.go
@@ -47,7 +47,7 @@ func getClusterCredentials(ctx context.Context, args []string) error {
 	resource := collection.Cluster("123").Credentials()
 
 	// Send the request to retrieve the credentials:
-	response, err := resource.Get().SendContext(ctx)
+	response, err := resource.Get().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/get_cluster_logs.go
+++ b/examples/get_cluster_logs.go
@@ -48,7 +48,7 @@ func getClusterLogs(ctx context.Context, args []string) error {
 	logsCollection := clustersResource.Cluster("1Jam7Ejgpm7AbZshbgaA9TsM1SQ").Logs()
 
 	// Send the request to retrieve the collection of logs:
-	listResponse, err := logsCollection.List().SendContext(ctx)
+	listResponse, err := logsCollection.List().Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func getClusterLogs(ctx context.Context, args []string) error {
 	listResponse.Items().Each(func(log *cmv1.Log) bool {
 		logID := log.ID()
 		logResource := logsCollection.Install()
-		getResponse, err := logResource.Get().SendContext(ctx)
+		getResponse, err := logResource.Get().Send(ctx)
 		if err != nil {
 			logger.Error(
 				err,

--- a/examples/get_metadata.go
+++ b/examples/get_metadata.go
@@ -42,7 +42,7 @@ func getMetadata(ctx context.Context, args []string) error {
 	client := connection.ClustersMgmt().V1()
 
 	// Send the request to retrieve the metadata:
-	response, err := client.Get().SendContext(ctx)
+	response, err := client.Get().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/get_service.go
+++ b/examples/get_service.go
@@ -48,7 +48,7 @@ func getService(ctx context.Context, args []string) error {
 	resource := collection.Service("dc440fc4-db27-40eb-8180-765bc4e28620") // Update as needed
 
 	// Send the request to retrieve the service:
-	response, err := resource.Get().SendContext(ctx)
+	response, err := resource.Get().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/list_applications.go
+++ b/examples/list_applications.go
@@ -54,7 +54,7 @@ func listApplications(ctx context.Context, args []string) error {
 			//Fullname("similitudinem-consentiat"). // Uncomment this to restrict results by fullname
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func listApplications(ctx context.Context, args []string) error {
 		response, err := services_collection.List().
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return err
 		}

--- a/examples/list_cloud_providers.go
+++ b/examples/list_cloud_providers.go
@@ -43,14 +43,14 @@ func listCloudProviders(ctx context.Context, args []string) error {
 	providersCollection := connection.ClustersMgmt().V1().CloudProviders()
 
 	// Retrieve the first page of cloud providers and print them:
-	providersResponse, err := providersCollection.List().SendContext(ctx)
+	providersResponse, err := providersCollection.List().Send(ctx)
 	if err != nil {
 		return err
 	}
 	providersResponse.Items().Each(func(provider *cmv1.CloudProvider) bool {
 		providerID := provider.ID()
 		regionsCollection := providersCollection.CloudProvider(providerID).Regions()
-		regionsResponse, err := regionsCollection.List().SendContext(ctx)
+		regionsResponse, err := regionsCollection.List().Send(ctx)
 		if err != nil {
 			logger.Error(err, "Can't retrieve regions")
 			return false

--- a/examples/list_cluster_creators.go
+++ b/examples/list_cluster_creators.go
@@ -60,7 +60,7 @@ func listClusterCreators(ctx context.Context, args []string) error {
 			Search("managed = 't'").
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func listClusterCreators(ctx context.Context, args []string) error {
 			// Retrieve the details of the subscription, so that we can follow the link
 			// to the account that created it:
 			subscriptionResource := subscriptionsCollection.Subscription(subscriptionID)
-			subscriptionGetResponse, err := subscriptionResource.Get().Send()
+			subscriptionGetResponse, err := subscriptionResource.Get().Send(ctx)
 			if err != nil {
 				logger.Error(
 					err,
@@ -105,7 +105,7 @@ func listClusterCreators(ctx context.Context, args []string) error {
 
 			// Retrieve the details of the account:
 			accountResource := accountsCollection.Account(creatorID)
-			accountGetResponse, err := accountResource.Get().Send()
+			accountGetResponse, err := accountResource.Get().Send(ctx)
 			if err != nil {
 				logger.Error(
 					err,

--- a/examples/list_clusters.go
+++ b/examples/list_clusters.go
@@ -52,7 +52,7 @@ func listClusters(ctx context.Context, args []string) error {
 			Search("name like 'my%'").
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return err
 		}

--- a/examples/list_products.go
+++ b/examples/list_products.go
@@ -54,7 +54,7 @@ func listProducts(ctx context.Context, args []string) error {
 			//Fullname("exhibentur").
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return err
 		}

--- a/examples/list_quota_cost.go
+++ b/examples/list_quota_cost.go
@@ -47,7 +47,7 @@ func listQuotaCost(ctx context.Context, args []string) error {
 	// Search quota cost items where quota_id starts with 'add-on':
 	response, err := collection.List().
 		Search("quota_id like 'add-on%'").
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/list_status_updates.go
+++ b/examples/list_status_updates.go
@@ -48,7 +48,7 @@ func listStatusUpdates(ctx context.Context, args []string) error {
 	// Update as needed.
 	product_ids := "4aff22fc-b5b9-4863-adfd-92dc92974cd5,33496a9f-f2bc-408a-b503-be726ab04976"
 
-	response, err := collection.List().ProductIds(product_ids).SendContext(ctx)
+	response, err := collection.List().ProductIds(product_ids).Send(ctx)
 
 	if err != nil {
 		return err

--- a/examples/list_versions.go
+++ b/examples/list_versions.go
@@ -51,7 +51,7 @@ func listVersions(ctx context.Context, args []string) error {
 		response, err := collection.List().
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return err
 		}

--- a/examples/load_config.go
+++ b/examples/load_config.go
@@ -51,7 +51,7 @@ func loadConfig(ctx context.Context, args []string) error {
 			Search("name like 'my%'").
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return err
 		}

--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -57,7 +57,7 @@ func prometheusMetrics(ctx context.Context, args []string) error {
 	// your browser to http://localhost:8000.
 	for {
 		// Get the list of clusters:
-		clustersListResponse, err := clustersCollection.List().SendContext(ctx)
+		clustersListResponse, err := clustersCollection.List().Send(ctx)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Can't send list request: %v\n", err)
 			os.Exit(1)
@@ -67,15 +67,15 @@ func prometheusMetrics(ctx context.Context, args []string) error {
 		clustersListResponse.Items().Each(func(cluster *cmv1.Cluster) bool {
 			// Get the details:
 			clusterResource := clustersCollection.Cluster(cluster.ID())
-			clusterResource.Get().SendContext(ctx)
+			clusterResource.Get().Send(ctx)
 
 			// Get the list of logs:
 			logsResource := clusterResource.Logs()
-			logsResource.List().SendContext(ctx)
+			logsResource.List().Send(ctx)
 
 			// Get the credentials:
 			credentialsResource := clusterResource.Credentials()
-			credentialsResource.Get().SendContext(ctx)
+			credentialsResource.Get().Send(ctx)
 
 			return true
 		})

--- a/examples/pushpop_job_queue.go
+++ b/examples/pushpop_job_queue.go
@@ -48,7 +48,7 @@ func pushpopJobQueue(ctx context.Context, args []string) error {
 	client := jobQueues.Queues().Queue(queueID)
 
 	// Push a new job
-	pushResponse, err := client.Push().Arguments("foo bar").SendContext(ctx)
+	pushResponse, err := client.Push().Arguments("foo bar").Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func pushpopJobQueue(ctx context.Context, args []string) error {
 	fmt.Printf("Pushed:\n\tid: %s\n\targuments: %s\n\n", pushID, pushArguments)
 
 	// Retrieve this job back
-	popResponse, err := client.Pop().SendContext(ctx)
+	popResponse, err := client.Pop().Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -70,13 +70,13 @@ func pushpopJobQueue(ctx context.Context, args []string) error {
 		popID, popArguments, popAttempts, abandonedAt, receiptID)
 
 	// Mark it as success
-	_, err = client.Jobs().Job(popID).Success().ReceiptId(receiptID).SendContext(ctx)
+	_, err = client.Jobs().Job(popID).Success().ReceiptId(receiptID).Send(ctx)
 	if err != nil {
 		return err
 	}
 
 	// To mark it as Failure use
-	// _, err = client.Jobs().Job(popID).Failure().FailureReason("Failure reason").ReceiptId(receiptID).SendContext(ctx)
+	// _, err = client.Jobs().Job(popID).Failure().FailureReason("Failure reason").ReceiptId(receiptID).Send(ctx)
 
 	return nil
 }

--- a/examples/resource_review.go
+++ b/examples/resource_review.go
@@ -56,7 +56,7 @@ func resourceReview(ctx context.Context, args []string) error {
 	// Send a request to get the list identifiers of clusters that we can see:
 	response, err := resource.Post().
 		Request(request).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/run_cluster_operator_metrics.go
+++ b/examples/run_cluster_operator_metrics.go
@@ -46,7 +46,7 @@ func runClusterOperatorMetrics(ctx context.Context, args []string) error {
 		ClusterOperators()
 
 	// Send the request to run the query:
-	response, err := resource.Get().SendContext(ctx)
+	response, err := resource.Get().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/run_metric_query.go
+++ b/examples/run_metric_query.go
@@ -46,7 +46,7 @@ func runMetricQuery(ctx context.Context, args []string) error {
 		CPUTotalByNodeRolesOS()
 
 	// Send the request to run the query:
-	response, err := resource.Get().SendContext(ctx)
+	response, err := resource.Get().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/sync_addons.go
+++ b/examples/sync_addons.go
@@ -68,7 +68,7 @@ func syncAddons(ctx context.Context, args []string) error {
 			}
 			_, err = collection.Add().
 				Body(apiItem).
-				SendContext(ctx)
+				Send(ctx)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ func syncAddons(ctx context.Context, args []string) error {
 			}
 			_, err = collection.Addon(id).Update().
 				Body(apiItem).
-				SendContext(ctx)
+				Send(ctx)
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ func syncAddons(ctx context.Context, args []string) error {
 			}
 			_, err = collection.Addon(id).Update().
 				Body(apiItem).
-				SendContext(ctx)
+				Send(ctx)
 			if err != nil {
 				return err
 			}
@@ -151,7 +151,7 @@ func loadAPI(ctx context.Context, collection *cmv1.AddOnsClient) (result map[str
 		response, err = collection.List().
 			Size(size).
 			Page(page).
-			SendContext(ctx)
+			Send(ctx)
 		if err != nil {
 			return
 		}

--- a/examples/transport_wrapper.go
+++ b/examples/transport_wrapper.go
@@ -76,7 +76,7 @@ func transportWrapper(ctx context.Context, args []string) error {
 	providersCollection := connection.ClustersMgmt().V1().CloudProviders()
 
 	// Retrieve the first page of cloud providers:
-	_, err = providersCollection.List().SendContext(ctx)
+	_, err = providersCollection.List().Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/update_cluster.go
+++ b/examples/update_cluster.go
@@ -57,7 +57,7 @@ func updateCluster(ctx context.Context, args []string) error {
 	// Send the request to update the cluster:
 	_, err = resource.Update().
 		Body(patch).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/update_product.go
+++ b/examples/update_product.go
@@ -58,7 +58,7 @@ func updateProduct(ctx context.Context, args []string) error {
 	// Send the request to update the product:
 	_, err = resource.Update().
 		Body(patch).
-		SendContext(ctx)
+		Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -101,9 +101,9 @@ func Segments(path string) []string {
 	return strings.Split(path, "/")
 }
 
-// PollContext repeatedly executes a task till it returns one of the given statuses and till the result
+// Poll repeatedly executes a task till it returns one of the given statuses and till the result
 // satisfies all the given predicates.
-func PollContext(
+func Poll(
 	ctx context.Context,
 	interval time.Duration,
 	statuses []int,

--- a/jobqueue/v1/job_client.go
+++ b/jobqueue/v1/job_client.go
@@ -117,15 +117,7 @@ func (r *JobFailureRequest) ReceiptId(value string) *JobFailureRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *JobFailureRequest) Send() (result *JobFailureResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *JobFailureRequest) SendContext(ctx context.Context) (result *JobFailureResponse, err error) {
+func (r *JobFailureRequest) Send(ctx context.Context) (result *JobFailureResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -239,15 +231,7 @@ func (r *JobSuccessRequest) ReceiptId(value string) *JobSuccessRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *JobSuccessRequest) Send() (result *JobSuccessResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *JobSuccessRequest) SendContext(ctx context.Context) (result *JobSuccessResponse, err error) {
+func (r *JobSuccessRequest) Send(ctx context.Context) (result *JobSuccessResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/jobqueue/v1/metadata_client.go
+++ b/jobqueue/v1/metadata_client.go
@@ -59,15 +59,7 @@ func (r *MetadataRequest) Header(name string, value interface{}) *MetadataReques
 }
 
 // Send sends the metadata request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends the metadata request, waits for the response, and returns it.
-func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/jobqueue/v1/queue_client.go
+++ b/jobqueue/v1/queue_client.go
@@ -135,13 +135,13 @@ func (r *QueuePollRequest) Predicate(value func(*QueueGetResponse) bool) *QueueP
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *QueuePollRequest) StartContext(ctx context.Context) (response *QueuePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *QueuePollRequest) Start(ctx context.Context) (response *QueuePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &QueuePollResponse{
 			response: result.(*QueueGetResponse),
@@ -153,7 +153,7 @@ func (r *QueuePollRequest) StartContext(ctx context.Context) (response *QueuePol
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *QueuePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -241,15 +241,7 @@ func (r *QueueGetRequest) Impersonate(user string) *QueueGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *QueueGetRequest) Send() (result *QueueGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *QueueGetRequest) SendContext(ctx context.Context) (result *QueueGetResponse, err error) {
+func (r *QueueGetRequest) Send(ctx context.Context) (result *QueueGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -375,15 +367,7 @@ func (r *QueuePopRequest) Impersonate(user string) *QueuePopRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *QueuePopRequest) Send() (result *QueuePopResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *QueuePopRequest) SendContext(ctx context.Context) (result *QueuePopResponse, err error) {
+func (r *QueuePopRequest) Send(ctx context.Context) (result *QueuePopResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -729,15 +713,7 @@ func (r *QueuePushRequest) CreatedAt(value time.Time) *QueuePushRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *QueuePushRequest) Send() (result *QueuePushResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *QueuePushRequest) SendContext(ctx context.Context) (result *QueuePushResponse, err error) {
+func (r *QueuePushRequest) Send(ctx context.Context) (result *QueuePushResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/jobqueue/v1/queues_client.go
+++ b/jobqueue/v1/queues_client.go
@@ -116,15 +116,7 @@ func (r *QueuesListRequest) Size(value int) *QueuesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *QueuesListRequest) Send() (result *QueuesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *QueuesListRequest) SendContext(ctx context.Context) (result *QueuesListResponse, err error) {
+func (r *QueuesListRequest) Send(ctx context.Context) (result *QueuesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/methods_test.go
+++ b/methods_test.go
@@ -35,6 +35,9 @@ import (
 )
 
 var _ = Describe("Methods", func() {
+	// Context used during the tests:
+	var ctx context.Context
+
 	// Servers used during the tests:
 	var oidServer *ghttp.Server
 	var apiServer *ghttp.Server
@@ -48,6 +51,9 @@ var _ = Describe("Methods", func() {
 
 	BeforeEach(func() {
 		var err error
+
+		// Create the context:
+		ctx = context.Background()
 
 		// Create the tokens:
 		accessToken := MakeTokenString("Bearer", 5*time.Minute)
@@ -375,7 +381,7 @@ var _ = Describe("Methods", func() {
 			response, err := collection.Add().
 				Body(body).
 				Parameter("dryRun", true).
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusNoContent))
@@ -401,7 +407,7 @@ var _ = Describe("Methods", func() {
 			_, err = connection.ClustersMgmt().V1().Clusters().Add().
 				Impersonate("my-user").
 				Body(body).
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package sdk
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -30,6 +31,9 @@ import (
 )
 
 var _ = Describe("Metrics enabled", func() {
+	// Context used during the tests:
+	var ctx context.Context
+
 	// Servers used during the tests:
 	var oidServer *ghttp.Server
 	var apiServer *ghttp.Server
@@ -40,6 +44,9 @@ var _ = Describe("Metrics enabled", func() {
 
 	BeforeEach(func() {
 		var err error
+
+		// Create the context:
+		ctx = context.Background()
 
 		// Create the tokens:
 		accessToken := MakeTokenString("Bearer", 5*time.Minute)
@@ -100,7 +107,7 @@ var _ = Describe("Metrics enabled", func() {
 	It("Generates request count for type safe request", func() {
 		// Send the request:
 		_, err := connection.ClustersMgmt().V1().Clusters().Cluster("123").Get().
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the metrics:
@@ -111,7 +118,7 @@ var _ = Describe("Metrics enabled", func() {
 	It("Generates token request count", func() {
 		// Send the request:
 		_, err := connection.ClustersMgmt().V1().Clusters().Cluster("123").Get().
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the metrics:
@@ -123,7 +130,7 @@ var _ = Describe("Metrics enabled", func() {
 	It("Generates token request duration", func() {
 		// Send the request:
 		_, err := connection.ClustersMgmt().V1().Clusters().Cluster("123").Get().
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the metrics:
@@ -146,6 +153,9 @@ var _ = Describe("Metrics enabled", func() {
 })
 
 var _ = Describe("Metrics disabled", func() {
+	// Context used during the tests:
+	var ctx context.Context
+
 	// Servers used during the tests:
 	var oidServer *ghttp.Server
 	var apiServer *ghttp.Server
@@ -215,7 +225,7 @@ var _ = Describe("Metrics disabled", func() {
 	It("Doesn't generate metrics for type safe request", func() {
 		// Send the request:
 		_, err := connection.ClustersMgmt().V1().Clusters().Cluster("123").Get().
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the metrics:

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package sdk
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,6 +33,9 @@ import (
 )
 
 var _ = Describe("Redirect", func() {
+	// Context used during the tests:
+	var ctx context.Context
+
 	// Tokens used during the tests:
 	var accessToken string
 	var refreshToken string
@@ -56,6 +60,9 @@ var _ = Describe("Redirect", func() {
 
 	BeforeEach(func() {
 		var err error
+
+		// Create the context:
+		ctx = context.Background()
 
 		// Create the tokens:
 		accessToken = MakeTokenString("Bearer", 5*time.Minute)
@@ -155,7 +162,7 @@ var _ = Describe("Redirect", func() {
 			)
 
 			// Send the request:
-			_, err := connection.ClustersMgmt().V1().Get().Send()
+			_, err := connection.ClustersMgmt().V1().Get().Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -166,7 +173,7 @@ var _ = Describe("Redirect", func() {
 			)
 
 			// Send the request:
-			_, err := connection.ClustersMgmt().V1().Get().Send()
+			_, err := connection.ClustersMgmt().V1().Get().Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/servicelogs/v1/cluster_logs_client.go
+++ b/servicelogs/v1/cluster_logs_client.go
@@ -118,15 +118,7 @@ func (r *ClusterLogsAddRequest) Body(value *LogEntry) *ClusterLogsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterLogsAddRequest) Send() (result *ClusterLogsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterLogsAddRequest) SendContext(ctx context.Context) (result *ClusterLogsAddResponse, err error) {
+func (r *ClusterLogsAddRequest) Send(ctx context.Context) (result *ClusterLogsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -317,15 +309,7 @@ func (r *ClusterLogsListRequest) Size(value int) *ClusterLogsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterLogsListRequest) Send() (result *ClusterLogsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterLogsListRequest) SendContext(ctx context.Context) (result *ClusterLogsListResponse, err error) {
+func (r *ClusterLogsListRequest) Send(ctx context.Context) (result *ClusterLogsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/servicelogs/v1/cluster_logs_uuid_client.go
+++ b/servicelogs/v1/cluster_logs_uuid_client.go
@@ -145,15 +145,7 @@ func (r *ClusterLogsUUIDListRequest) Size(value int) *ClusterLogsUUIDListRequest
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ClusterLogsUUIDListRequest) Send() (result *ClusterLogsUUIDListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ClusterLogsUUIDListRequest) SendContext(ctx context.Context) (result *ClusterLogsUUIDListResponse, err error) {
+func (r *ClusterLogsUUIDListRequest) Send(ctx context.Context) (result *ClusterLogsUUIDListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.order != nil {
 		helpers.AddValue(&query, "order", *r.order)

--- a/servicelogs/v1/log_entry_client.go
+++ b/servicelogs/v1/log_entry_client.go
@@ -112,13 +112,13 @@ func (r *LogEntryPollRequest) Predicate(value func(*LogEntryGetResponse) bool) *
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *LogEntryPollRequest) StartContext(ctx context.Context) (response *LogEntryPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *LogEntryPollRequest) Start(ctx context.Context) (response *LogEntryPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &LogEntryPollResponse{
 			response: result.(*LogEntryGetResponse),
@@ -130,7 +130,7 @@ func (r *LogEntryPollRequest) StartContext(ctx context.Context) (response *LogEn
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *LogEntryPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *LogEntryDeleteRequest) Impersonate(user string) *LogEntryDeleteRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LogEntryDeleteRequest) Send() (result *LogEntryDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LogEntryDeleteRequest) SendContext(ctx context.Context) (result *LogEntryDeleteResponse, err error) {
+func (r *LogEntryDeleteRequest) Send(ctx context.Context) (result *LogEntryDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *LogEntryGetRequest) Impersonate(user string) *LogEntryGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *LogEntryGetRequest) Send() (result *LogEntryGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *LogEntryGetRequest) SendContext(ctx context.Context) (result *LogEntryGetResponse, err error) {
+func (r *LogEntryGetRequest) Send(ctx context.Context) (result *LogEntryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/servicelogs/v1/metadata_client.go
+++ b/servicelogs/v1/metadata_client.go
@@ -59,15 +59,7 @@ func (r *MetadataRequest) Header(name string, value interface{}) *MetadataReques
 }
 
 // Send sends the metadata request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends the metadata request, waits for the response, and returns it.
-func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/servicemgmt/v1/managed_service_client.go
+++ b/servicemgmt/v1/managed_service_client.go
@@ -112,13 +112,13 @@ func (r *ManagedServicePollRequest) Predicate(value func(*ManagedServiceGetRespo
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ManagedServicePollRequest) StartContext(ctx context.Context) (response *ManagedServicePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ManagedServicePollRequest) Start(ctx context.Context) (response *ManagedServicePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ManagedServicePollResponse{
 			response: result.(*ManagedServiceGetResponse),
@@ -130,7 +130,7 @@ func (r *ManagedServicePollRequest) StartContext(ctx context.Context) (response 
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ManagedServicePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -218,15 +218,7 @@ func (r *ManagedServiceDeleteRequest) Impersonate(user string) *ManagedServiceDe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ManagedServiceDeleteRequest) Send() (result *ManagedServiceDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ManagedServiceDeleteRequest) SendContext(ctx context.Context) (result *ManagedServiceDeleteResponse, err error) {
+func (r *ManagedServiceDeleteRequest) Send(ctx context.Context) (result *ManagedServiceDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -325,15 +317,7 @@ func (r *ManagedServiceGetRequest) Impersonate(user string) *ManagedServiceGetRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ManagedServiceGetRequest) Send() (result *ManagedServiceGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ManagedServiceGetRequest) SendContext(ctx context.Context) (result *ManagedServiceGetResponse, err error) {
+func (r *ManagedServiceGetRequest) Send(ctx context.Context) (result *ManagedServiceGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/servicemgmt/v1/metadata_client.go
+++ b/servicemgmt/v1/metadata_client.go
@@ -59,15 +59,7 @@ func (r *MetadataRequest) Header(name string, value interface{}) *MetadataReques
 }
 
 // Send sends the metadata request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends the metadata request, waits for the response, and returns it.
-func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/servicemgmt/v1/services_client.go
+++ b/servicemgmt/v1/services_client.go
@@ -118,15 +118,7 @@ func (r *ServicesAddRequest) Body(value *ManagedService) *ServicesAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServicesAddRequest) Send() (result *ServicesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServicesAddRequest) SendContext(ctx context.Context) (result *ServicesAddResponse, err error) {
+func (r *ServicesAddRequest) Send(ctx context.Context) (result *ServicesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -276,15 +268,7 @@ func (r *ServicesListRequest) Size(value int) *ServicesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServicesListRequest) Send() (result *ServicesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServicesListRequest) SendContext(ctx context.Context) (result *ServicesListResponse, err error) {
+func (r *ServicesListRequest) Send(ctx context.Context) (result *ServicesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.page != nil {
 		helpers.AddValue(&query, "page", *r.page)

--- a/statusboard/v1/application_client.go
+++ b/statusboard/v1/application_client.go
@@ -135,13 +135,13 @@ func (r *ApplicationPollRequest) Predicate(value func(*ApplicationGetResponse) b
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ApplicationPollRequest) StartContext(ctx context.Context) (response *ApplicationPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ApplicationPollRequest) Start(ctx context.Context) (response *ApplicationPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ApplicationPollResponse{
 			response: result.(*ApplicationGetResponse),
@@ -153,7 +153,7 @@ func (r *ApplicationPollRequest) StartContext(ctx context.Context) (response *Ap
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ApplicationPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -241,15 +241,7 @@ func (r *ApplicationDeleteRequest) Impersonate(user string) *ApplicationDeleteRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationDeleteRequest) Send() (result *ApplicationDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationDeleteRequest) SendContext(ctx context.Context) (result *ApplicationDeleteResponse, err error) {
+func (r *ApplicationDeleteRequest) Send(ctx context.Context) (result *ApplicationDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -348,15 +340,7 @@ func (r *ApplicationGetRequest) Impersonate(user string) *ApplicationGetRequest 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationGetRequest) Send() (result *ApplicationGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationGetRequest) SendContext(ctx context.Context) (result *ApplicationGetResponse, err error) {
+func (r *ApplicationGetRequest) Send(ctx context.Context) (result *ApplicationGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -491,15 +475,7 @@ func (r *ApplicationUpdateRequest) Body(value *Application) *ApplicationUpdateRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationUpdateRequest) Send() (result *ApplicationUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationUpdateRequest) SendContext(ctx context.Context) (result *ApplicationUpdateResponse, err error) {
+func (r *ApplicationUpdateRequest) Send(ctx context.Context) (result *ApplicationUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/application_dependencies_client.go
+++ b/statusboard/v1/application_dependencies_client.go
@@ -118,15 +118,7 @@ func (r *ApplicationDependenciesAddRequest) Body(value *ApplicationDependency) *
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationDependenciesAddRequest) Send() (result *ApplicationDependenciesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationDependenciesAddRequest) SendContext(ctx context.Context) (result *ApplicationDependenciesAddResponse, err error) {
+func (r *ApplicationDependenciesAddRequest) Send(ctx context.Context) (result *ApplicationDependenciesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -285,15 +277,7 @@ func (r *ApplicationDependenciesListRequest) Size(value int) *ApplicationDepende
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationDependenciesListRequest) Send() (result *ApplicationDependenciesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationDependenciesListRequest) SendContext(ctx context.Context) (result *ApplicationDependenciesListResponse, err error) {
+func (r *ApplicationDependenciesListRequest) Send(ctx context.Context) (result *ApplicationDependenciesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.orderBy != nil {
 		helpers.AddValue(&query, "order_by", *r.orderBy)

--- a/statusboard/v1/application_dependency_client.go
+++ b/statusboard/v1/application_dependency_client.go
@@ -124,13 +124,13 @@ func (r *ApplicationDependencyPollRequest) Predicate(value func(*ApplicationDepe
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ApplicationDependencyPollRequest) StartContext(ctx context.Context) (response *ApplicationDependencyPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ApplicationDependencyPollRequest) Start(ctx context.Context) (response *ApplicationDependencyPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ApplicationDependencyPollResponse{
 			response: result.(*ApplicationDependencyGetResponse),
@@ -142,7 +142,7 @@ func (r *ApplicationDependencyPollRequest) StartContext(ctx context.Context) (re
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ApplicationDependencyPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *ApplicationDependencyDeleteRequest) Impersonate(user string) *Applicati
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationDependencyDeleteRequest) Send() (result *ApplicationDependencyDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationDependencyDeleteRequest) SendContext(ctx context.Context) (result *ApplicationDependencyDeleteResponse, err error) {
+func (r *ApplicationDependencyDeleteRequest) Send(ctx context.Context) (result *ApplicationDependencyDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *ApplicationDependencyGetRequest) Impersonate(user string) *ApplicationD
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationDependencyGetRequest) Send() (result *ApplicationDependencyGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationDependencyGetRequest) SendContext(ctx context.Context) (result *ApplicationDependencyGetResponse, err error) {
+func (r *ApplicationDependencyGetRequest) Send(ctx context.Context) (result *ApplicationDependencyGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *ApplicationDependencyUpdateRequest) Body(value *ApplicationDependency) 
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationDependencyUpdateRequest) Send() (result *ApplicationDependencyUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationDependencyUpdateRequest) SendContext(ctx context.Context) (result *ApplicationDependencyUpdateResponse, err error) {
+func (r *ApplicationDependencyUpdateRequest) Send(ctx context.Context) (result *ApplicationDependencyUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/applications_client.go
+++ b/statusboard/v1/applications_client.go
@@ -118,15 +118,7 @@ func (r *ApplicationsAddRequest) Body(value *Application) *ApplicationsAddReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationsAddRequest) Send() (result *ApplicationsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationsAddRequest) SendContext(ctx context.Context) (result *ApplicationsAddResponse, err error) {
+func (r *ApplicationsAddRequest) Send(ctx context.Context) (result *ApplicationsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -294,15 +286,7 @@ func (r *ApplicationsListRequest) Size(value int) *ApplicationsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ApplicationsListRequest) Send() (result *ApplicationsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ApplicationsListRequest) SendContext(ctx context.Context) (result *ApplicationsListResponse, err error) {
+func (r *ApplicationsListRequest) Send(ctx context.Context) (result *ApplicationsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.fullname != nil {
 		helpers.AddValue(&query, "fullname", *r.fullname)

--- a/statusboard/v1/metadata_client.go
+++ b/statusboard/v1/metadata_client.go
@@ -59,15 +59,7 @@ func (r *MetadataRequest) Header(name string, value interface{}) *MetadataReques
 }
 
 // Send sends the metadata request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *MetadataRequest) Send() (result *MetadataResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends the metadata request, waits for the response, and returns it.
-func (r *MetadataRequest) SendContext(ctx context.Context) (result *MetadataResponse, err error) {
+func (r *MetadataRequest) Send(ctx context.Context) (result *MetadataResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{

--- a/statusboard/v1/peer_dependencies_client.go
+++ b/statusboard/v1/peer_dependencies_client.go
@@ -118,15 +118,7 @@ func (r *PeerDependenciesAddRequest) Body(value *PeerDependency) *PeerDependenci
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PeerDependenciesAddRequest) Send() (result *PeerDependenciesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PeerDependenciesAddRequest) SendContext(ctx context.Context) (result *PeerDependenciesAddResponse, err error) {
+func (r *PeerDependenciesAddRequest) Send(ctx context.Context) (result *PeerDependenciesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -285,15 +277,7 @@ func (r *PeerDependenciesListRequest) Size(value int) *PeerDependenciesListReque
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PeerDependenciesListRequest) Send() (result *PeerDependenciesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PeerDependenciesListRequest) SendContext(ctx context.Context) (result *PeerDependenciesListResponse, err error) {
+func (r *PeerDependenciesListRequest) Send(ctx context.Context) (result *PeerDependenciesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.orderBy != nil {
 		helpers.AddValue(&query, "order_by", *r.orderBy)

--- a/statusboard/v1/peer_dependency_client.go
+++ b/statusboard/v1/peer_dependency_client.go
@@ -124,13 +124,13 @@ func (r *PeerDependencyPollRequest) Predicate(value func(*PeerDependencyGetRespo
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *PeerDependencyPollRequest) StartContext(ctx context.Context) (response *PeerDependencyPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *PeerDependencyPollRequest) Start(ctx context.Context) (response *PeerDependencyPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &PeerDependencyPollResponse{
 			response: result.(*PeerDependencyGetResponse),
@@ -142,7 +142,7 @@ func (r *PeerDependencyPollRequest) StartContext(ctx context.Context) (response 
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *PeerDependencyPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *PeerDependencyDeleteRequest) Impersonate(user string) *PeerDependencyDe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PeerDependencyDeleteRequest) Send() (result *PeerDependencyDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PeerDependencyDeleteRequest) SendContext(ctx context.Context) (result *PeerDependencyDeleteResponse, err error) {
+func (r *PeerDependencyDeleteRequest) Send(ctx context.Context) (result *PeerDependencyDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *PeerDependencyGetRequest) Impersonate(user string) *PeerDependencyGetRe
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PeerDependencyGetRequest) Send() (result *PeerDependencyGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PeerDependencyGetRequest) SendContext(ctx context.Context) (result *PeerDependencyGetResponse, err error) {
+func (r *PeerDependencyGetRequest) Send(ctx context.Context) (result *PeerDependencyGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *PeerDependencyUpdateRequest) Body(value *PeerDependency) *PeerDependenc
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *PeerDependencyUpdateRequest) Send() (result *PeerDependencyUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *PeerDependencyUpdateRequest) SendContext(ctx context.Context) (result *PeerDependencyUpdateResponse, err error) {
+func (r *PeerDependencyUpdateRequest) Send(ctx context.Context) (result *PeerDependencyUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/product_client.go
+++ b/statusboard/v1/product_client.go
@@ -145,13 +145,13 @@ func (r *ProductPollRequest) Predicate(value func(*ProductGetResponse) bool) *Pr
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ProductPollRequest) StartContext(ctx context.Context) (response *ProductPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ProductPollRequest) Start(ctx context.Context) (response *ProductPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ProductPollResponse{
 			response: result.(*ProductGetResponse),
@@ -163,7 +163,7 @@ func (r *ProductPollRequest) StartContext(ctx context.Context) (response *Produc
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ProductPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -251,15 +251,7 @@ func (r *ProductDeleteRequest) Impersonate(user string) *ProductDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProductDeleteRequest) Send() (result *ProductDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProductDeleteRequest) SendContext(ctx context.Context) (result *ProductDeleteResponse, err error) {
+func (r *ProductDeleteRequest) Send(ctx context.Context) (result *ProductDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -358,15 +350,7 @@ func (r *ProductGetRequest) Impersonate(user string) *ProductGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProductGetRequest) Send() (result *ProductGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProductGetRequest) SendContext(ctx context.Context) (result *ProductGetResponse, err error) {
+func (r *ProductGetRequest) Send(ctx context.Context) (result *ProductGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -501,15 +485,7 @@ func (r *ProductUpdateRequest) Body(value *Product) *ProductUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProductUpdateRequest) Send() (result *ProductUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProductUpdateRequest) SendContext(ctx context.Context) (result *ProductUpdateResponse, err error) {
+func (r *ProductUpdateRequest) Send(ctx context.Context) (result *ProductUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/products_client.go
+++ b/statusboard/v1/products_client.go
@@ -118,15 +118,7 @@ func (r *ProductsAddRequest) Body(value *Product) *ProductsAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProductsAddRequest) Send() (result *ProductsAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProductsAddRequest) SendContext(ctx context.Context) (result *ProductsAddResponse, err error) {
+func (r *ProductsAddRequest) Send(ctx context.Context) (result *ProductsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -294,15 +286,7 @@ func (r *ProductsListRequest) Size(value int) *ProductsListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ProductsListRequest) Send() (result *ProductsListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ProductsListRequest) SendContext(ctx context.Context) (result *ProductsListResponse, err error) {
+func (r *ProductsListRequest) Send(ctx context.Context) (result *ProductsListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.fullname != nil {
 		helpers.AddValue(&query, "fullname", *r.fullname)

--- a/statusboard/v1/service_client.go
+++ b/statusboard/v1/service_client.go
@@ -135,13 +135,13 @@ func (r *ServicePollRequest) Predicate(value func(*ServiceGetResponse) bool) *Se
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ServicePollRequest) StartContext(ctx context.Context) (response *ServicePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ServicePollRequest) Start(ctx context.Context) (response *ServicePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ServicePollResponse{
 			response: result.(*ServiceGetResponse),
@@ -153,7 +153,7 @@ func (r *ServicePollRequest) StartContext(ctx context.Context) (response *Servic
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ServicePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -241,15 +241,7 @@ func (r *ServiceDeleteRequest) Impersonate(user string) *ServiceDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceDeleteRequest) Send() (result *ServiceDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceDeleteRequest) SendContext(ctx context.Context) (result *ServiceDeleteResponse, err error) {
+func (r *ServiceDeleteRequest) Send(ctx context.Context) (result *ServiceDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -348,15 +340,7 @@ func (r *ServiceGetRequest) Impersonate(user string) *ServiceGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceGetRequest) Send() (result *ServiceGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceGetRequest) SendContext(ctx context.Context) (result *ServiceGetResponse, err error) {
+func (r *ServiceGetRequest) Send(ctx context.Context) (result *ServiceGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -491,15 +475,7 @@ func (r *ServiceUpdateRequest) Body(value *Service) *ServiceUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceUpdateRequest) Send() (result *ServiceUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceUpdateRequest) SendContext(ctx context.Context) (result *ServiceUpdateResponse, err error) {
+func (r *ServiceUpdateRequest) Send(ctx context.Context) (result *ServiceUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/service_dependencies_client.go
+++ b/statusboard/v1/service_dependencies_client.go
@@ -118,15 +118,7 @@ func (r *ServiceDependenciesAddRequest) Body(value *ServiceDependency) *ServiceD
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceDependenciesAddRequest) Send() (result *ServiceDependenciesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceDependenciesAddRequest) SendContext(ctx context.Context) (result *ServiceDependenciesAddResponse, err error) {
+func (r *ServiceDependenciesAddRequest) Send(ctx context.Context) (result *ServiceDependenciesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -285,15 +277,7 @@ func (r *ServiceDependenciesListRequest) Size(value int) *ServiceDependenciesLis
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceDependenciesListRequest) Send() (result *ServiceDependenciesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceDependenciesListRequest) SendContext(ctx context.Context) (result *ServiceDependenciesListResponse, err error) {
+func (r *ServiceDependenciesListRequest) Send(ctx context.Context) (result *ServiceDependenciesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.orderBy != nil {
 		helpers.AddValue(&query, "order_by", *r.orderBy)

--- a/statusboard/v1/service_dependency_client.go
+++ b/statusboard/v1/service_dependency_client.go
@@ -124,13 +124,13 @@ func (r *ServiceDependencyPollRequest) Predicate(value func(*ServiceDependencyGe
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *ServiceDependencyPollRequest) StartContext(ctx context.Context) (response *ServiceDependencyPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *ServiceDependencyPollRequest) Start(ctx context.Context) (response *ServiceDependencyPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &ServiceDependencyPollResponse{
 			response: result.(*ServiceDependencyGetResponse),
@@ -142,7 +142,7 @@ func (r *ServiceDependencyPollRequest) StartContext(ctx context.Context) (respon
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *ServiceDependencyPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *ServiceDependencyDeleteRequest) Impersonate(user string) *ServiceDepend
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceDependencyDeleteRequest) Send() (result *ServiceDependencyDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceDependencyDeleteRequest) SendContext(ctx context.Context) (result *ServiceDependencyDeleteResponse, err error) {
+func (r *ServiceDependencyDeleteRequest) Send(ctx context.Context) (result *ServiceDependencyDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *ServiceDependencyGetRequest) Impersonate(user string) *ServiceDependenc
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceDependencyGetRequest) Send() (result *ServiceDependencyGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceDependencyGetRequest) SendContext(ctx context.Context) (result *ServiceDependencyGetResponse, err error) {
+func (r *ServiceDependencyGetRequest) Send(ctx context.Context) (result *ServiceDependencyGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *ServiceDependencyUpdateRequest) Body(value *ServiceDependency) *Service
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServiceDependencyUpdateRequest) Send() (result *ServiceDependencyUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServiceDependencyUpdateRequest) SendContext(ctx context.Context) (result *ServiceDependencyUpdateResponse, err error) {
+func (r *ServiceDependencyUpdateRequest) Send(ctx context.Context) (result *ServiceDependencyUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/services_client.go
+++ b/statusboard/v1/services_client.go
@@ -118,15 +118,7 @@ func (r *ServicesAddRequest) Body(value *Service) *ServicesAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServicesAddRequest) Send() (result *ServicesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServicesAddRequest) SendContext(ctx context.Context) (result *ServicesAddResponse, err error) {
+func (r *ServicesAddRequest) Send(ctx context.Context) (result *ServicesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -303,15 +295,7 @@ func (r *ServicesListRequest) Size(value int) *ServicesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *ServicesListRequest) Send() (result *ServicesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *ServicesListRequest) SendContext(ctx context.Context) (result *ServicesListResponse, err error) {
+func (r *ServicesListRequest) Send(ctx context.Context) (result *ServicesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.fullname != nil {
 		helpers.AddValue(&query, "fullname", *r.fullname)

--- a/statusboard/v1/status_client.go
+++ b/statusboard/v1/status_client.go
@@ -124,13 +124,13 @@ func (r *StatusPollRequest) Predicate(value func(*StatusGetResponse) bool) *Stat
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *StatusPollRequest) StartContext(ctx context.Context) (response *StatusPollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *StatusPollRequest) Start(ctx context.Context) (response *StatusPollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &StatusPollResponse{
 			response: result.(*StatusGetResponse),
@@ -142,7 +142,7 @@ func (r *StatusPollRequest) StartContext(ctx context.Context) (response *StatusP
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *StatusPollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *StatusDeleteRequest) Impersonate(user string) *StatusDeleteRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusDeleteRequest) Send() (result *StatusDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusDeleteRequest) SendContext(ctx context.Context) (result *StatusDeleteResponse, err error) {
+func (r *StatusDeleteRequest) Send(ctx context.Context) (result *StatusDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *StatusGetRequest) Impersonate(user string) *StatusGetRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusGetRequest) Send() (result *StatusGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusGetRequest) SendContext(ctx context.Context) (result *StatusGetResponse, err error) {
+func (r *StatusGetRequest) Send(ctx context.Context) (result *StatusGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *StatusUpdateRequest) Body(value *Status) *StatusUpdateRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusUpdateRequest) Send() (result *StatusUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusUpdateRequest) SendContext(ctx context.Context) (result *StatusUpdateResponse, err error) {
+func (r *StatusUpdateRequest) Send(ctx context.Context) (result *StatusUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/status_update_client.go
+++ b/statusboard/v1/status_update_client.go
@@ -124,13 +124,13 @@ func (r *StatusUpdatePollRequest) Predicate(value func(*StatusUpdateGetResponse)
 	return r
 }
 
-// StartContext starts the polling loop. Responses will be considered successful if the status is one of
+// Start starts the polling loop. Responses will be considered successful if the status is one of
 // the values specified with the Status method and if all the predicates specified with the Predicate
 // method return nil.
 //
 // The context must have a timeout or deadline, otherwise this method will immediately return an error.
-func (r *StatusUpdatePollRequest) StartContext(ctx context.Context) (response *StatusUpdatePollResponse, err error) {
-	result, err := helpers.PollContext(ctx, r.interval, r.statuses, r.predicates, r.task)
+func (r *StatusUpdatePollRequest) Start(ctx context.Context) (response *StatusUpdatePollResponse, err error) {
+	result, err := helpers.Poll(ctx, r.interval, r.statuses, r.predicates, r.task)
 	if result != nil {
 		response = &StatusUpdatePollResponse{
 			response: result.(*StatusUpdateGetResponse),
@@ -142,7 +142,7 @@ func (r *StatusUpdatePollRequest) StartContext(ctx context.Context) (response *S
 // task adapts the types of the request/response types so that they can be used with the generic
 // polling function from the helpers package.
 func (r *StatusUpdatePollRequest) task(ctx context.Context) (status int, result interface{}, err error) {
-	response, err := r.request.SendContext(ctx)
+	response, err := r.request.Send(ctx)
 	if response != nil {
 		status = response.Status()
 		result = response
@@ -230,15 +230,7 @@ func (r *StatusUpdateDeleteRequest) Impersonate(user string) *StatusUpdateDelete
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusUpdateDeleteRequest) Send() (result *StatusUpdateDeleteResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusUpdateDeleteRequest) SendContext(ctx context.Context) (result *StatusUpdateDeleteResponse, err error) {
+func (r *StatusUpdateDeleteRequest) Send(ctx context.Context) (result *StatusUpdateDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -337,15 +329,7 @@ func (r *StatusUpdateGetRequest) Impersonate(user string) *StatusUpdateGetReques
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusUpdateGetRequest) Send() (result *StatusUpdateGetResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusUpdateGetRequest) SendContext(ctx context.Context) (result *StatusUpdateGetResponse, err error) {
+func (r *StatusUpdateGetRequest) Send(ctx context.Context) (result *StatusUpdateGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	uri := &url.URL{
@@ -480,15 +464,7 @@ func (r *StatusUpdateUpdateRequest) Body(value *Status) *StatusUpdateUpdateReque
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusUpdateUpdateRequest) Send() (result *StatusUpdateUpdateResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusUpdateUpdateRequest) SendContext(ctx context.Context) (result *StatusUpdateUpdateResponse, err error) {
+func (r *StatusUpdateUpdateRequest) Send(ctx context.Context) (result *StatusUpdateUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}

--- a/statusboard/v1/status_updates_client.go
+++ b/statusboard/v1/status_updates_client.go
@@ -119,15 +119,7 @@ func (r *StatusUpdatesAddRequest) Body(value *Status) *StatusUpdatesAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusUpdatesAddRequest) Send() (result *StatusUpdatesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusUpdatesAddRequest) SendContext(ctx context.Context) (result *StatusUpdatesAddResponse, err error) {
+func (r *StatusUpdatesAddRequest) Send(ctx context.Context) (result *StatusUpdatesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -304,15 +296,7 @@ func (r *StatusUpdatesListRequest) Size(value int) *StatusUpdatesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusUpdatesListRequest) Send() (result *StatusUpdatesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusUpdatesListRequest) SendContext(ctx context.Context) (result *StatusUpdatesListResponse, err error) {
+func (r *StatusUpdatesListRequest) Send(ctx context.Context) (result *StatusUpdatesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.createdAfter != nil {
 		helpers.AddValue(&query, "created_after", *r.createdAfter)

--- a/statusboard/v1/statuses_client.go
+++ b/statusboard/v1/statuses_client.go
@@ -119,15 +119,7 @@ func (r *StatusesAddRequest) Body(value *Status) *StatusesAddRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusesAddRequest) Send() (result *StatusesAddResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusesAddRequest) SendContext(ctx context.Context) (result *StatusesAddResponse, err error) {
+func (r *StatusesAddRequest) Send(ctx context.Context) (result *StatusesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	header := helpers.CopyHeader(r.header)
 	buffer := &bytes.Buffer{}
@@ -304,15 +296,7 @@ func (r *StatusesListRequest) Size(value int) *StatusesListRequest {
 }
 
 // Send sends this request, waits for the response, and returns it.
-//
-// This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method.
-func (r *StatusesListRequest) Send() (result *StatusesListResponse, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request, waits for the response, and returns it.
-func (r *StatusesListRequest) SendContext(ctx context.Context) (result *StatusesListResponse, err error) {
+func (r *StatusesListRequest) Send(ctx context.Context) (result *StatusesListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
 	if r.createdAfter != nil {
 		helpers.AddValue(&query, "created_after", *r.createdAfter)


### PR DESCRIPTION
This patch makes mandatory the use of a context in the `Send` method and
removes the `SendContext` method.