### PR TITLE
Release 0.1.259

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.259 Apr 8 2022
+
+- Update to model 0.0.180:
+  - Fix JSON names of identity provider types.
+  - Add enable minor version upgrades flag to upgrade policy.
+
 ## 0.1.258 Apr 5 2022
 
 - Update to model 0.0.189:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.258"
+const Version = "0.1.259"


### PR DESCRIPTION
The more relevant changes in this version are the following:

- Update to model 0.0.190:
  - Fix JSON names of identity provider types.
  - Add enable minor version upgrades flag to upgrade policy.

Related: https://github.com/openshift-online/ocm-sdk-go/issues/624