### PR TITLE
Add govcloud parameter to cloud region 

### DIFF
--- a/clustersmgmt/v1/cloud_region_builder.go
+++ b/clustersmgmt/v1/cloud_region_builder.go
@@ -33,7 +33,7 @@ type CloudRegionBuilder struct {
 	enabled            bool
 	supportsHypershift bool
 	supportsMultiAZ    bool
-	govCloud	       bool
+	govCloud	   bool
 }
 
 // NewCloudRegion creates a new builder of 'cloud_region' objects.

--- a/clustersmgmt/v1/cloud_region_builder.go
+++ b/clustersmgmt/v1/cloud_region_builder.go
@@ -33,6 +33,7 @@ type CloudRegionBuilder struct {
 	enabled            bool
 	supportsHypershift bool
 	supportsMultiAZ    bool
+	govCloud	       bool
 }
 
 // NewCloudRegion creates a new builder of 'cloud_region' objects.
@@ -120,6 +121,13 @@ func (b *CloudRegionBuilder) SupportsMultiAZ(value bool) *CloudRegionBuilder {
 	return b
 }
 
+// GovCloud sets the value of the 'govCloud' attribute to the given value.
+func (b *CloudRegionBuilder) GovCloud(value bool) *CloudRegionBuilder {
+	b.govCloud = value
+	b.bitmap_ |= 64
+	return b
+}
+
 // Copy copies the attributes of the given object into this builder, discarding any previous values.
 func (b *CloudRegionBuilder) Copy(object *CloudRegion) *CloudRegionBuilder {
 	if object == nil {
@@ -139,6 +147,7 @@ func (b *CloudRegionBuilder) Copy(object *CloudRegion) *CloudRegionBuilder {
 	b.name = object.name
 	b.supportsHypershift = object.supportsHypershift
 	b.supportsMultiAZ = object.supportsMultiAZ
+	b.govCloud = object.govCloud
 	return b
 }
 
@@ -160,5 +169,6 @@ func (b *CloudRegionBuilder) Build() (object *CloudRegion, err error) {
 	object.name = b.name
 	object.supportsHypershift = b.supportsHypershift
 	object.supportsMultiAZ = b.supportsMultiAZ
+	object.govCloud = b.govCloud
 	return
 }

--- a/clustersmgmt/v1/cloud_region_type.go
+++ b/clustersmgmt/v1/cloud_region_type.go
@@ -45,6 +45,7 @@ type CloudRegion struct {
 	enabled            bool
 	supportsHypershift bool
 	supportsMultiAZ    bool
+	govCloud           bool
 }
 
 // Kind returns the name of the type of the object.
@@ -267,6 +268,29 @@ func (o *CloudRegion) GetSupportsMultiAZ() (value bool, ok bool) {
 	ok = o != nil && o.bitmap_&512 != 0
 	if ok {
 		value = o.supportsMultiAZ
+	}
+	return
+}
+
+// GovCloud returns the value of the 'govCloud' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Whether the region allows AWS GovCloud.
+func (o *CloudRegion) GovCloud() bool {
+	if o != nil && o.bitmap_&64 != 0 {
+		return o.govCloud
+	}
+	return false
+}
+
+// GetGovCloud returns the value of the 'GovCloud' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Whether the region allows AWS GovCloud.
+func (o *CloudRegion) GetEnabled() (value bool, ok bool) {
+	ok = o != nil && o.bitmap_&64 != 0
+	if ok {
+		value = o.govCloud
 	}
 	return
 }

--- a/clustersmgmt/v1/cloud_region_type_json.go
+++ b/clustersmgmt/v1/cloud_region_type_json.go
@@ -127,6 +127,15 @@ func writeCloudRegion(object *CloudRegion, stream *jsoniter.Stream) {
 		stream.WriteObjectField("supports_multi_az")
 		stream.WriteBool(object.supportsMultiAZ)
 	}
+	present_ = object.bitmap_&64 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("govcloud")
+		stream.WriteBool(object.govCloud)
+		count++
+	}
 	stream.WriteObjectEnd()
 }
 
@@ -190,6 +199,10 @@ func readCloudRegion(iterator *jsoniter.Iterator) *CloudRegion {
 			value := iterator.ReadBool()
 			object.supportsMultiAZ = value
 			object.bitmap_ |= 512
+		case "govcloud":
+			value := iterator.ReadBool()
+			object.govCloud = value
+			object.bitmap_ |= 64
 		default:
 			iterator.ReadAny()
 		}


### PR DESCRIPTION
Adding the govcloud parameter, in order to include it in region posting testing for OCM-backend-tests.