### PR TITLE
OCM-2780 | fix: Don't error when response is 204 and no content-type

### DIFF
--- a/internal/check_content_type.go
+++ b/internal/check_content_type.go
@@ -38,6 +38,9 @@ var wsRegex = regexp.MustCompile(`\s+`)
 func CheckContentType(response *http.Response) error {
 	var err error
 	var mediaType string
+	if response.StatusCode == http.StatusNoContent {
+		return nil
+	}
 	contentType := response.Header.Get("Content-Type")
 	if contentType != "" {
 		mediaType, _, err = mime.ParseMediaType(contentType)

--- a/send.go
+++ b/send.go
@@ -99,6 +99,9 @@ func (c *Connection) RoundTrip(request *http.Request) (response *http.Response, 
 	}
 
 	// Check that the response content type is JSON:
+	if response.StatusCode == http.StatusNoContent {
+		return
+	}
 	err = internal.CheckContentType(response)
 	if err != nil {
 		return

--- a/send.go
+++ b/send.go
@@ -99,9 +99,6 @@ func (c *Connection) RoundTrip(request *http.Request) (response *http.Response, 
 	}
 
 	// Check that the response content type is JSON:
-	if response.StatusCode == http.StatusNoContent {
-		return
-	}
 	err = internal.CheckContentType(response)
 	if err != nil {
 		return


### PR DESCRIPTION
Also fixes: https://issues.redhat.com/browse/OCM-4087

Original ticket: https://issues.redhat.com/browse/OCM-2780

This MR makes it so that when we have a 204 no content, we return empty response regardless of a missing content-type in the header. This was causing errors leading to nil responses in the SDK within the Keycloak FedRAMP environment