### PR TITLE
Allow Connection to avoid using the default authentication transport

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -986,6 +986,34 @@ var _ = Describe("Connection", func() {
 		err = connection.Close()
 		Expect(err).To(BeNil())
 	})
+
+	It("Can be created with no authentication", func() {
+		connection, err := NewUnauthenticatedConnectionBuilder().
+			Logger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(connection).ToNot(BeNil())
+		Expect(connection.Scopes()).To(BeEmpty())
+		Expect(connection.TokenURL()).To(BeEmpty())
+		clientId, clientSecret := connection.Client()
+		Expect(clientId).To(BeEmpty())
+		Expect(clientSecret).To(BeEmpty())
+		user, password := connection.User()
+		Expect(user).To(BeEmpty())
+		Expect(password).To(BeEmpty())
+		access, refresh, err := connection.Tokens()
+		Expect(access).To(BeEmpty())
+		Expect(refresh).To(BeEmpty())
+		Expect(err).ToNot(HaveOccurred())
+		access, refresh, err = connection.TokensContext(context.Background())
+		Expect(access).To(BeEmpty())
+		Expect(refresh).To(BeEmpty())
+		Expect(err).ToNot(HaveOccurred())
+
+		err = connection.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
 })
 
 type TestTransport struct {

--- a/examples/get_cluster_unauthenticated.go
+++ b/examples/get_cluster_unauthenticated.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+// This example retrieves a cluster using an OCM connection that does
+// not perform authentication. The example assumes that there is a
+// local Cluster Service process running at http://localhost:9000 and
+// that no Authentication is enabled in it.
+func main() {
+	// Create a context:
+	ctx := context.Background()
+
+	// Create a logger that has the debug level enabled:
+	logger, err := logging.NewGoLoggerBuilder().
+		Debug(true).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection without using authentication,
+	// and remember to close it:
+	connection, err := sdk.NewUnauthenticatedConnectionBuilder().
+		Logger(logger).
+		URL("http://localhost:9000").
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	collection := connection.ClustersMgmt().V1().Clusters()
+
+	// Get the client for the resource that manages the cluster that we are looking for. Note
+	// that this will not send any request to the server yet, so it will succeed even if that
+	// cluster doesn't exist.
+	resource := collection.Cluster("1i1rics0s96htk98gmh50rkakdljoiau")
+
+	// Send the request to retrieve the cluster:
+	response, err := resource.Get().SendContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve cluster: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print the result:
+	cluster := response.Body()
+	fmt.Printf("%s - %s\n", cluster.ID(), cluster.Name())
+
+}

--- a/token.go
+++ b/token.go
@@ -33,6 +33,9 @@ import (
 //
 // This operation is potentially lengthy, as it may require network communication. Consider using a
 // context and the TokensContext method.
+// The returned access and refresh tokens are empty strings if the
+// connection does not use authentication. In that case no error is
+// returned either
 func (c *Connection) Tokens(expiresIn ...time.Duration) (access, refresh string, err error) {
 	if len(expiresIn) == 1 {
 		access, refresh, err = c.TokensContext(context.Background(), expiresIn[0])
@@ -48,8 +51,13 @@ func (c *Connection) Tokens(expiresIn ...time.Duration) (access, refresh string,
 // expired, this method will do it and will return an error if it fails.
 //
 // If new tokens are needed the request will be retried with an exponential backoff.
+// The returned access and refresh tokens are empty strings if the
+// connection does not use authentication. In that case no error is
+// returned either
 func (c *Connection) TokensContext(ctx context.Context, expiresIn ...time.Duration) (access,
 	refresh string, err error) {
-	access, refresh, err = c.authnWrapper.Tokens(ctx, expiresIn...)
+	if c.authnWrapper != nil {
+		access, refresh, err = c.authnWrapper.Tokens(ctx, expiresIn...)
+	}
 	return
 }


### PR DESCRIPTION
# Description

This MR implements being able to use a `Connection` object without authentication being performed on the OCM SDK Go client side.

The motivation for this is to be able to connect to an OCM service that does not require authentication using the OCM SDK Go. For example, when running Cluster Service locally without authentication enabled.

A solution is proposed and described in this PR. I also listed alternatives that I could think of, each with its own tradeoffs and implications. I think in this case it is probably a case of desired tradeoffs.

I also added new example example as part of the PR contents.

## Implemented solution

Users of the OCM SDK Go can create a Connection by using a ConnectionBuilder. Before this PR users could create a ConnectionBuilder by using the `NewConnectionBuilder` constructor method.

This PR adds a new UnauthenticatedConnectionBuilder constructor method that returns a ConnectionBuilder that when is built returns a Connection that does not perform authentication (this is, that it does not make use of the authentication.TransportWrapper http transport).

With this, users of the OCM SDK Go have two ways of creating a ConnectionBuilder:
* NewConnectionBuilder
* NewUnauthenticatedConnectionBuilder

A new `bool includeDefaultAuthenticationTransportWrapper` unexported attribute has been included in the Connection type. When it is set to false then the default authentication wrapper attribute is not set in the Connection object which leaves it as nil. Methods of the Connection type that make use of the default authentication wrapper attribute it check if is nil and if it is they return "noops" like empty strings, nil errors, ... . The includeDefaultAuthenticationTransportWrapper attribute is set to false when NewUnauthenticatedConnectionBuilder is used

### Implications of the new solution

* The Connection type has authentication-related methods: TokenURL, Client, User, Scopes, Tokens, TokensContext. Because no authentication is used when using NewUnauthenticatedConnectionBuilder, these methods have to return something anyway. "noop" returns have been implemented in that case (when authnWrapper is nil) like nil strings and nil errors, no matter what the input parameters of those methods are.
* Now we have two constructor methods for ConnectionBuilder
* Now `authnWrapper` can be nil in the Connection type when no authentication is used for it
* Due to the previous point, there are now nil checks for the authnWrapper attribute in different methods in the Connection type that make use of it. If in the future the authnWrapper is used in other places nil checks should be implemented for it too. An alternative would be assuming the user won't call methods that need authentication. However if that were to happen nil exceptions would return
* When calling NewUnauthenticatedConnectionBuilder, if the user calls authentication-specific builder methods those will basicall have no effect

## Alternative solutions

* Instead of having 2 different constructor methods for ConnectionBuilder, update the existing one to receive as a parameter whether the default authentication wrapper is to be used for the connection or not, or receive a ConnectionBuilder options struct with one of its attributes being whether the default authentication wrapper is to be used for the connection or not.
  * This solution is a "breaking change" in the sense that code (users or within ocm sdk go itself) that makes use of NewConnectionBuilder needs to be updated when using the code after this PR (in a new ocm sdk go version)
* Change the behavior of  the `TransportWrapper` method in the ConnectionBuilder to be a set instead of an append
  * This solution is a breaking change due to the `TransportWrapper` method changing its behavior
  * This solution also makes responsible the user to be aware and set among the default transport wrappers
* Add a new method in the ConnectionBuilder type that is something like bool UseDefaultAuthenticationWrapper which is
  set to true by default
  * This solution has the same implications as the proposed solution replacing having two constructor methods for a new additional method on the builder

Aside from the previous alternative solutions, there are other possible approaches that imply a bigger redesign. If we analyze the Connection type, one of the characteristics is that it assumes that it always uses authentication. This is reflected by it offering methods that are authentication-specific only: TokenURL, Client, User, Scopes, Tokens, TokensContext.
This other approaches involve trying to decouple authentication from the Connection type.
Some of this approaches are:
* Approach 1
  * Change Connection to not have default authentication transport at all. No authentication related attributes nor methods
  * Create a new AuthenticatedConnection type that contains a Connection and basically adds the authentication to it
  * This approach is a breaking change
  * This approach implies that now there are two different connection types
  * This approach might also imply that now there two different connection builder types
  * If a part of the code in the SDK uses Connection type then it won't be able to use authentication specific methods
* Approach 2
  * Create an UnauthenticatedConnection type. It has no authentication related attributes nor methods
  * Refactor the Connection type to contain an UnauthenticatedConnection instance. This type has all the methods UnauthenticatedConnection has plus authentication-specific related methods
  * This approach implies that now there are two different connection types. For example, ConnectionWithNoRetry
  * Another note is that if we want to add/remove other behaviors we might end up with an explosion of number of types.
  * This approach might imply you also need multiple different connection builders
  * OCM SDK Go code itself
  * If a part of the code in the SDK uses UnauthenticatedConnection type then it won't be able to use authentication specific methods
* Approach 3
  * Create a Connection interface that does not include any authentication specific behavior nor retry behavior
  * Create a BaseConnection struct type that implements the Connection interface
  * Create an AuthenticatedConnection struct type that implements the Connection interface plus authentication specific methods. This type contains a Connection instance as part of it
  * Create a RetriableConnection struct type that includes a Connection interface. It implements also the Connection interface and adds additional retry-specific methods too
  * This approach is a breaking change
  * This approach also implies that if the Connection is passed around in the code and for some reason we need for example authentication specific data then we need to type assert it to an AuthenticatedConnection and deal appropriately if it is not the expected type
  * This approach also leaves the responsability of instantiating the desired connection behavior. This might also imply multiple connection builders at different levels.

## Pending
- [x] Testing. For now I have not implemented any potential tests. I will evaluate it once an agreement to a solution has been reached.