### PR TITLE
Update to metamodel 0.0.59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ model_version:=v0.0.293
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.58
+metamodel_version:=v0.0.59
 
 # Additional flags to pass to the `ginkgo` command. This is used in the GitHub
 # actions environment to skip tests that are sensitive to the speed of the


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the following:

- Honor `@http` annotation in query parameters.