### PR TITLE
ci: add automated release pipeline

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Auto-tag on merge
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: auto-tag-main
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    # Skip if the commit is a release commit (avoid infinite loop)
+    if: "!startsWith(github.event.head_commit.message, 'Release v')"
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine next version
+        id: version
+        run: |
+          LATEST=$(git tag -l 'v0.1.*' --sort=-version:refname | head -1)
+          if [ -z "$LATEST" ]; then
+            echo "next=v0.1.1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PATCH=$(echo "$LATEST" | sed 's/v0\.1\.//')
+          NEXT=$((PATCH + 1))
+          echo "next=v0.1.${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "Latest tag: ${LATEST}, next: v0.1.${NEXT}"
+
+      - name: Create tag
+        env:
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Single tag (no sub-modules in ocm-sdk-go)
+          git tag "${VERSION}"
+          git push origin "${VERSION}"

--- a/.github/workflows/sync-from-model.yaml
+++ b/.github/workflows/sync-from-model.yaml
@@ -1,0 +1,115 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Sync from model
+
+on:
+  repository_dispatch:
+    types:
+      - model-updated
+
+concurrency:
+  group: sync-from-model
+  cancel-in-progress: false
+
+jobs:
+  sync-from-model:
+    name: Bump model and regenerate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Validate payload
+        env:
+          VERSION: ${{ github.event.client_payload.version }}
+          RELEASE_URL: ${{ github.event.client_payload.release_url }}
+        run: |
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Invalid version format: $VERSION"
+            exit 1
+          fi
+          if ! echo "$RELEASE_URL" | grep -qE '^https://github\.com/[^/]+/[^/]+/releases/'; then
+            echo "Error: Invalid release URL format: $RELEASE_URL"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "RELEASE_URL=$RELEASE_URL" >> "$GITHUB_ENV"
+
+      - name: Bump ocm-api-model dependency
+        run: |
+          echo "Bumping ocm-api-model to ${VERSION}"
+          ./hack/update-model.sh "${VERSION}"
+
+      - name: Regenerate SDK
+        run: make update
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No SDK changes from this model update."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "SDK changes detected:"
+            git diff --stat
+          fi
+
+      - name: Create PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="sync-model/${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "${BRANCH}"
+          git add -A
+          git commit -m "chore: bump ocm-api-model to ${VERSION}
+
+          Auto-generated from ocm-api-model release ${VERSION}.
+          Release: ${RELEASE_URL}"
+
+          # Delete stale remote branch if it exists from a previous run
+          git push origin --delete "${BRANCH}" 2>/dev/null || true
+          git push origin "${BRANCH}"
+
+          gh pr create \
+            --title "chore: bump ocm-api-model to ${VERSION}" \
+            --body "## Auto-generated SDK update
+
+          Triggered by ocm-api-model release [${VERSION}](${RELEASE_URL}).
+
+          The ocm-api-model dependency was bumped and the SDK was regenerated
+          using \`make update\`.
+
+          ### Review
+          This PR contains only auto-generated code. If CI passes, it is safe to merge." \
+            --base main \
+            --head "${BRANCH}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,28 @@
 
 ## Releasing a new OCM API Model version
 
-First, all changes to the [ocm-api-model](https://github.com/openshift-online/ocm-api-model) have been defined and reviewed. Then, the client types for the model need to be generated via `make update` target in the `ocm-api-model` project.
+This section describes the release process in the [ocm-api-model](https://github.com/openshift-online/ocm-api-model) repository. Once a model release is published, it triggers the SDK update process described in the next section.
 
-Once the client types and api description are merged in [ocm-api-model](https://github.com/openshift-online/ocm-api-model), the version of the ocm-api-model
-must be incremented for consumption in ocm-sdk-go generation. The version is defined by the latest git tag.
+First, all changes to the model have been defined and reviewed. Then, the client types for the model need to be generated via `make update` target in the `ocm-api-model` project.
 
-Once all changes to the OCM API Model have been committed to the main branch and a new tag is pused a new release will be created automatically.Then, you will need to update these changes in the SDK. (See "Updating the OCM SDK" section)
+Once all changes have been committed to the main branch, the automated release pipeline in **ocm-api-model** handles the rest:
+
+1. **Auto-tag** (runs in ocm-api-model) — a GitHub Action automatically bumps the patch version, regenerates `clientapi/` and `openapi/`, updates `CHANGES.md`, and pushes all sub-module tags.
+2. **Release** (runs in ocm-api-model) — the tag push triggers a GitHub Release.
+3. **SDK sync** (runs in ocm-api-model) — the release sends a `repository_dispatch` event to this repository (ocm-sdk-go), triggering the SDK update below.
+
+If the automation is not available, you can manually tag and release in ocm-api-model:
+
+```shell
+make update
+git add -A
+git commit -m "Release vX.Y.Z"
+git tag vX.Y.Z
+git tag clientapi/vX.Y.Z
+git tag model/vX.Y.Z
+git tag metamodel_generator/vX.Y.Z
+git push origin main --tags
+```
 
 ### Validating model updates
 
@@ -26,6 +42,19 @@ make update
 
 ## Updating the OCM SDK
 
+### Automated (recommended)
+
+When a new ocm-api-model release is published, a GitHub Action automatically:
+
+1. Receives a `repository_dispatch` event from ocm-api-model
+2. Bumps the ocm-api-model dependency using `./hack/update-model.sh`
+3. Regenerates the SDK using `make update`
+4. Opens a PR with the changes
+
+Review and merge the auto-generated PR. On merge, a new SDK version tag is created automatically.
+
+### Manual
+
 The OCM SDK can be generated simply by running the following after all changes have been made:
 
 ```shell
@@ -42,6 +71,12 @@ Whenever an update is made, ensure that the corresponding example in [examples](
 necessary. It is *highly recommended* that new endpoints have a new example created.
 
 ## Releasing a new OCM SDK Version
+
+### Automated (recommended)
+
+On merge to main, a GitHub Action automatically bumps the patch version and pushes a new tag. The existing `publish-release` workflow then creates the GitHub Release.
+
+### Manual
 
 Releasing a new version requires submitting an MR for review/merge with an update to the `Version` constant in
 [version.go](version.go). Additionally, update the [CHANGES.md](CHANGES.md) file to include the new version and


### PR DESCRIPTION
Add two GitHub Actions workflows:

- auto-tag.yaml: automatically bumps the patch version and pushes a release tag when changes merge to main.

- sync-from-model.yaml: receives a repository_dispatch event from ocm-api-model, bumps the model dependency, runs make generate to regenerate SDK code, and opens a PR. Auto-detects fork environments for testing.

## Description

<!-- Briefly describe the change and its motivation. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
