### PR TITLE
OCM-13888 | fix: Ensure labels for metrics correctly reference service name and not API version.

### DIFF
--- a/metrics/handler_wrapper_test.go
+++ b/metrics/handler_wrapper_test.go
@@ -371,6 +371,10 @@ var _ = Describe("Metrics", func() {
 				"/api/service_logs/v1/accounts/123",
 				"ocm-logs-service",
 			),
+			Entry(
+				"Future service not in existing service list",
+				"/api/future_mgmt/v1/",
+				"ocm-future_mgmt"),
 		)
 	})
 

--- a/metrics/labels.go
+++ b/metrics/labels.go
@@ -39,7 +39,7 @@ func serviceLabel(path string) string {
 	} else {
 		parts := strings.Split(path, "/")
 		if len(parts) > 3 {
-			return "ocm-" + parts[3]
+			return "ocm-" + parts[2]
 		}
 		return ""
 	}


### PR DESCRIPTION
We are having metrics generated with the following label structure for services that are not hard-coded into the label generation process: `ocm-v1`. Essentially, the label is selecting the API version part of the path, rather than the service name. This is making it very hard to understand what services are receiving traffic, unless they are in the hard-coded list.

This fix ensures that we select the service name from the path rather than the service version. I have explicitly decided against updating the list of hard-coded service mappings for the sake of maintenance going forward.