### PR TITLE
Make context mandatory for getting tokens

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -34,6 +34,12 @@ import (
 )
 
 var _ = Describe("Connection", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
 	It("Can be created with access token", func() {
 		accessToken := MakeTokenString("Bearer", 5*time.Minute)
 		connection, err := NewConnection().
@@ -204,9 +210,9 @@ var _ = Describe("Connection", func() {
 		// Try to get the tokens using a explicit and short timeout to make the test run
 		// faster (by default it takes up to 15 seconds) but give it enough time to retry
 		// a few times:
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		_, _, err = connection.TokensContext(ctx)
+		_, _, err = connection.Tokens(ctx)
 
 		// Check that the transport was called at least three times:
 		Expect(transport.called).To(BeNumerically(">=", 3))
@@ -408,7 +414,7 @@ var _ = Describe("Connection", func() {
 		client, secret := connection.Client()
 		Expect(client).To(Equal("myclient"))
 		Expect(secret).To(Equal("mysecret"))
-		returnedAccess, returnedRefresh, err := connection.Tokens()
+		returnedAccess, returnedRefresh, err := connection.Tokens(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(returnedAccess).To(Equal(fileAccess))
 		Expect(returnedRefresh).To(Equal(fileRefresh))
@@ -503,7 +509,7 @@ var _ = Describe("Connection", func() {
 		client, secret := connection.Client()
 		Expect(client).To(Equal("myclient"))
 		Expect(secret).To(Equal("mysecret"))
-		returnedAccess, returnedRefresh, err := connection.Tokens()
+		returnedAccess, returnedRefresh, err := connection.Tokens(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(returnedAccess).To(Equal(fileAccess))
 		Expect(returnedRefresh).To(Equal(fileRefresh))
@@ -614,7 +620,7 @@ var _ = Describe("Connection", func() {
 		client, secret := connection.Client()
 		Expect(client).To(Equal("overriden.myclient"))
 		Expect(secret).To(Equal("overriden.mysecret"))
-		returnedAccess, returnedRefresh, err := connection.Tokens()
+		returnedAccess, returnedRefresh, err := connection.Tokens(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(returnedAccess).To(Equal(overridenAccess))
 		Expect(returnedRefresh).To(Equal(overridenRefresh))
@@ -724,7 +730,7 @@ var _ = Describe("Connection", func() {
 		client, secret := connection.Client()
 		Expect(client).To(Equal("myclient"))
 		Expect(secret).To(Equal("mysecret"))
-		returnedAccess, returnedRefresh, err := connection.Tokens()
+		returnedAccess, returnedRefresh, err := connection.Tokens(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(returnedAccess).To(Equal(fileAccess))
 		Expect(returnedRefresh).To(Equal(fileRefresh))

--- a/token.go
+++ b/token.go
@@ -25,30 +25,12 @@ import (
 	"time"
 )
 
-// Tokens returns the access and refresh tokens that are currently in use by the connection. If it
+// Tokens returns the access and refresh tokens that are currently in use by the connection.  If it
 // is necessary to request new tokens because they weren't requested yet, or because they are
 // expired, this method will do it and will return an error if it fails.
 //
 // If new tokens are needed the request will be retried with an exponential backoff.
-//
-// This operation is potentially lengthy, as it may require network communication. Consider using a
-// context and the TokensContext method.
-func (c *Connection) Tokens(expiresIn ...time.Duration) (access, refresh string, err error) {
-	if len(expiresIn) == 1 {
-		access, refresh, err = c.TokensContext(context.Background(), expiresIn[0])
-	} else {
-		access, refresh, err = c.TokensContext(context.Background())
-	}
-	return
-
-}
-
-// TokensContext returns the access and refresh tokens that are currently in use by the connection.
-// If it is necessary to request new tokens because they weren't requested yet, or because they are
-// expired, this method will do it and will return an error if it fails.
-//
-// If new tokens are needed the request will be retried with an exponential backoff.
-func (c *Connection) TokensContext(ctx context.Context, expiresIn ...time.Duration) (access,
+func (c *Connection) Tokens(ctx context.Context, expiresIn ...time.Duration) (access,
 	refresh string, err error) {
 	access, refresh, err = c.authnWrapper.Tokens(ctx, expiresIn...)
 	return


### PR DESCRIPTION
This patch removes the `TokensContext` method and makes the context
parameter mandatory for the `Tokens` method.