### PR TITLE
OCM-3234 | chore(release): release 0.1.378

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.378
+- Update model version v0.0.330
+  - Add `Update` method to `HypershiftConfig` resource
+
 ## 0.1.377
 - Update model version v0.0.329
   - Add get `ClusterId` to `network_verification_type` resource

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.377"
+const Version = "0.1.378"


### PR DESCRIPTION
Refs:
https://issues.redhat.com/browse/OCM-3234
https://github.com/openshift-online/ocm-sdk-go/pull/860