### PR TITLE
chore: release v0.1.340

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.340
+- Update model version v0.0.281
+  - Add `RootVolume` of type `MachineTypeRootVolume` to `MachineType` type.
+
 ## 0.1.339
 - Update model version v0.0.280
   - Add `HttpTokensState` to `AWS` resource.

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.339"
+const Version = "0.1.340"


### PR DESCRIPTION
Bump release to include changes from model 0.0.281.