### PR TITLE
Make context mandatory in raw HTTP methods

### DIFF
--- a/alternative_url_test.go
+++ b/alternative_url_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Alternative URLs", func() {
 			// Send the request:
 			_, err = connection.Get().
 				Path("/api/clusters_mgmt").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -159,7 +159,7 @@ var _ = Describe("Alternative URLs", func() {
 			// Send the request:
 			_, err = connection.Get().
 				Path("/api/clusters_mgmt").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -194,7 +194,7 @@ var _ = Describe("Alternative URLs", func() {
 			// Send the request:
 			_, err = connection.Get().
 				Path("/api/clusters_mgmt/v1").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/h2c_test.go
+++ b/h2c_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package sdk
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,12 +35,16 @@ import (
 
 var _ = Describe("H2C", func() {
 	var (
+		ctx          context.Context
 		accessToken  string
 		refreshToken string
 		oidServer    *ghttp.Server
 	)
 
 	BeforeEach(func() {
+		// Create the context:
+		ctx = context.Background()
+
 		// Create the tokens:
 		accessToken = MakeTokenString("Bearer", 5*time.Minute)
 		refreshToken = MakeTokenString("Refresh", 10*time.Hour)
@@ -110,7 +115,7 @@ var _ = Describe("H2C", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.String()).To(MatchJSON(`{
@@ -174,7 +179,7 @@ var _ = Describe("H2C", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.String()).To(MatchJSON(`{

--- a/methods_test.go
+++ b/methods_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			_, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -128,7 +128,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			_, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -145,7 +145,7 @@ var _ = Describe("Methods", func() {
 			_, err := connection.Get().
 				Path("/mypath").
 				Parameter("myparameter", "myvalue").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("Methods", func() {
 				Path("/mypath").
 				Parameter("myparameter", "myvalue").
 				Parameter("yourparameter", "yourvalue").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -181,7 +181,7 @@ var _ = Describe("Methods", func() {
 			_, err := connection.Get().
 				Path("/mypath").
 				Header("myheader", "myvalue").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -200,7 +200,7 @@ var _ = Describe("Methods", func() {
 				Path("/mypath").
 				Header("myheader", "myvalue").
 				Header("yourheader", "yourvalue").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -213,7 +213,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusOK))
@@ -230,7 +230,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusOK))
@@ -245,7 +245,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusBadRequest))
@@ -260,7 +260,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusInternalServerError))
@@ -268,7 +268,7 @@ var _ = Describe("Methods", func() {
 
 		It("Fails if no path is given", func() {
 			response, err := connection.Get().
-				Send()
+				Send(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("path"))
 			Expect(err.Error()).To(ContainSubstring("mandatory"))
@@ -291,14 +291,14 @@ var _ = Describe("Methods", func() {
 			// Send first request. The server will respond setting a cookie.
 			_, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send second request, which should include the cookie returned by the
 			// server in the first response.
 			_, err = connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -320,7 +320,7 @@ var _ = Describe("Methods", func() {
 			defer cancel()
 			_, err := connection.Get().
 				Path("/mypath").
-				SendContext(ctx)
+				Send(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
 		})
@@ -339,7 +339,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			_, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -354,7 +354,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Post().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusOK))
@@ -422,7 +422,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Patch().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusOK))
@@ -439,7 +439,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Put().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusOK))
@@ -462,7 +462,7 @@ var _ = Describe("Methods", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/api/clusters_mgmt/v1/clusters").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.Status()).To(Equal(http.StatusOK))
@@ -485,7 +485,7 @@ var _ = Describe("Methods", func() {
 			// Try to get the access token:
 			_, err := connection.Get().
 				Path("/api/clusters_mgmt/v1/clusters").
-				Send()
+				Send(ctx)
 			Expect(err).To(HaveOccurred())
 			message := err.Error()
 			Expect(message).To(ContainSubstring("text/plain"))
@@ -504,7 +504,7 @@ var _ = Describe("Methods", func() {
 			// Try to get the access token:
 			_, err := connection.Get().
 				Path("/api/clusters_mgmt/v1/clusters").
-				Send()
+				Send(ctx)
 			Expect(err).To(HaveOccurred())
 			message := err.Error()
 			Expect(message).To(ContainSubstring("text/html"))
@@ -523,7 +523,7 @@ var _ = Describe("Methods", func() {
 			// Try to get the access token:
 			_, err := connection.Get().
 				Path("/api/clusters_mgmt/v1/clusters").
-				Send()
+				Send(ctx)
 			Expect(err).To(HaveOccurred())
 			message := err.Error()
 			Expect(message).To(ContainSubstring("text/html"))

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Metrics enabled", func() {
 		// Send the request:
 		_, err := connection.Get().
 			Path("/api/clusters_mgmt/v1/clusters/123").
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the metrics:
@@ -214,7 +214,7 @@ var _ = Describe("Metrics disabled", func() {
 		// Send the request:
 		_, err := connection.Get().
 			Path("/api/clusters_mgmt/v1/clusters/123").
-			Send()
+			Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the metrics:

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Redirect", func() {
 			// Send the request:
 			_, err := connection.Get().
 				Path("/api/clusters_mgmt/v1").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -149,7 +149,7 @@ var _ = Describe("Redirect", func() {
 			// Send the request:
 			_, err := connection.Get().
 				Path("/api/clusters_mgmt/v1").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/request.go
+++ b/request.go
@@ -89,18 +89,7 @@ func (r *Request) String(value string) *Request {
 // something fails. Note that any HTTP status code returned by the server is considered a valid
 // response, and will not be translated into an error. It is up to the caller to check the status
 // code and handle it.
-//
-// This operation is potentially lengthy, as it requires network communication. Consider using a
-// context and the SendContext method.
-func (r *Request) Send() (result *Response, err error) {
-	return r.SendContext(context.Background())
-}
-
-// SendContext sends this request to the server and returns the corresponding response, or an error
-// if something fails. Note that any HTTP status code returned by the server is considered a valid
-// response, and will not be translated into an error. It is up to the caller to check the status
-// code and handle it.
-func (r *Request) SendContext(ctx context.Context) (result *Response, err error) {
+func (r *Request) Send(ctx context.Context) (result *Response, err error) {
 	query := internal.CopyQuery(r.query)
 	header := internal.CopyHeader(r.header)
 	uri := &url.URL{

--- a/retry_test.go
+++ b/retry_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Retry", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
-			response, err := connection.Get().Path("/mypath").Send()
+			response, err := connection.Get().Path("/mypath").Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 		})
@@ -80,7 +80,7 @@ var _ = Describe("Retry", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
-			response, err := connection.Get().Path("/mypath").Send()
+			response, err := connection.Get().Path("/mypath").Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 		})
@@ -102,7 +102,7 @@ var _ = Describe("Retry", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
-			response, err := connection.Get().Path("/mypath").Send()
+			response, err := connection.Get().Path("/mypath").Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 		})
@@ -126,7 +126,7 @@ var _ = Describe("Retry", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
-			response, err := connection.Delete().Path("/mypath").Send()
+			response, err := connection.Delete().Path("/mypath").Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 		})
@@ -150,7 +150,7 @@ var _ = Describe("Retry", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
-			response, err := connection.Post().Path("/mypath").String("{}").Send()
+			response, err := connection.Post().Path("/mypath").String("{}").Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 		})
@@ -175,7 +175,7 @@ var _ = Describe("Retry", func() {
 			response, err := connection.Post().
 				Path("/mypath").
 				String(`{}`).
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 		})
@@ -200,7 +200,7 @@ var _ = Describe("Retry", func() {
 			response, err := connection.Post().
 				Path("/mypath").
 				String(`{}`).
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 		})
@@ -227,7 +227,7 @@ var _ = Describe("Retry", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Send the request:
-		response, err := connection.Get().Path("/mypath").Send()
+		response, err := connection.Get().Path("/mypath").Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 
@@ -262,7 +262,7 @@ var _ = Describe("Retry", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Send the request:
-		response, err := connection.Get().Path("/mypath").Send()
+		response, err := connection.Get().Path("/mypath").Send(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 

--- a/unix_sockets_test.go
+++ b/unix_sockets_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package sdk
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 )
 
 var _ = Describe("Unix sockets", func() {
+	var ctx context.Context
 	var accessToken string
 	var refreshToken string
 	var oidServer *ghttp.Server
@@ -39,6 +41,9 @@ var _ = Describe("Unix sockets", func() {
 	var oidURL string
 
 	BeforeEach(func() {
+		// Create the context:
+		ctx = context.Background()
+
 		// Create the tokens:
 		accessToken = MakeTokenString("Bearer", 5*time.Minute)
 		refreshToken = MakeTokenString("Refresh", 10*time.Hour)
@@ -109,7 +114,7 @@ var _ = Describe("Unix sockets", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.String()).To(MatchJSON(`{
@@ -173,7 +178,7 @@ var _ = Describe("Unix sockets", func() {
 			// Send the request:
 			response, err := connection.Get().
 				Path("/mypath").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			Expect(response.String()).To(MatchJSON(`{
@@ -248,7 +253,7 @@ var _ = Describe("Unix sockets", func() {
 			// Send a request to the Unix server:
 			unixResponse, err := connection.Get().
 				Path("/api/clusters_mgmt").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(unixResponse.String()).To(MatchJSON(`{
 				"href": "/api/clusters_mgmt"
@@ -257,7 +262,7 @@ var _ = Describe("Unix sockets", func() {
 			// Send a request to the TCP server:
 			tcpResponse, err := connection.Get().
 				Path("/api/accounts_mgmt").
-				Send()
+				Send(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tcpResponse.String()).To(MatchJSON(`{
 				"href": "/api/accounts_mgmt"


### PR DESCRIPTION
This patch makes the context parameter mandatory in the raw HTTP `Send`
methods.