### PR TITLE
chore: release v0.1.343

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This document describes the relevant changes between releases of the OCM API
 SDK.
+## 0.1.343
+- Update model version v0.0.286
+  - Add MachineTypeRootVolume to MachinePool
+
 ## 0.1.342
 - Update model version v0.0.285
   - Changed DNS Domain from Class to a Struct.
@@ -101,7 +105,7 @@ SDK.
 ## 0.1.320
 - Update to model v0.0.261
   - Add `commonAnnotations` and `commonLabels` to addons
-- Update to Addon structs and openapi.json for supporting 
+- Update to Addon structs and openapi.json for supporting
   - `commonAnnotations`
   - `commonLabels`
 
@@ -157,7 +161,7 @@ SDK.
 
 ## 0.1.309
 - Update to model v0.0.250
-  - Add `Addon Inquiries API` to `addons_mgmt` 
+  - Add `Addon Inquiries API` to `addons_mgmt`
 
 ## 0.1.308
 - Update to model v0.0.249
@@ -198,20 +202,20 @@ SDK.
   - Add `DeletedSubscriptions`
   - Add `AddonCluster`
   - Add `AddonStatus`
-  
+
 ## 0.1.300
 - Update PR check to include go v1.19
 - Update goimports to v0.4.0
 - Update to model v0.0.240
   - Fix `AddonConfig` on `AddonConfigType` resource model.
 
-## 0.1.299 
+## 0.1.299
 - Update to model 0.0.239
   - Fixes for `NodePoolAutoScaling` and `AWSNodePool`.
 
 ## 0.1.298
 - Update to model 0.0.238
-  - `NodePool` fixes. 
+  - `NodePool` fixes.
 
 ## 0.1.297
 - Update to model 0.0.237

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.341"
+const Version = "0.1.343"


### PR DESCRIPTION
Bump release to include changes from model 0.0.286. Note that `version.go` bumps from 341 to 343 since this commit https://github.com/openshift-online/ocm-sdk-go/commit/728dd2f166ae7192579863df45253f770b2b6905 forgot to bump it.