### PR TITLE
Update to metamodel 0.0.53

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ model_version:=v0.0.187
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.52
+metamodel_version:=v0.0.53
 
 .PHONY: examples
 examples:


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Don't consider `Status` and `Error` built-in request parameters.