### PR TITLE
OCM-3852 | chore: Release notes for SDK version 0.1.381

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.381
+- Update model version to v0.0.333
+  - Add `/api/clusters_mgmt/v1/clusters/{id}/kubelet_config` endpoint
+  - Add `KubeletConfig` struct
+  - Update `Cluster` struct to be able to optionally embed the `KubeletConfig` struct
+
 ## 0.1.380
 - Update model version v0.0.332
   - Add `AdditionalInfraSecurityGroupIds` to `AWS` type

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.380"
+const Version = "0.1.381"


### PR DESCRIPTION
This PR adds release notes for release `0.1.381` which adds support for the `kubelet_config` resource on clusters.