### PR TITLE
chore: update golangci-lint in GH action to 1.61.0

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Run the linter
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.56.2
+        version: v1.61.0
         args: --timeout 10m
         skip-pkg-cache: true
         skip-build-cache: true


### PR DESCRIPTION
The current version was causing CI issues where the GitHub runner was stopping due to what we think is excessive usage of resource. Possibly a memory leak. Updating the golangci-lint version used by the GitHub action fixes the issue. We also get the newest changes and fixes by updating the version.