### PR TITLE
OCM-4964: Refine allowed keystores

### DIFF
--- a/authentication/securestore/main.go
+++ b/authentication/securestore/main.go
@@ -13,9 +13,8 @@ const (
 	SecureStoreConfigKey = "securestore"       // OCM_CONFIG key to enable secure OS store
 	KindInternetPassword = "Internet password" // MacOS Keychain item kind
 	ItemKey              = "RedHatSSO"
-	CollectionName       = "login"         // Common OS default collection name
-	DefaultFilePath      = "~/.config/ocm" // File path when using File backend
-	MaxWindowsByteSize   = 2500            // Windows Credential Manager has a 2500 byte limit
+	CollectionName       = "login" // Common OS default collection name
+	MaxWindowsByteSize   = 2500    // Windows Credential Manager has a 2500 byte limit
 )
 
 func getKeyringConfig() keyring.Config {
@@ -26,13 +25,7 @@ func getKeyringConfig() keyring.Config {
 			keyring.WinCredBackend,
 			keyring.KeychainBackend,
 			keyring.SecretServiceBackend,
-			keyring.KWalletBackend,
-			keyring.KeyCtlBackend,
 			keyring.PassBackend,
-			// The FileBackend is a last resort and will store credentials in an encrypted file. This has
-			// the worst user experience as the user will have to enter a password every time they attempt
-			// to access the file.
-			keyring.FileBackend,
 		},
 		// Generic
 		ServiceName: ItemKey,
@@ -45,18 +38,12 @@ func getKeyringConfig() keyring.Config {
 		WinCredPrefix: ItemKey,
 		// Secret Service
 		LibSecretCollectionName: CollectionName,
-		// KWallet
-		KWalletFolder: CollectionName,
-		KWalletAppID:  ItemKey,
-		// KeyCtl
-		KeyCtlScope: "user",
-		// Encrypted File
-		FilePasswordFunc: keyring.TerminalPrompt,
-		FileDir:          DefaultFilePath,
 	}
 }
 
 // AvailableBackends provides a slice of all available backend keys on the current OS.
+//
+// Note: CGO_ENABLED=1 is required for OSX Keychain and darwin builds
 //
 // The first backend in the slice is the first one that will be used.
 func AvailableBackends() []string {
@@ -68,6 +55,8 @@ func AvailableBackends() []string {
 }
 
 // UpsertConfigToKeyring will upsert the provided credentials to first priority OS secure store.
+//
+// Note: CGO_ENABLED=1 is required for OSX Keychain and darwin builds
 func UpsertConfigToKeyring(creds []byte) error {
 	ring, err := keyring.Open(getKeyringConfig())
 	if err != nil {
@@ -96,6 +85,8 @@ func UpsertConfigToKeyring(creds []byte) error {
 }
 
 // GetConfigFromKeyring will retrieve the credentials from the first priority OS secure store.
+//
+// Note: CGO_ENABLED=1 is required for OSX Keychain and darwin builds
 func GetConfigFromKeyring() ([]byte, error) {
 	credentials := []byte("")
 


### PR DESCRIPTION
* Removes KeyCtl, KWallet, and File as available keystores