### PR TITLE
Improve AI-assisted development readiness: AGENTS.md, templates, .gitignore, pre-commit hooks [Generated by gurnben's Agent]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. -->
+
+## Environment
+
+- OS: 
+- Version: 
+- Go version (if applicable): 
+
+## Additional Context
+
+<!-- Add any other context, logs, or screenshots. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+<!-- A clear description of what problem this feature would solve. -->
+
+## Proposed Solution
+
+<!-- Describe the solution you'd like. -->
+
+## Alternatives Considered
+
+<!-- Any alternative solutions or features you've considered. -->
+
+## Additional Context
+
+<!-- Add any other context or mockups. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+
+<!-- Briefly describe the change and its motivation. -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD or tooling change
+
+## Testing
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+
+- [ ] Unit tests pass (`make test`)
+- [ ] Integration tests pass (if applicable)
+- [ ] Manual verification completed
+
+## Checklist
+
+- [ ] My code follows the project's coding conventions
+- [ ] I have updated documentation as needed
+- [ ] I have added tests that prove my fix/feature works
+- [ ] All new and existing tests pass

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,40 @@
 # local bin directory
 /bin
 /metamodel_generator/metamodel
+
+# === Additional patterns for agent-readiness ===
+# Binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+*.prof
+
+# Go workspace file
+go.work
+go.work.sum
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.project
+.settings/
+
+# OS files
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Build output
+/bin/
+/dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ['--allow-multiple-documents']
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: check-merge-conflict
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.1.2
+    hooks:
+      - id: golangci-lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+This file provides guidance to AI coding assistants when working with this repository.
+
+## Project Overview
+
+OCM SDK for Go — a client library that simplifies interaction with the OpenShift Cluster Manager (OCM) API. Provides type-safe Go bindings generated from the OCM API model, with authentication, pagination, and error handling built in.
+
+## Build & Test Commands
+
+```bash
+make generate        # Regenerate SDK code from model definitions
+make fmt             # Format Go source code
+make goimports       # Organize imports
+make lint            # Run golangci-lint
+make examples        # Build example programs
+make clean           # Remove generated files
+```
+
+Tests use Ginkgo:
+```bash
+make ginkgo-install  # Install Ginkgo test runner
+ginkgo ./...         # Run all tests
+```
+
+## Architecture
+
+The SDK is organized by OCM API service area, each in its own top-level package:
+
+- **clustersmgmt/**: Cluster management API bindings
+- **accountsmgmt/**: Account management API bindings
+- **addonsmgmt/**: Add-on management API bindings
+- **servicelogs/**: Service logs API bindings
+- **authorizations/**: Authorization API bindings
+- **authentication/**: Authentication utilities and token handling
+- **configuration/**: SDK configuration
+- **errors/**: Error type definitions
+- **helpers/**: Shared utility functions
+- **logging/**: Logging interfaces
+- **testing/**: Test utilities and mock transport
+- **examples/**: Usage examples
+
+## Key Conventions
+
+- Module path: `github.com/openshift-online/ocm-sdk-go`
+- Most code is auto-generated from the OCM API model — do not edit generated files directly
+- Uses builder pattern for constructing API requests
+- Ginkgo/Gomega for testing
+- Generated files can be identified by their header comments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+<!-- Canonical source: AGENTS.md. This file is auto-generated for Claude Code compatibility. -->
+
+This file provides guidance to AI coding assistants when working with this repository.
+
+## Project Overview
+
+OCM SDK for Go — a client library that simplifies interaction with the OpenShift Cluster Manager (OCM) API. Provides type-safe Go bindings generated from the OCM API model, with authentication, pagination, and error handling built in.
+
+## Build & Test Commands
+
+```bash
+make generate        # Regenerate SDK code from model definitions
+make fmt             # Format Go source code
+make goimports       # Organize imports
+make lint            # Run golangci-lint
+make examples        # Build example programs
+make clean           # Remove generated files
+```
+
+Tests use Ginkgo:
+```bash
+make ginkgo-install  # Install Ginkgo test runner
+ginkgo ./...         # Run all tests
+```
+
+## Architecture
+
+The SDK is organized by OCM API service area, each in its own top-level package:
+
+- **clustersmgmt/**: Cluster management API bindings
+- **accountsmgmt/**: Account management API bindings
+- **addonsmgmt/**: Add-on management API bindings
+- **servicelogs/**: Service logs API bindings
+- **authorizations/**: Authorization API bindings
+- **authentication/**: Authentication utilities and token handling
+- **configuration/**: SDK configuration
+- **errors/**: Error type definitions
+- **helpers/**: Shared utility functions
+- **logging/**: Logging interfaces
+- **testing/**: Test utilities and mock transport
+- **examples/**: Usage examples
+
+## Key Conventions
+
+- Module path: `github.com/openshift-online/ocm-sdk-go`
+- Most code is auto-generated from the OCM API model — do not edit generated files directly
+- Uses builder pattern for constructing API requests
+- Ginkgo/Gomega for testing
+- Generated files can be identified by their header comments


### PR DESCRIPTION
## Summary

Adds foundational agent-readiness infrastructure to this repository.

### Changes

- **AGENTS.md** + **CLAUDE.md** — AI coding assistant guidance with build commands, architecture overview, and key conventions (AGENTS.md is tool-agnostic; CLAUDE.md is a copy for Claude Code compatibility)
- **PR & Issue templates** — standardized `.github/PULL_REQUEST_TEMPLATE.md`, bug report, and feature request templates
- **.gitignore** — expanded with language-specific and IDE/OS patterns
- **.pre-commit-config.yaml** — pre-commit hooks for automated code quality checks

## AgentReady Score Impact

This PR is part of an organization-wide initiative to improve AI-assisted development readiness across `openshift-online`, measured by [AgentReady](https://github.com/ambient-code/agentready) (v2.31.2).

| Metric | Value |
|--------|-------|
| **Current score** | **40.9/100** (Bronze) |
| **This PR** | **+17 points** |
| **Score after this PR** | **58/100** (Bronze) |
| **All open PRs combined** | **+32 points** → **73/100** (Silver) |

### Attributes addressed by this PR

  - CLAUDE.md/AGENTS.md (+10)
  - PR/Issue templates (+1)
  - .gitignore (+3)
  - Pre-commit hooks (+3)

## Context

All content was derived from this repository's actual Makefile targets, `go.mod`, existing documentation, and code structure. No placeholder content.

## Testing

- [ ] No functional code changes — documentation and tooling only
- [ ] Pre-commit hooks can be tested with `pre-commit run --all-files`

---

> :robot_face: *This PR was generated by an AI agent* ([Claude](https://claude.ai)) as part of an organization-wide initiative to improve AI-assisted development readiness across `openshift-online`. The agent assessed all 32 public repositories using [AgentReady](https://github.com/ambient-code/agentready), identified improvement opportunities, generated the changes, and opened this PR. All commits are GPG-signed by [@gurnben](https://github.com/gurnben).
