### PR TITLE
Release 0.1.268

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.268
+
+- Update to model 0.0.200:
+  - Add `hypershift.enabled` field to the cluster type.
 
 ## 0.1.267
 - Update to model 0.0.199:

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.267"
+const Version = "0.1.268"


### PR DESCRIPTION
The more relevant changes in the new release are the following:

- Update to model 0.0.200
  - Add `hypershift.enabled` field to the cluster type.