### PR TITLE
Update `golangci-lint` and disable cache

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -60,7 +60,9 @@ jobs:
     - name: Run the linter
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42.0
+        version: v1.45.2
+        skip-pkg-cache: true
+        skip-build-cache: true
 
   generate:
     name: Generate


### PR DESCRIPTION
We have some lint jobs failing in GitHub. This patch updates the version
of the tool and disables cache to try to solve that problem.