### PR TITLE
ROSAENG-62396 | chore: bump version to v0.1.508

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the OCM API
 SDK.
 
+## 0.1.508 Aug 7 2026
+
+- chore: version bump to v0.1.508 (skip v0.1.507 due to duplicate tag on proxy.golang.org)
+
 ## 0.1.507 Aug 5 2026
 
 - ROSAENG-61162 | feat: changes to support BYO firewall for OSD-GCP deployments

--- a/version.go
+++ b/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package sdk
 
-const Version = "0.1.507"
+const Version = "0.1.508"


### PR DESCRIPTION
Skip v0.1.507 due to duplicate tag on proxy.golang.org.

## Description

<!-- Briefly describe the change and its motivation. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog notes for release `0.1.508`.
  * Documented that version `0.1.507` was skipped due to a duplicate release tag.

* **Release**
  * Updated the SDK version to `0.1.508`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->