### PR TITLE
Remove context from `Build` methods

### DIFF
--- a/authentication/handler.go
+++ b/authentication/handler.go
@@ -571,7 +571,7 @@ func (h *Handler) loadKeys(ctx context.Context) error {
 			"Loading keys",
 			"file", keysFile,
 		)
-		err := h.loadKeysFile(ctx, keysFile)
+		err := h.loadKeysFile(keysFile)
 		if err != nil {
 			h.logger.Error(
 				err,
@@ -601,12 +601,12 @@ func (h *Handler) loadKeys(ctx context.Context) error {
 }
 
 // loadKeysFile loads a JSON we key set from a file.
-func (h *Handler) loadKeysFile(ctx context.Context, file string) error {
+func (h *Handler) loadKeysFile(file string) error {
 	reader, err := os.Open(file) // nolint
 	if err != nil {
 		return err
 	}
-	return h.readKeys(ctx, reader)
+	return h.readKeys(reader)
 }
 
 // loadKeysURL loads a JSON we key set from an URL.
@@ -630,11 +630,11 @@ func (h *Handler) loadKeysURL(ctx context.Context, addr string) error {
 			)
 		}
 	}()
-	return h.readKeys(ctx, response.Body)
+	return h.readKeys(response.Body)
 }
 
 // readKeys reads the keys from JSON web key set available in the given reader.
-func (h *Handler) readKeys(ctx context.Context, reader io.Reader) error {
+func (h *Handler) readKeys(reader io.Reader) error {
 	// Read the JSON data:
 	jsonData, err := ioutil.ReadAll(reader)
 	if err != nil {

--- a/authentication/transport_wrapper.go
+++ b/authentication/transport_wrapper.go
@@ -320,7 +320,7 @@ func (b *TransportWrapperBuilder) MetricsRegisterer(
 }
 
 // Build uses the information stored in the builder to create a new transport wrapper.
-func (b *TransportWrapperBuilder) Build(ctx context.Context) (result *TransportWrapper, err error) {
+func (b *TransportWrapperBuilder) Build() (result *TransportWrapper, err error) {
 	// Check parameters:
 	if b.logger.GetSink() == nil {
 		err = fmt.Errorf("logger is mandatory")
@@ -450,7 +450,7 @@ func (b *TransportWrapperBuilder) Build(ctx context.Context) (result *TransportW
 			"default", tokenURL,
 		)
 	}
-	tokenServer, err := internal.ParseServerAddress(ctx, tokenURL)
+	tokenServer, err := internal.ParseServerAddress(tokenURL)
 	if err != nil {
 		err = fmt.Errorf("can't parse token URL '%s': %w", tokenURL, err)
 		return
@@ -488,7 +488,7 @@ func (b *TransportWrapperBuilder) Build(ctx context.Context) (result *TransportW
 		TrustedCAs(b.trustedCAs...).
 		Insecure(b.insecure).
 		TransportWrappers(b.transportWrappers...).
-		Build(ctx)
+		Build()
 	if err != nil {
 		return
 	}
@@ -741,8 +741,8 @@ func (w *TransportWrapper) tokens(ctx context.Context, attempt int,
 		}
 	}
 	if w.logger.V(1).Enabled() {
-		w.debugExpiry(ctx, "bearer", w.accessToken, accessExpires, accessRemaining)
-		w.debugExpiry(ctx, "refresh", w.refreshToken, refreshExpires, refreshRemaining)
+		w.debugExpiry("bearer", w.accessToken, accessExpires, accessRemaining)
+		w.debugExpiry("refresh", w.refreshToken, refreshExpires, refreshRemaining)
 	}
 
 	// If the access token is available and it isn't expired or about to expire then we can
@@ -930,7 +930,7 @@ func (w *TransportWrapper) sendFormTimed(ctx context.Context, form url.Values) (
 	}
 
 	// Select the HTTP client:
-	client, err := w.clientSelector.Select(ctx, w.tokenServer)
+	client, err := w.clientSelector.Select(w.tokenServer)
 	if err != nil {
 		return
 	}
@@ -1057,8 +1057,8 @@ func (w *TransportWrapper) haveSecret() bool {
 }
 
 // debugExpiry sends to the log information about the expiration of the given token.
-func (w *TransportWrapper) debugExpiry(ctx context.Context, typ string, token *tokenInfo,
-	expires bool, left time.Duration) {
+func (w *TransportWrapper) debugExpiry(typ string, token *tokenInfo, expires bool,
+	left time.Duration) {
 	if token != nil {
 		if expires {
 			if left < 0 {

--- a/authentication/transport_wrapper_test.go
+++ b/authentication/transport_wrapper_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Tokens", func() {
 			TokenURL(server.URL()).
 			TrustedCA(ca).
 			Tokens(accessToken, refreshToken).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			err = wrapper.Close()
@@ -115,7 +115,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -154,7 +154,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(accessToken, refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -187,7 +187,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -225,7 +225,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(expiredAccess, refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -258,7 +258,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(expiredAccess, refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -291,7 +291,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(firstAccess, refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -327,7 +327,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(firstAccess, refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -350,7 +350,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(accessToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -372,7 +372,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(accessToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -394,7 +394,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -432,7 +432,7 @@ var _ = Describe("Tokens", func() {
 					TokenURL(server.URL()).
 					TrustedCA(ca).
 					Tokens(refreshToken).
-					Build(ctx)
+					Build()
 				Expect(err).ToNot(HaveOccurred())
 				defer func() {
 					err = wrapper.Close()
@@ -475,7 +475,7 @@ var _ = Describe("Tokens", func() {
 					TokenURL(server.URL()).
 					TrustedCA(ca).
 					Tokens(refreshToken).
-					Build(ctx)
+					Build()
 				Expect(err).ToNot(HaveOccurred())
 				defer func() {
 					err = wrapper.Close()
@@ -516,7 +516,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(expiredAccess, refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -555,7 +555,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -594,7 +594,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -632,7 +632,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -675,7 +675,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -718,7 +718,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -751,7 +751,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("baduser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -778,7 +778,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "badpassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -814,7 +814,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -850,7 +850,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -881,7 +881,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -913,7 +913,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				User("myuser", "mypassword").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -939,7 +939,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(accessToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -963,7 +963,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(accessToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -997,7 +997,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Client("myclient", "mysecret").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1031,7 +1031,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Client("myclient", "mysecret").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1064,7 +1064,7 @@ var _ = Describe("Tokens", func() {
 				TrustedCA(ca).
 				Client("myclient", "mysecret").
 				Tokens(expiredAccess).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1092,7 +1092,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Client("badclient", "mysecret").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1119,7 +1119,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Client("myclient", "badsecret").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1155,7 +1155,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Client("myclient", "mysecret").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1192,7 +1192,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Client("myclient", "mysecret").
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1234,7 +1234,7 @@ var _ = Describe("Tokens", func() {
 				TrustedCA(ca).
 				Client("myclient", "mysecret").
 				Tokens(expiredAccess, validRefresh).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1287,7 +1287,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1328,7 +1328,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1363,7 +1363,7 @@ var _ = Describe("Tokens", func() {
 				TokenURL(server.URL()).
 				TrustedCA(ca).
 				Tokens(refreshToken).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -1410,7 +1410,7 @@ var _ = Describe("Tokens", func() {
 			TokenURL(server.URL()).
 			TrustedCA(ca).
 			Tokens(accessToken, refreshToken, pullSecretAccessToken).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			err = wrapper.Close()

--- a/examples/client_credentials_grant.go
+++ b/examples/client_credentials_grant.go
@@ -32,7 +32,7 @@ func clientCredentialsGrant(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Client("myclientid", "myclientsecret").
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/create_cluster.go
+++ b/examples/create_cluster.go
@@ -31,7 +31,7 @@ func createCluster(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/create_product.go
+++ b/examples/create_product.go
@@ -32,7 +32,7 @@ func createProduct(ctx context.Context, args []string) error {
 		Logger(logger).
 		URL("http://localhost:8000").
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/create_syncset.go
+++ b/examples/create_syncset.go
@@ -35,7 +35,7 @@ func createSyncset(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/delete_cluster.go
+++ b/examples/delete_cluster.go
@@ -31,7 +31,7 @@ func deleteCluster(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/delete_product.go
+++ b/examples/delete_product.go
@@ -32,7 +32,7 @@ func deleteProduct(ctx context.Context, args []string) error {
 		Logger(logger).
 		URL("http://localhost:8000").
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/delete_subscription.go
+++ b/examples/delete_subscription.go
@@ -31,7 +31,7 @@ func deleteSubscription(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/existing_token.go
+++ b/examples/existing_token.go
@@ -46,7 +46,7 @@ func existingToken(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(string(accessToken), string(refreshToken)).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/export_control_review.go
+++ b/examples/export_control_review.go
@@ -33,7 +33,7 @@ func exportControlReview(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/get_cluster_credentials.go
+++ b/examples/get_cluster_credentials.go
@@ -32,7 +32,7 @@ func getClusterCredentials(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/get_cluster_logs.go
+++ b/examples/get_cluster_logs.go
@@ -33,7 +33,7 @@ func getClusterLogs(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_applications.go
+++ b/examples/list_applications.go
@@ -35,7 +35,7 @@ func listApplications(ctx context.Context, args []string) error {
 		Logger(logger).
 		URL("http://localhost:8000").
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_cloud_providers.go
+++ b/examples/list_cloud_providers.go
@@ -33,7 +33,7 @@ func listCloudProviders(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_cluster_creators.go
+++ b/examples/list_cluster_creators.go
@@ -34,7 +34,7 @@ func listClusterCreators(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_clusters.go
+++ b/examples/list_clusters.go
@@ -33,7 +33,7 @@ func listClusters(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_products.go
+++ b/examples/list_products.go
@@ -35,7 +35,7 @@ func listProducts(ctx context.Context, args []string) error {
 		Logger(logger).
 		URL("http://localhost:8000").
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_quota_cost.go
+++ b/examples/list_quota_cost.go
@@ -33,7 +33,7 @@ func listQuotaCost(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_status_updates.go
+++ b/examples/list_status_updates.go
@@ -35,7 +35,7 @@ func listStatusUpdates(ctx context.Context, args []string) error {
 		Logger(logger).
 		URL("http://localhost:8000").
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/list_versions.go
+++ b/examples/list_versions.go
@@ -33,7 +33,7 @@ func listVersions(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/load_config.go
+++ b/examples/load_config.go
@@ -32,7 +32,7 @@ func loadConfig(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Load("load_config.yaml").
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -43,7 +43,7 @@ func prometheusMetrics(ctx context.Context, args []string) error {
 		Logger(logger).
 		Tokens(token).
 		MetricsSubsystem("api_outbound").
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/pushpop_job_queue.go
+++ b/examples/pushpop_job_queue.go
@@ -32,7 +32,7 @@ func pushpopJobQueue(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/resource_review.go
+++ b/examples/resource_review.go
@@ -33,7 +33,7 @@ func resourceReview(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/run_cluster_operator_metrics.go
+++ b/examples/run_cluster_operator_metrics.go
@@ -32,7 +32,7 @@ func runClusterOperatorMetrics(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/run_metric_query.go
+++ b/examples/run_metric_query.go
@@ -32,7 +32,7 @@ func runMetricQuery(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/sync_addons.go
+++ b/examples/sync_addons.go
@@ -36,7 +36,7 @@ func syncAddons(ctx context.Context, args []string) error {
 		URL("https://clusters-service.apps-crc.testing").
 		Insecure(true).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/transport_wrapper.go
+++ b/examples/transport_wrapper.go
@@ -66,7 +66,7 @@ func transportWrapper(ctx context.Context, args []string) error {
 		TransportWrapper(func(wrapped http.RoundTripper) http.RoundTripper {
 			return NewLoggingTransport(logger, wrapped)
 		}).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/update_cluster.go
+++ b/examples/update_cluster.go
@@ -32,7 +32,7 @@ func updateCluster(ctx context.Context, args []string) error {
 	connection, err := sdk.NewConnection().
 		Logger(logger).
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/examples/update_product.go
+++ b/examples/update_product.go
@@ -33,7 +33,7 @@ func updateProduct(ctx context.Context, args []string) error {
 		Logger(logger).
 		URL("http://localhost:8000").
 		Tokens(token).
-		BuildContext(ctx)
+		Build()
 	if err != nil {
 		return err
 	}

--- a/internal/client_selector_test.go
+++ b/internal/client_selector_test.go
@@ -17,15 +17,13 @@ limitations under the License.
 package internal
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
 	. "github.com/onsi/gomega"             // nolint
 )
 
 var _ = Describe("Create client selector", func() {
 	It("Can't be created without a logger", func() {
-		selector, err := NewClientSelector().Build(context.Background())
+		selector, err := NewClientSelector().Build()
 		Expect(err).To(HaveOccurred())
 		Expect(selector).To(BeNil())
 		message := err.Error()
@@ -36,20 +34,16 @@ var _ = Describe("Create client selector", func() {
 
 var _ = Describe("Select client", func() {
 	var (
-		ctx      context.Context
 		selector *ClientSelector
 	)
 
 	BeforeEach(func() {
 		var err error
 
-		// Create a context:
-		ctx = context.Background()
-
 		// Create the selector:
 		selector, err = NewClientSelector().
 			Logger(logger).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(selector).ToNot(BeNil())
 	})
@@ -61,47 +55,47 @@ var _ = Describe("Select client", func() {
 	})
 
 	It("Reuses client for same TCP address", func() {
-		address, err := ParseServerAddress(ctx, "tcp://my.server.com")
+		address, err := ParseServerAddress("tcp://my.server.com")
 		Expect(err).ToNot(HaveOccurred())
-		firstClient, err := selector.Select(ctx, address)
+		firstClient, err := selector.Select(address)
 		Expect(err).ToNot(HaveOccurred())
-		secondClient, err := selector.Select(ctx, address)
+		secondClient, err := selector.Select(address)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(secondClient).To(BeIdenticalTo(firstClient))
 	})
 
 	It("Doesn't reuse client for different TCP addresses", func() {
-		firstAddress, err := ParseServerAddress(ctx, "tcp://my.server.com")
+		firstAddress, err := ParseServerAddress("tcp://my.server.com")
 		Expect(err).ToNot(HaveOccurred())
-		secondAddress, err := ParseServerAddress(ctx, "tcp://your.server.com")
+		secondAddress, err := ParseServerAddress("tcp://your.server.com")
 		Expect(err).ToNot(HaveOccurred())
-		firstClient, err := selector.Select(ctx, firstAddress)
+		firstClient, err := selector.Select(firstAddress)
 		Expect(err).ToNot(HaveOccurred())
-		secondClient, err := selector.Select(ctx, secondAddress)
+		secondClient, err := selector.Select(secondAddress)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(secondClient == firstClient).To(BeFalse())
 	})
 
 	It("Reuses client for different TCP protocols", func() {
-		firstAddress, err := ParseServerAddress(ctx, "http://my.server.com")
+		firstAddress, err := ParseServerAddress("http://my.server.com")
 		Expect(err).ToNot(HaveOccurred())
-		secondAddress, err := ParseServerAddress(ctx, "https://my.server.com")
+		secondAddress, err := ParseServerAddress("https://my.server.com")
 		Expect(err).ToNot(HaveOccurred())
-		firstClient, err := selector.Select(ctx, firstAddress)
+		firstClient, err := selector.Select(firstAddress)
 		Expect(err).ToNot(HaveOccurred())
-		secondClient, err := selector.Select(ctx, secondAddress)
+		secondClient, err := selector.Select(secondAddress)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(secondClient == firstClient).To(BeTrue())
 	})
 
 	It("Doesn't resuse client for different Unix sockets", func() {
-		firstAddress, err := ParseServerAddress(ctx, "unix://my.server.com/my.socket")
+		firstAddress, err := ParseServerAddress("unix://my.server.com/my.socket")
 		Expect(err).ToNot(HaveOccurred())
-		secondAddress, err := ParseServerAddress(ctx, "unix://my.server.com/your.socket")
+		secondAddress, err := ParseServerAddress("unix://my.server.com/your.socket")
 		Expect(err).ToNot(HaveOccurred())
-		firstClient, err := selector.Select(ctx, firstAddress)
+		firstClient, err := selector.Select(firstAddress)
 		Expect(err).ToNot(HaveOccurred())
-		secondClient, err := selector.Select(ctx, secondAddress)
+		secondClient, err := selector.Select(secondAddress)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(secondClient == firstClient).To(BeFalse())
 	})

--- a/internal/server_address.go
+++ b/internal/server_address.go
@@ -19,7 +19,6 @@ limitations under the License.
 package internal
 
 import (
-	"context"
 	"fmt"
 	neturl "net/url"
 	"strings"
@@ -95,7 +94,7 @@ type ServerAddress struct {
 //	- unix://my.server.com/sockets/my.socket - HTTP on top Unix socket.
 //	- unix+https://my.server.com/sockets/my.socket - HTTPS on top of Unix socket.
 //	- h2c+unix://my.server.com?socket=/sockets/my.socket - H2C on top of Unix.
-func ParseServerAddress(ctx context.Context, text string) (result *ServerAddress, err error) {
+func ParseServerAddress(text string) (result *ServerAddress, err error) {
 	// Parse the URL:
 	parsed, err := neturl.Parse(text)
 	if err != nil {
@@ -104,7 +103,7 @@ func ParseServerAddress(ctx context.Context, text string) (result *ServerAddress
 	query := parsed.Query()
 
 	// Extract the network and protocol from the scheme:
-	networkFromScheme, protocolFromScheme, err := parseScheme(ctx, parsed.Scheme)
+	networkFromScheme, protocolFromScheme, err := parseScheme(parsed.Scheme)
 	if err != nil {
 		return
 	}
@@ -255,7 +254,7 @@ func ParseServerAddress(ctx context.Context, text string) (result *ServerAddress
 	return
 }
 
-func parseScheme(ctx context.Context, scheme string) (network, protocol string,
+func parseScheme(scheme string) (network, protocol string,
 	err error) {
 	components := strings.Split(strings.ToLower(scheme), "+")
 	if len(components) > 2 {

--- a/internal/server_address_test.go
+++ b/internal/server_address_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package internal
 
 import (
-	"context"
 	"net/url"
 
 	. "github.com/onsi/ginkgo/v2/dsl/table" // nolint
@@ -27,7 +26,7 @@ import (
 var _ = DescribeTable(
 	"Parsing success",
 	func(input string, expected *ServerAddress) {
-		actual, err := ParseServerAddress(context.Background(), input)
+		actual, err := ParseServerAddress(input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual.Text).To(Equal(input))
 		Expect(actual.Network).To(Equal(expected.Network))
@@ -388,7 +387,7 @@ var _ = DescribeTable(
 var _ = DescribeTable(
 	"Parsing error",
 	func(input string, expected ...string) {
-		actual, err := ParseServerAddress(context.Background(), input)
+		actual, err := ParseServerAddress(input)
 		Expect(err).To(HaveOccurred())
 		Expect(actual).To(BeNil())
 		message := err.Error()

--- a/retry/transport_wrapper.go
+++ b/retry/transport_wrapper.go
@@ -113,7 +113,7 @@ func (b *TransportWrapperBuilder) Jitter(value float64) *TransportWrapperBuilder
 }
 
 // Build uses the information stored in the builder to create a new transport wrapper.
-func (b *TransportWrapperBuilder) Build(ctx context.Context) (result *TransportWrapper, err error) {
+func (b *TransportWrapperBuilder) Build() (result *TransportWrapper, err error) {
 	// Check parameters:
 	if b.logger.GetSink() == nil {
 		err = fmt.Errorf("logger is mandatory")

--- a/retry/transport_wrapper_test.go
+++ b/retry/transport_wrapper_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package retry
 
 import (
-	"context"
 	"crypto/tls"
 	"io/ioutil"
 	"net"
@@ -36,15 +35,9 @@ import (
 )
 
 var _ = Describe("Creation", func() {
-	var ctx context.Context
-
-	BeforeEach(func() {
-		ctx = context.Background()
-	})
-
 	It("Can't be created without a logger", func() {
 		wrapper, err := NewTransportWrapper().
-			Build(ctx)
+			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(wrapper).To(BeNil())
 		message := err.Error()
@@ -56,7 +49,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Limit(10).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(wrapper).ToNot(BeNil())
 		err = wrapper.Close()
@@ -67,7 +60,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Limit(0).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(wrapper).ToNot(BeNil())
 		err = wrapper.Close()
@@ -78,7 +71,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Limit(-1).
-			Build(ctx)
+			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(wrapper).To(BeNil())
 		message := err.Error()
@@ -91,7 +84,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Interval(5 * time.Second).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(wrapper).ToNot(BeNil())
 		err = wrapper.Close()
@@ -102,7 +95,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Interval(0).
-			Build(ctx)
+			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(wrapper).To(BeNil())
 		message := err.Error()
@@ -115,7 +108,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Interval(0).
-			Build(ctx)
+			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(wrapper).To(BeNil())
 		message := err.Error()
@@ -128,7 +121,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Jitter(0.3).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(wrapper).ToNot(BeNil())
 		err = wrapper.Close()
@@ -139,7 +132,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Jitter(0.0).
-			Build(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(wrapper).ToNot(BeNil())
 		err = wrapper.Close()
@@ -150,7 +143,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Jitter(-1).
-			Build(ctx)
+			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(wrapper).To(BeNil())
 		message := err.Error()
@@ -163,7 +156,7 @@ var _ = Describe("Creation", func() {
 		wrapper, err := NewTransportWrapper().
 			Logger(logger).
 			Jitter(2).
-			Build(ctx)
+			Build()
 		Expect(err).To(HaveOccurred())
 		Expect(wrapper).To(BeNil())
 		message := err.Error()
@@ -174,12 +167,6 @@ var _ = Describe("Creation", func() {
 })
 
 var _ = Describe("Server error", func() {
-	var ctx context.Context
-
-	BeforeEach(func() {
-		ctx = context.Background()
-	})
-
 	When("Retry enabled", func() {
 		It("Retries 503 without request body", func() {
 			// Create a transport that returns a 503 error for the first request and 200
@@ -193,7 +180,7 @@ var _ = Describe("Server error", func() {
 			wrapper, err := NewTransportWrapper().
 				Logger(logger).
 				Interval(100 * time.Millisecond).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -228,7 +215,7 @@ var _ = Describe("Server error", func() {
 			wrapper, err := NewTransportWrapper().
 				Logger(logger).
 				Interval(100 * time.Millisecond).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -267,7 +254,7 @@ var _ = Describe("Server error", func() {
 			wrapper, err := NewTransportWrapper().
 				Logger(logger).
 				Interval(100 * time.Millisecond).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -302,7 +289,7 @@ var _ = Describe("Server error", func() {
 			wrapper, err := NewTransportWrapper().
 				Logger(logger).
 				Interval(100 * time.Millisecond).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -344,7 +331,7 @@ var _ = Describe("Server error", func() {
 				Logger(logger).
 				Limit(0).
 				Interval(100 * time.Millisecond).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -380,7 +367,7 @@ var _ = Describe("Server error", func() {
 				Logger(logger).
 				Limit(0).
 				Interval(100 * time.Millisecond).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -406,15 +393,11 @@ var _ = Describe("Server error", func() {
 })
 
 var _ = Describe("Protocol error", func() {
-	var ctx context.Context
 	var listener net.Listener
 	var address string
 	var transport http.RoundTripper
 
 	BeforeEach(func() {
-		// Create a context:
-		ctx = context.Background()
-
 		// Create a listener:
 		listener, address = Listen()
 
@@ -459,7 +442,7 @@ var _ = Describe("Protocol error", func() {
 			wrapper, err := NewTransportWrapper().
 				Logger(logger).
 				Interval(100 * time.Millisecond).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -502,7 +485,7 @@ var _ = Describe("Protocol error", func() {
 				Limit(3).
 				Interval(100 * time.Millisecond).
 				Jitter(0).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -578,7 +561,7 @@ var _ = Describe("Protocol error", func() {
 				Limit(3).
 				Interval(100 * time.Millisecond).
 				Jitter(0).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -613,7 +596,7 @@ var _ = Describe("Protocol error", func() {
 				Limit(0).
 				Interval(100 * time.Millisecond).
 				Jitter(0).
-				Build(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = wrapper.Close()
@@ -636,9 +619,6 @@ var _ = Describe("Protocol error", func() {
 
 var _ = It("Tolerates connection reset by peer", func() {
 	var err error
-
-	// Create a context:
-	ctx := context.Background()
 
 	// Create a listener:
 	listener, address := Listen()
@@ -678,7 +658,7 @@ var _ = It("Tolerates connection reset by peer", func() {
 		Logger(logger).
 		Interval(100 * time.Millisecond).
 		Jitter(0).
-		Build(ctx)
+		Build()
 	Expect(err).ToNot(HaveOccurred())
 	defer func() {
 		err = wrapper.Close()
@@ -707,9 +687,6 @@ var _ = It("Tolerates connection reset by peer", func() {
 var _ = It("Doesn't change request body object", func() {
 	var err error
 
-	// Create a context:
-	ctx := context.Background()
-
 	// Prepare the server:
 	server := MakeTCPServer()
 	defer server.Close()
@@ -721,7 +698,7 @@ var _ = It("Doesn't change request body object", func() {
 	wrapper, err := NewTransportWrapper().
 		Logger(logger).
 		Jitter(0).
-		Build(ctx)
+		Build()
 	Expect(err).ToNot(HaveOccurred())
 	defer func() {
 		err = wrapper.Close()
@@ -748,9 +725,6 @@ var _ = It("Doesn't change request body object", func() {
 
 var _ = It("Tolerates unepected EOF", func() {
 	var err error
-
-	// Create a context:
-	ctx := context.Background()
 
 	// Create a listener:
 	listener, address := Listen()
@@ -791,7 +765,7 @@ var _ = It("Tolerates unepected EOF", func() {
 		Logger(logger).
 		Interval(100 * time.Millisecond).
 		Jitter(0).
-		Build(ctx)
+		Build()
 	Expect(err).ToNot(HaveOccurred())
 	defer func() {
 		err = wrapper.Close()

--- a/retry_test.go
+++ b/retry_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Retry", func() {
 					)
 				}).
 				RetryInterval(10 * time.Millisecond).
-				BuildContext(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
@@ -76,7 +76,7 @@ var _ = Describe("Retry", func() {
 					)
 				}).
 				RetryInterval(10 * time.Millisecond).
-				BuildContext(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
@@ -98,7 +98,7 @@ var _ = Describe("Retry", func() {
 					)
 				}).
 				RetryInterval(10 * time.Millisecond).
-				BuildContext(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
@@ -122,7 +122,7 @@ var _ = Describe("Retry", func() {
 					)
 				}).
 				RetryInterval(10 * time.Millisecond).
-				BuildContext(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
@@ -146,7 +146,7 @@ var _ = Describe("Retry", func() {
 					)
 				}).
 				RetryInterval(10 * time.Millisecond).
-				BuildContext(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
@@ -168,7 +168,7 @@ var _ = Describe("Retry", func() {
 					)
 				}).
 				RetryInterval(10 * time.Millisecond).
-				BuildContext(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
@@ -193,7 +193,7 @@ var _ = Describe("Retry", func() {
 					)
 				}).
 				RetryInterval(10 * time.Millisecond).
-				BuildContext(ctx)
+				Build()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Send the request:
@@ -223,7 +223,7 @@ var _ = Describe("Retry", func() {
 				)
 			}).
 			RetryInterval(10 * time.Millisecond).
-			BuildContext(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 
 		// Send the request:
@@ -258,7 +258,7 @@ var _ = Describe("Retry", func() {
 				)
 			}).
 			RetryInterval(10 * time.Millisecond).
-			BuildContext(ctx)
+			Build()
 		Expect(err).ToNot(HaveOccurred())
 
 		// Send the request:

--- a/send.go
+++ b/send.go
@@ -87,7 +87,7 @@ func (c *Connection) RoundTrip(request *http.Request) (response *http.Response, 
 	request.Header.Set("Accept", "application/json")
 
 	// Select the client:
-	client, err := c.clientSelector.Select(ctx, server)
+	client, err := c.clientSelector.Select(server)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
These methods don't perform any cancellable or potentially long running
operation, so they don't need to receive a context.