### PR TITLE
Update metamodel to version 0.0.68

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ model_version:=v0.0.417
 model_url:=https://github.com/openshift-online/ocm-api-model.git
 
 # Details of the metamodel to use:
-metamodel_version:=v0.0.67
+metamodel_version:=v0.0.68
 
 goimports_version:=v0.4.0
 


### PR DESCRIPTION
This version of the metamodel fix a reference issue. 
More details can be found [here](https://github.com/openshift-online/ocm-api-metamodel/pull/226) 