### PR TITLE
OCM-4744 | chore: Bump the SDK to use API model version 0.0.337

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ export PATH := $(LOCAL_BIN_PATH):$(PATH)
 export CGO_ENABLED=0
 
 # Details of the model to use:
-model_version:=v0.0.336
+model_version:=v0.0.337
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:

--- a/clustersmgmt/v1/kubelet_config_client.go
+++ b/clustersmgmt/v1/kubelet_config_client.go
@@ -450,7 +450,7 @@ type KubeletConfigPostRequest struct {
 	path      string
 	query     url.Values
 	header    http.Header
-	request   *KubeletConfig
+	body      *KubeletConfig
 }
 
 // Parameter adds a query parameter.
@@ -472,9 +472,9 @@ func (r *KubeletConfigPostRequest) Impersonate(user string) *KubeletConfigPostRe
 	return r
 }
 
-// Request sets the value of the 'request' parameter.
-func (r *KubeletConfigPostRequest) Request(value *KubeletConfig) *KubeletConfigPostRequest {
-	r.request = value
+// Body sets the value of the 'body' parameter.
+func (r *KubeletConfigPostRequest) Body(value *KubeletConfig) *KubeletConfigPostRequest {
+	r.body = value
 	return r
 }
 

--- a/clustersmgmt/v1/kubelet_config_resource_json.go
+++ b/clustersmgmt/v1/kubelet_config_resource_json.go
@@ -36,7 +36,7 @@ func readKubeletConfigGetResponse(response *KubeletConfigGetResponse, reader io.
 	return err
 }
 func writeKubeletConfigPostRequest(request *KubeletConfigPostRequest, writer io.Writer) error {
-	return MarshalKubeletConfig(request.request, writer)
+	return MarshalKubeletConfig(request.body, writer)
 }
 func readKubeletConfigPostResponse(response *KubeletConfigPostResponse, reader io.Reader) error {
 	var err error


### PR DESCRIPTION
This PR bumps the API model to `v0.0.337` primarily to allow us to rebuild the SDK to fix OCM-4744. 
