### PR TITLE
OCM-7117 | chore: update metamodel version in sdk to v0.060

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.414
+- Update metamodel version v0.0.60
+
 ## 0.1.413
 - Update model version v0.0.366
   - Fix Default Capabilities.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ model_version:=v0.0.366
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.59
+metamodel_version:=v0.0.60
 
 goimports_version:=v0.4.0
 

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.413"
+const Version = "0.1.414"


### PR DESCRIPTION
Due to data type introduced below never used in the api model ("[]Integer"):
[https://github.com/openshift-online/ocm-api-model/pull/921
`[]integer`](https://github.com/openshift-online/ocm-api-model/pull/921/files#diff-865de0e694fcf8dc6d76b5c66fc15d558acc7fe328563928ddfbb624867912b8R31)

the metamodel would generate an error when generating files for the SDK (via the make generate command).
```
output/clustersmgmt/v1/load_balancer_quota_values_client.go:162:12: expected type, found '.'
output/clustersmgmt/v1/load_balancer_quota_values_client.go:191:59: expected type, found '.'
output/clustersmgmt/v1/load_balancer_quota_values_client.go:194:6: expected declaration, found '}'
E: Can't format generated sources: exit status 2
```

Fix introduced in version metamodel v0.060, thanks to @mnecas 
https://github.com/openshift-online/ocm-api-metamodel/pull/203