### PR TITLE
OCM-4965: Secure store tweaks

### DIFF
--- a/authentication/securestore/main_test.go
+++ b/authentication/securestore/main_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains tests for the functions that extract authentication and authorization
+// information from contexts.
+
+package securestore
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+)
+
+func TestSecurestore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Authentication.Securestore")
+}
+
+var _ = Describe("Validation", func() {
+	It("Validates an invalid backend", func() {
+		err := ValidateBackend("invalid")
+		Expect(err).To(Equal(ErrKeyringInvalid))
+
+		err = UpsertConfigToKeyring("invalid", []byte("test"))
+		Expect(err).To(Equal(ErrKeyringInvalid))
+
+		bytes, err := GetConfigFromKeyring("invalid")
+		Expect(err).To(Equal(ErrKeyringInvalid))
+		Expect(bytes).To(BeNil())
+
+		err = RemoveConfigFromKeyring("invalid")
+		Expect(err).To(Equal(ErrKeyringInvalid))
+	})
+
+	It("Validates an empty backend", func() {
+		err := ValidateBackend("")
+		Expect(err).To(Equal(ErrKeyringInvalid))
+
+		err = UpsertConfigToKeyring("", []byte("test"))
+		Expect(err).To(Equal(ErrKeyringInvalid))
+
+		bytes, err := GetConfigFromKeyring("")
+		Expect(err).To(Equal(ErrKeyringInvalid))
+		Expect(bytes).To(BeNil())
+
+		err = RemoveConfigFromKeyring("")
+		Expect(err).To(Equal(ErrKeyringInvalid))
+	})
+
+})

--- a/examples/secure_store.go
+++ b/examples/secure_store.go
@@ -9,6 +9,10 @@ import (
 )
 
 func main() {
+
+	// Modify the following variable to match your OS:
+	keyring := "keychain"
+
 	// Create a context:
 	clientId := "ocm-cli"
 
@@ -27,7 +31,7 @@ func main() {
 	config := []byte("mybytestringagain")
 
 	// Upsert to keyring
-	err = securestore.UpsertConfigToKeyring(config)
+	err = securestore.UpsertConfigToKeyring(keyring, config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error upserting to keyring: %v", err)
 		os.Exit(1)
@@ -35,14 +39,14 @@ func main() {
 
 	// Upsert again to keyring
 	config = []byte(token)
-	err = securestore.UpsertConfigToKeyring(config)
+	err = securestore.UpsertConfigToKeyring(keyring, config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error upserting to keyring: %v", err)
 		os.Exit(1)
 	}
 
 	// Read bytes back from Keyring
-	readVal, err := securestore.GetConfigFromKeyring()
+	readVal, err := securestore.GetConfigFromKeyring(keyring)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading from keyring: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
* Add test for invalid and empty keyrings
* Additional Error Standardization
* Add support that allows the caller to define a keyring to target
* Add error handling for denied Keychain access due to permissions