### PR TITLE
Install and use ginkgo cli at project level

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -39,10 +39,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Setup Go tools
-      run: |
-        go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
-
     - name: Run the tests
       run: make tests ginkgo_flags="--skip-package leadership,retry"
 

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ ginkgo_flags:=
 
 .DEFAULT_GOAL := examples
 
+GINKGO := $(LOCAL_BIN_PATH)/ginkgo
+ginkgo-install:
+	@GOBIN=$(LOCAL_BIN_PATH) go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4 ;\
+
 .PHONY: examples
 examples:
 	cd examples && \
@@ -50,8 +54,8 @@ examples:
 	done
 
 .PHONY: test tests
-test tests:
-	ginkgo run -r $(ginkgo_flags)
+test tests: ginkgo-install
+	$(GINKGO) run -r $(ginkgo_flags)
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ goimports_version:=v0.4.0
 # machine: the leadership flag and retry tests.
 ginkgo_flags:=
 
+.DEFAULT_GOAL := examples
+
 .PHONY: examples
 examples:
 	cd examples && \


### PR DESCRIPTION
Currently, in the project the ginkgo cli tool is used by
some Makefile targets of the project and at Go level.

However, the project assumes that the cli tool is installed in the
user's environment. This leads to errors when trying to use
the Makefile targets and the user being confused as to why.

Aside from that, even if the user has the tool in the environment, the
version used by t might be different than the version that is specified
in go.mod, which might lead to errors when running the tool and
different observed behavior between users.

This set of changes ensures that the tools used by the Makefile are the
ones installed by it. This ensures that anyone that uses the project
and runs the ginkgo cli tool using the Makefile targets will use the same
version of the tool.

The tool is now always installed in the `bin` directory
of the project's path.

Users of the project that want to directly use the installed tool
manually should run it using the binary installed at project
level to ensure that there are no differences in the tool version.

Finally, remove the explicit install of the `ginkgo` binary in the CI
workflow as it is now automatically installed when running the tests
through the Makefile.