### PR TITLE
feat: install and use tools at project scope level

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -78,9 +78,6 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Setup Goimports
-      run: go install golang.org/x/tools/cmd/goimports@v0.4.0
-
     - name: Generate code
       run: make generate
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 !/examples/*.yaml
 !/examples/go.mod
 !/examples/go.sum
+
+# local bin directory
+/bin

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
+#
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+LOCAL_BIN_PATH := $(PROJECT_PATH)/bin
+
+# Add the project-level bin directory into PATH. Needed in order
+# for the tasks to use project-level bin directory binaries first
+export PATH := $(LOCAL_BIN_PATH):$(PATH)
 
 # Disable CGO so that we always generate static binaries:
 export CGO_ENABLED=0
@@ -23,6 +32,8 @@ model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
 metamodel_version:=v0.0.59
+
+goimports_version:=v0.4.0
 
 # Additional flags to pass to the `ginkgo` command. This is used in the GitHub
 # actions environment to skip tests that are sensitive to the speed of the
@@ -50,7 +61,7 @@ lint:
 	golangci-lint run
 
 .PHONY: generate
-generate: model metamodel
+generate: model metamodel-install goimports-install
 	rm -rf \
 		accountsmgmt \
 		addonsmgmt \
@@ -65,11 +76,11 @@ generate: model metamodel
 		webrca \
 		osdfleetmgmt \
 		openapi
-	metamodel generate go \
+	$(METAMODEL) generate go \
 		--model=model/model \
 		--base=github.com/openshift-online/ocm-sdk-go \
 		--output=.
-	metamodel generate openapi \
+	$(METAMODEL) generate openapi \
 		--model=model/model \
 		--output=openapi
 
@@ -86,8 +97,13 @@ model:
 	fi
 
 .PHONY: metamodel
-metamodel:
-	go install github.com/openshift-online/ocm-api-metamodel/cmd/metamodel@$(metamodel_version)
+METAMODEL=$(LOCAL_BIN_PATH)/metamodel
+metamodel-install:
+	GOBIN=$(LOCAL_BIN_PATH) go install github.com/openshift-online/ocm-api-metamodel/cmd/metamodel@$(metamodel_version)
+
+.PHONY: goimports
+goimports-install:
+	@GOBIN=$(LOCAL_BIN_PATH) go install golang.org/x/tools/cmd/goimports@$(goimports_version)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Currently, in the project some tools are used to generate Go types and the OpenAPI specs from the OCM API model.

This tools are used by some Makefile targets of the project.

However, the project assumes that the tools are installed in the user's environment. This leads to errors when trying to use the Makefile targets and the user being confused as to why.

Aside from that, even if the user has those tools in the environment, the version used by those tools might be different than the version that was used to generate the Go types and OpenAPI specs in the repository's content, which might lead to differences in the autogenerated code with respect to what's commited in the repository and between users.

This set of changes ensures that the tools used by the Makefile are the ones installed by it. This ensures that anyone that used the project and generates the code sing the Makefile targets will use the same version of the tools

The tools are now always installed in the `bin` directory of the project's path.

Users of the project that want to directly use the installed tools manually should run them using the binaries installed at project level to ensure that there are no differences in the tool versions.

This set of changes also ensures that `goimports` is also installed as a project-level binary it as it is a requirement to run the `metamodel` tool. If the user didn't have it installed this ended up in errors.

Finally, it removes the explicit install of the `goimports` binary as it is now automatically installed when running `make generate`

### Testing

To test it make sure that you can run `make generate` successfully even if you don't have `metamodel` nor `goimports` in your PATH. Also verify that the binaries are installed in the `bin` directory of the project's root path