### PR TITLE
OCM-5081 | Change AWS node tags to map[string]*string

### DIFF
--- a/clustersmgmt/v1/aws_node_pool_builder.go
+++ b/clustersmgmt/v1/aws_node_pool_builder.go
@@ -28,7 +28,7 @@ type AWSNodePoolBuilder struct {
 	href            string
 	instanceProfile string
 	instanceType    string
-	tags            map[string]string
+	tags            map[string]*string
 }
 
 // NewAWSNodePool creates a new builder of 'AWS_node_pool' objects.
@@ -76,7 +76,7 @@ func (b *AWSNodePoolBuilder) InstanceType(value string) *AWSNodePoolBuilder {
 }
 
 // Tags sets the value of the 'tags' attribute to the given value.
-func (b *AWSNodePoolBuilder) Tags(value map[string]string) *AWSNodePoolBuilder {
+func (b *AWSNodePoolBuilder) Tags(value map[string]*string) *AWSNodePoolBuilder {
 	b.tags = value
 	if value != nil {
 		b.bitmap_ |= 32
@@ -97,7 +97,7 @@ func (b *AWSNodePoolBuilder) Copy(object *AWSNodePool) *AWSNodePoolBuilder {
 	b.instanceProfile = object.instanceProfile
 	b.instanceType = object.instanceType
 	if len(object.tags) > 0 {
-		b.tags = map[string]string{}
+		b.tags = map[string]*string{}
 		for k, v := range object.tags {
 			b.tags[k] = v
 		}
@@ -116,7 +116,7 @@ func (b *AWSNodePoolBuilder) Build() (object *AWSNodePool, err error) {
 	object.instanceProfile = b.instanceProfile
 	object.instanceType = b.instanceType
 	if b.tags != nil {
-		object.tags = make(map[string]string)
+		object.tags = make(map[string]*string)
 		for k, v := range b.tags {
 			object.tags[k] = v
 		}

--- a/clustersmgmt/v1/aws_node_pool_type.go
+++ b/clustersmgmt/v1/aws_node_pool_type.go
@@ -40,7 +40,7 @@ type AWSNodePool struct {
 	href            string
 	instanceProfile string
 	instanceType    string
-	tags            map[string]string
+	tags            map[string]*string
 }
 
 // Kind returns the name of the type of the object.
@@ -150,7 +150,7 @@ func (o *AWSNodePool) GetInstanceType() (value string, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
-func (o *AWSNodePool) Tags() map[string]string {
+func (o *AWSNodePool) Tags() map[string]*string {
 	if o != nil && o.bitmap_&32 != 0 {
 		return o.tags
 	}
@@ -161,7 +161,7 @@ func (o *AWSNodePool) Tags() map[string]string {
 // a flag indicating if the attribute has a value.
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
-func (o *AWSNodePool) GetTags() (value map[string]string, ok bool) {
+func (o *AWSNodePool) GetTags() (value map[string]*string, ok bool) {
 	ok = o != nil && o.bitmap_&32 != 0
 	if ok {
 		value = o.tags

--- a/clustersmgmt/v1/aws_node_pool_type_json.go
+++ b/clustersmgmt/v1/aws_node_pool_type_json.go
@@ -105,7 +105,7 @@ func writeAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 				}
 				item := object.tags[key]
 				stream.WriteObjectField(key)
-				stream.WriteString(item)
+				stream.WriteString(*item)
 			}
 			stream.WriteObjectEnd()
 		} else {
@@ -156,14 +156,14 @@ func readAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 			object.instanceType = value
 			object.bitmap_ |= 16
 		case "tags":
-			value := map[string]string{}
+			value := map[string]*string{}
 			for {
 				key := iterator.ReadObject()
 				if key == "" {
 					break
 				}
 				item := iterator.ReadString()
-				value[key] = item
+				value[key] = &item
 			}
 			object.tags = value
 			object.bitmap_ |= 32


### PR DESCRIPTION
Draft:
For an AWS node tag to be deleted through CS, the value of the tag is expected to be nil. This is not possible today with the AWS node tag type being map[string]string in the SDK. One way is to change this type in the SDK to map[string]*string