### PR TITLE
Release v0.1.324

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.324
+- Update model to v0.0.265
+  - Rename `HypershiftEnabled` boolean to `HostedControlPlaneEnabled` in `Version` Type model.
+
 ## 0.1.323
 - Update model to v0.0.264
   - Add `Hosted Oidc Configs` endpoints.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.323"
+const Version = "0.1.324"


### PR DESCRIPTION
 ## 0.1.324                                                                                                              
 - Update model to v0.0.265                                                                                              
    - Rename `HypershiftEnabled` boolean to `HostedControlPlaneEnabled` in `Version` Type model. 