### PR TITLE
Skip speed sensitive tests in GitHub actions

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -45,7 +45,7 @@ jobs:
         go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
     - name: Run the tests
-      run: make tests
+      run: make tests ginkgo_flags="--skip-package leadership,retry"
 
     - name: Build the examples
       run: make examples

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ model_url:=https://github.com/openshift-online/ocm-api-model.git
 # Details of the metamodel to use:
 metamodel_version:=v0.0.54
 
+# Additional flags to pass to the `ginkgo` command. This is used in the GitHub
+# actions environment to skip tests that are sensitive to the speed of the
+# machine: the leadership flag and retry tests.
+ginkgo_flags:=
+
 .PHONY: examples
 examples:
 	cd examples && \
@@ -33,7 +38,7 @@ examples:
 
 .PHONY: test tests
 test tests:
-	ginkgo run -r
+	ginkgo run -r $(ginkgo_flags)
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
This patch changes the GitHub actions to skip the tests that are
sensitive to the speed of the machine: the leadership flag and retry
tests.