### PR TITLE
Release 0.1.260

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,14 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.260 Apr 11 2022
+
+- Update to model 0.0.191:
+  - Fix JSON representation of log severity.
+
 ## 0.1.259 Apr 8 2022
 
-- Update to model 0.0.180:
+- Update to model 0.0.190:
   - Fix JSON names of identity provider types.
   - Add enable minor version upgrades flag to upgrade policy.
 

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.259"
+const Version = "0.1.260"


### PR DESCRIPTION
The more relevant changes in this release are the following:

- Update to model 0.0.191:
  - Fix JSON representation of log severity.